### PR TITLE
feat: add Streaming Optimized toggle for BHD uploads

### DIFF
--- a/src/backend/process.py
+++ b/src/backend/process.py
@@ -1273,6 +1273,7 @@ class ProcessBackEnd:
                 edition=edition,
                 localization=localization,
                 add_localization_to_custom_edition=tracker_payload.add_localization_to_custom_edition,
+                stream_optimized=tracker_payload.stream_optimized,
             )
         elif tracker is TrackerSelection.PASS_THE_POPCORN:
             tracker_payload = self.config.cfg_payload.ptp_tracker

--- a/src/backend/trackers/beyondhd.py
+++ b/src/backend/trackers/beyondhd.py
@@ -96,6 +96,7 @@ def bhd_uploader(
     edition: str | None = None,
     localization: str | None = None,
     add_localization_to_custom_edition: bool = False,
+    stream_optimized: bool = False,
 ) -> str | None:
     uploader = BHDUploader(
         api_key=api_key,
@@ -116,6 +117,7 @@ def bhd_uploader(
         edition=edition,
         localization=localization,
         add_localization_to_custom_edition=add_localization_to_custom_edition,
+        stream_optimized=stream_optimized,
     )
 
 
@@ -149,6 +151,7 @@ class BHDUploader:
         edition: str | None = None,
         localization: str | None = None,
         add_localization_to_custom_edition: bool = False,
+        stream_optimized: bool = False,
     ) -> str | None:
         upload_payload = {
             "name": tracker_title
@@ -160,8 +163,9 @@ class BHDUploader:
             "internal": int(internal),
             "live": live_release.value,
             "anon": int(anonymous),
-            # "stream": 1,
         }
+        if stream_optimized:
+            upload_payload["stream"] = 1
         if imdb_id:
             upload_payload["imdb_id"] = imdb_id
         if tmdb_id:

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -441,6 +441,9 @@ class Config:
             bhd_data["add_localization_to_custom_edition"] = (
                 self.cfg_payload.bhd_tracker.add_localization_to_custom_edition
             )
+            bhd_data["stream_optimized"] = (
+                self.cfg_payload.bhd_tracker.stream_optimized
+            )
 
             # PassThePopcorn tracker
             if "pass_the_popcorn" not in tracker_data:
@@ -1252,6 +1255,7 @@ class Config:
                 add_localization_to_custom_edition=bhd_tracker_data.get(
                     "add_localization_to_custom_edition", False
                 ),
+                stream_optimized=bhd_tracker_data.get("stream_optimized", False),
             )
 
             ptp_tracker_data = tracker_data["pass_the_popcorn"]

--- a/src/frontend/custom_widgets/tracker_listbox.py
+++ b/src/frontend/custom_widgets/tracker_listbox.py
@@ -356,6 +356,9 @@ class BHDTrackerEdit(TrackerEditBase):
         )
         self.add_localization_to_custom_edition = QCheckBox(self)
 
+        stream_optimized_lbl = QLabel("Upload releases as Streaming Optimized", self)
+        self.stream_optimized = QCheckBox(self)
+
         image_width_lbl = QLabel("Image Width", self)
         self.image_width = QSpinBox(self)
         self.image_width.setRange(100, 2000)
@@ -370,6 +373,7 @@ class BHDTrackerEdit(TrackerEditBase):
         self.add_pair_to_layout(
             localization_to_custom_edition_lbl, self.add_localization_to_custom_edition
         )
+        self.add_pair_to_layout(stream_optimized_lbl, self.stream_optimized)
         self.add_pair_to_layout(image_width_lbl, self.image_width)
         self.add_screen_shot_settings()
 
@@ -392,6 +396,7 @@ class BHDTrackerEdit(TrackerEditBase):
         self.add_localization_to_custom_edition.setChecked(
             tracker_data.add_localization_to_custom_edition
         )
+        self.stream_optimized.setChecked(bool(tracker_data.stream_optimized))
         self.image_width.setValue(tracker_data.image_width)
         if self.screen_shot_settings:
             self.screen_shot_settings.load_settings(
@@ -420,6 +425,9 @@ class BHDTrackerEdit(TrackerEditBase):
         self.config.cfg_payload.bhd_tracker.internal = int(self.internal.isChecked())
         self.config.cfg_payload.bhd_tracker.add_localization_to_custom_edition = (
             self.add_localization_to_custom_edition.isChecked()
+        )
+        self.config.cfg_payload.bhd_tracker.stream_optimized = (
+            self.stream_optimized.isChecked()
         )
         self.config.cfg_payload.bhd_tracker.image_width = self.image_width.value()
         if self.screen_shot_settings:

--- a/src/payloads/trackers.py
+++ b/src/payloads/trackers.py
@@ -66,6 +66,7 @@ class BeyondHDInfo(TrackerInfo):
     internal: int = 0
     image_width: int = 350
     add_localization_to_custom_edition: bool = False
+    stream_optimized: bool = False
 
 
 @dataclass(slots=True)


### PR DESCRIPTION
Add "Upload releases as Streaming Optimized" checkbox to BHD settings. When enabled, includes "stream": 1 in the upload API payload.