### PR TITLE
fix: Amend BHD release title naming for audio format compliance

### DIFF
--- a/src/backend/trackers/beyondhd.py
+++ b/src/backend/trackers/beyondhd.py
@@ -263,6 +263,8 @@ class BHDUploader:
     def generate_release_title(release_title: str) -> str:
         name = release_title.replace(".", " ")
         name = re.sub(r"\s{2,}", " ", name)
+        name = re.sub(r"\s(\d)\s([01])\s", r" \1.\2 ", name)
+        name = re.sub(r"\bDD\s+(\d\.[01])", r"DD\1", name)
         return name
 
 


### PR DESCRIPTION
Amend BHD release title naming for audio format compliance, eg:
- DD 1 0 > DD1.0
- DDP 7 1 > DDP 7.1