### PR TITLE
fix: Amend audio naming for BHD release name compliance

### DIFF
--- a/src/backend/trackers/beyondhd.py
+++ b/src/backend/trackers/beyondhd.py
@@ -263,6 +263,13 @@ class BHDUploader:
     def generate_release_title(release_title: str) -> str:
         name = release_title.replace(".", " ")
         name = re.sub(r"\s{2,}", " ", name)
+        year_match = re.search(r"\b(?:19|20)\d{2}\b", name)
+        if year_match:
+            before_year = name[:year_match.end()]
+            after_year = name[year_match.end():]
+            after_year = re.sub(r"\s(\d)\s([01])\s", r" \1.\2 ", after_year)
+            after_year = re.sub(r"\bDD\s+(\d\.[01])", r"DD\1", after_year)
+            name = before_year + after_year
         return name
 
 

--- a/src/backend/trackers/beyondhd.py
+++ b/src/backend/trackers/beyondhd.py
@@ -263,13 +263,8 @@ class BHDUploader:
     def generate_release_title(release_title: str) -> str:
         name = release_title.replace(".", " ")
         name = re.sub(r"\s{2,}", " ", name)
-        year_match = re.search(r"\b(?:19|20)\d{2}\b", name)
-        if year_match:
-            before_year = name[:year_match.end()]
-            after_year = name[year_match.end():]
-            after_year = re.sub(r"\s(\d)\s([01])\s", r" \1.\2 ", after_year)
-            after_year = re.sub(r"\bDD\s+(\d\.[01])", r"DD\1", after_year)
-            name = before_year + after_year
+        name = re.sub(r"\s(\d)\s([01])\s", r" \1.\2 ", name)
+        name = re.sub(r"\bDD\s+(\d\.[01])", r"DD\1", name)
         return name
 
 

--- a/src/frontend/wizards/rename_encode.py
+++ b/src/frontend/wizards/rename_encode.py
@@ -297,6 +297,13 @@ class RenameEncode(BaseWizardPage):
 
         self._pre_load_attribute_combos(media_file.stem)
 
+        # Apply localization override from plugin if present
+        localization_override = self.config.shared_data.dynamic_data.get("localization_override")
+        if localization_override:
+            localization_idx = self.localization_combo.findText(localization_override)
+            if localization_idx > -1:
+                self.localization_combo.setCurrentIndex(localization_idx)
+
         self.token_override.setText(self.config.cfg_payload.mvr_token)
 
         get_quality = self.backend.get_quality(


### PR DESCRIPTION
Amend audio formatting in release names for compliance with BHD, eg:
- DD 1 0 > DD1.0
- DDP 7 1 > DDP 7.1

Fixes #210 