### PR TITLE
feat: add super seeding mode option for qBittorrent client

### DIFF
--- a/runtime/config/defaults/default_config.toml
+++ b/runtime/config/defaults/default_config.toml
@@ -387,7 +387,7 @@ host = "http://127.0.0.1"
 port = 0
 user = ""
 password = ""
-specific_params = { "category" = "" }
+specific_params = { "category" = "", "super_seeding" = false }
 
 [torrent_client.deluge]
 enabled = false

--- a/src/backend/torrent_clients/qbittorrent.py
+++ b/src/backend/torrent_clients/qbittorrent.py
@@ -1,6 +1,7 @@
 from qbittorrentapi import Client as QBitClient
 import qbittorrentapi.exceptions
 from pathlib import Path
+from torf import Torrent
 
 from src.exceptions import TrackerClientError
 from src.payloads.clients import TorrentClient
@@ -57,6 +58,11 @@ class QBittorrentClient:
                 category=self._get_category(),
             )
             if add_torrent == "Ok.":
+                if self._get_super_seeding():
+                    torrent = Torrent.read(torrent_file)
+                    self.client.torrents_set_super_seeding(
+                        enable=True, torrent_hashes=torrent.infohash
+                    )
                 return True, "qBittorrent injection successful"
             else:
                 return False, "qBittorrent injection failed"
@@ -74,6 +80,9 @@ class QBittorrentClient:
                 "You must supply your category in the configuration"
             )
         return category
+
+    def _get_super_seeding(self) -> bool:
+        return bool(self.qbit_config.specific_params.get("super_seeding", False))
 
     def _get_port(self) -> int | None:
         port = int(self.qbit_config.port)

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -71,7 +71,7 @@ class Config:
 
     ACCEPTED_EXTENSIONS = (".mkv", ".mp4")
 
-    QBIT_SPECIFIC = ("category",)
+    QBIT_SPECIFIC = ("category", "super_seeding")
 
     DELUGE_SPECIFIC = ("label", "path")
 
@@ -1539,8 +1539,15 @@ class Config:
             # qbittorrent
             qbittorrent = TorrentClient(**torrent_client_data["qbittorrent"])
             for qbit_specific in self.QBIT_SPECIFIC:
-                if not qbittorrent.specific_params.get(qbit_specific):
-                    qbittorrent.specific_params[qbit_specific] = ""
+                if qbit_specific not in qbittorrent.specific_params:
+                    default_val = (
+                        self.cfg_payload_defaults.qbittorrent.specific_params.get(
+                            qbit_specific, ""
+                        )
+                        if self.cfg_payload_defaults
+                        else ""
+                    )
+                    qbittorrent.specific_params[qbit_specific] = default_val
 
             # deluge
             deluge = TorrentClient(**torrent_client_data["deluge"])


### PR DESCRIPTION
Add new checkbox setting to enable super seeding mode when injecting torrents into qBittorrent. After successful torrent injection, if enabled, calls the setSuperSeeding API with the torrent's infohash.