### PR TITLE
feat: Add BHD edition support

### DIFF
--- a/src/backend/process.py
+++ b/src/backend/process.py
@@ -1246,6 +1246,16 @@ class ProcessBackEnd:
             tracker_payload = self.config.cfg_payload.bhd_tracker
             if not tracker_payload.api_key:
                 raise TrackerError("Missing API key for BeyondHD")
+
+            # Get edition from shared data
+            edition = self.config.shared_data.dynamic_data.get("edition_override")
+
+            # Get localization from override tokens
+            override_tokens = self.config.shared_data.dynamic_data.get(
+                "override_tokens", {}
+            )
+            localization = override_tokens.get("localization")
+
             return bhd_uploader(
                 api_key=tracker_payload.api_key,
                 torrent_file=torrent_file,
@@ -1260,6 +1270,9 @@ class ProcessBackEnd:
                 anonymous=bool(tracker_payload.anonymous),
                 promo=tracker_payload.promo,
                 timeout=self.config.cfg_payload.timeout,
+                edition=edition,
+                localization=localization,
+                add_localization_to_custom_edition=tracker_payload.add_localization_to_custom_edition,
             )
         elif tracker is TrackerSelection.PASS_THE_POPCORN:
             tracker_payload = self.config.cfg_payload.ptp_tracker

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -438,6 +438,9 @@ class Config:
             ).value
             bhd_data["internal"] = self.cfg_payload.bhd_tracker.internal
             bhd_data["image_width"] = self.cfg_payload.bhd_tracker.image_width
+            bhd_data["add_localization_to_custom_edition"] = (
+                self.cfg_payload.bhd_tracker.add_localization_to_custom_edition
+            )
 
             # PassThePopcorn tracker
             if "pass_the_popcorn" not in tracker_data:
@@ -1246,6 +1249,9 @@ class Config:
                 live_release=BHDLiveRelease(bhd_tracker_data["live_release"]),
                 internal=bhd_tracker_data["internal"],
                 image_width=bhd_tracker_data["image_width"],
+                add_localization_to_custom_edition=bhd_tracker_data.get(
+                    "add_localization_to_custom_edition", False
+                ),
             )
 
             ptp_tracker_data = tracker_data["pass_the_popcorn"]

--- a/src/enums/trackers/beyondhd.py
+++ b/src/enums/trackers/beyondhd.py
@@ -68,3 +68,40 @@ class BHDLiveRelease(Enum):
             BHDLiveRelease.LIVE: "Live",
         }
         return str_map[self]
+
+
+class BHDEdition(Enum):
+    """BeyondHD supported edition values and their mappings from NfoForge edition names"""
+
+    COLLECTOR = "Collector"
+    DIRECTOR = "Director"
+    EXTENDED = "Extended"
+    LIMITED = "Limited"
+    SPECIAL = "Special"
+    THEATRICAL = "Theatrical"
+    UNCUT = "Uncut"
+    UNRATED = "Unrated"
+
+    @classmethod
+    def from_nfoforge_edition(cls, edition: str) -> "BHDEdition | None":
+        """
+        Map NfoForge edition names to BeyondHD edition values.
+
+        Args:
+            edition: Edition string from NfoForge rename wizard
+
+        Returns:
+            BHDEdition enum member if mapping exists, None otherwise
+        """
+        # Mapping from NfoForge edition names to BHD editions
+        mapping = {
+            "Collectors Edition": cls.COLLECTOR,
+            "Directors Cut": cls.DIRECTOR,
+            "Extended Cut": cls.EXTENDED,
+            "Limited Edition": cls.LIMITED,
+            "Special Edition": cls.SPECIAL,
+            "Theatrical Cut": cls.THEATRICAL,
+            "Uncut": cls.UNCUT,
+            "Unrated": cls.UNRATED,
+        }
+        return mapping.get(edition)

--- a/src/frontend/custom_widgets/tracker_listbox.py
+++ b/src/frontend/custom_widgets/tracker_listbox.py
@@ -351,6 +351,11 @@ class BHDTrackerEdit(TrackerEditBase):
         internal_lbl = QLabel("Internal", self)
         self.internal = QCheckBox(self)
 
+        localization_to_custom_edition_lbl = QLabel(
+            "Add/append localization to Custom Edition field on upload", self
+        )
+        self.add_localization_to_custom_edition = QCheckBox(self)
+
         image_width_lbl = QLabel("Image Width", self)
         self.image_width = QSpinBox(self)
         self.image_width.setRange(100, 2000)
@@ -362,6 +367,9 @@ class BHDTrackerEdit(TrackerEditBase):
         self.add_pair_to_layout(promo_lbl, self.promo)
         self.add_pair_to_layout(live_release_lbl, self.live_release)
         self.add_pair_to_layout(internal_lbl, self.internal)
+        self.add_pair_to_layout(
+            localization_to_custom_edition_lbl, self.add_localization_to_custom_edition
+        )
         self.add_pair_to_layout(image_width_lbl, self.image_width)
         self.add_screen_shot_settings()
 
@@ -381,6 +389,9 @@ class BHDTrackerEdit(TrackerEditBase):
             self.live_release, BHDLiveRelease, tracker_data.live_release
         )
         self.internal.setChecked(bool(tracker_data.internal))
+        self.add_localization_to_custom_edition.setChecked(
+            tracker_data.add_localization_to_custom_edition
+        )
         self.image_width.setValue(tracker_data.image_width)
         if self.screen_shot_settings:
             self.screen_shot_settings.load_settings(
@@ -407,6 +418,9 @@ class BHDTrackerEdit(TrackerEditBase):
             self.live_release.currentData()
         )
         self.config.cfg_payload.bhd_tracker.internal = int(self.internal.isChecked())
+        self.config.cfg_payload.bhd_tracker.add_localization_to_custom_edition = (
+            self.add_localization_to_custom_edition.isChecked()
+        )
         self.config.cfg_payload.bhd_tracker.image_width = self.image_width.value()
         if self.screen_shot_settings:
             col_s, col_space, row_space = self.screen_shot_settings.current_settings()

--- a/src/payloads/trackers.py
+++ b/src/payloads/trackers.py
@@ -65,6 +65,7 @@ class BeyondHDInfo(TrackerInfo):
     live_release: BHDLiveRelease = BHDLiveRelease.LIVE
     internal: int = 0
     image_width: int = 350
+    add_localization_to_custom_edition: bool = False
 
 
 @dataclass(slots=True)


### PR DESCRIPTION
### Add support for `edition` and `custom_edition` API fields with automatic mapping and optional localization appending.

- Created enum mapping 8 NfoForge editions to BHD values
- Unmapped editions automatically use custom_edition field
- Added optional "Add/append localization to Custom Edition on upload" setting: appends "Dubbed"/"Subbed" with " / " separator when enabled
- Config persistence with backwards compatibility (defaults to False)
- Debug logging for troubleshooting