### PR TITLE
fix: Exclude language detection from guessit in media search

### DIFF
--- a/src/backend/media_search.py
+++ b/src/backend/media_search.py
@@ -189,7 +189,7 @@ class MediaSearchBackEnd:
 
     @staticmethod
     def _guessit(input_string: str) -> tuple[str | None, str]:
-        get_info = guessit(input_string)
+        get_info = guessit(input_string, {"excludes": ["language"]})
         title = get_info.get("title")
         year = get_info.get("year", "")
         if not title and year:

--- a/src/frontend/wizards/media_search.py
+++ b/src/frontend/wizards/media_search.py
@@ -512,7 +512,7 @@ class MediaSearch(BaseWizardPage):
         GSigs().wizard_next_button_change_txt.emit("Select Title")
 
     def _get_title_only(self, file_path: Path) -> str:
-        guess = guessit(file_path.stem)
+        guess = guessit(file_path.stem, {"excludes": ["language"]})
         title = guess.get("title")
         year = guess.get("year")
         if title and year:


### PR DESCRIPTION
- Pass {"excludes": ["language"]} to all guessit calls in the media search flow so words that coincide with language identifiers are not stripped from titles
- Affects both the backend _guessit helper and the frontend _get_title_only method