### PR TITLE
feat: Add localization override for rename/encode wizard

### DIFF
--- a/src/frontend/wizards/rename_encode.py
+++ b/src/frontend/wizards/rename_encode.py
@@ -297,6 +297,13 @@ class RenameEncode(BaseWizardPage):
 
         self._pre_load_attribute_combos(media_file.stem)
 
+        # Apply localization override from plugin if present
+        localization_override = self.config.shared_data.dynamic_data.get("localization_override")
+        if localization_override:
+            localization_idx = self.localization_combo.findText(localization_override)
+            if localization_idx > -1:
+                self.localization_combo.setCurrentIndex(localization_idx)
+
         self.token_override.setText(self.config.cfg_payload.mvr_token)
 
         get_quality = self.backend.get_quality(


### PR DESCRIPTION
Add a localization override for rename/encode wizard, which alloows for an input wizard plugin to pre-set the value of the `Localization` field in the renaming wizard.