### PR TITLE
fix: tracker config schema regressions from the typed-config refactor

### DIFF
--- a/runtime/config/defaults/default_config.toml
+++ b/runtime/config/defaults/default_config.toml
@@ -43,7 +43,7 @@ mvr_title_override_enabled = true
 mvr_title_colon_replace = 3
 mvr_title_token_override = ""
 mvr_title_replace_map = [['''\s''', "."]]
-anonymous = 0
+anonymous = false
 api_key = ""
 username = ""
 password = ""
@@ -90,12 +90,12 @@ mvr_title_override_enabled = false
 mvr_title_token_override = ""
 mvr_title_replace_map = []
 mvr_title_colon_replace = 3
-anonymous = 0
+anonymous = false
 api_key = ""
 rss_key = ""
 promo = 0
 live_release = 1
-internal = 0
+internal = false
 image_width = 350
 
 [tracker.pass_the_popcorn]
@@ -137,15 +137,15 @@ mvr_title_token_override = ""
 mvr_title_replace_map = []
 mvr_title_colon_replace = 3
 api_key = ""
-anonymous = 0
-internal = 0
-personal_release = 0
-stream_optimized = 0
-opt_in_to_mod_queue = 0
-featured = 0
-free = 0
-double_up = 0
-sticky = 0
+anonymous = false
+internal = false
+personal_release = false
+stream_optimized = false
+opt_in_to_mod_queue = false
+featured = false
+free = false
+double_up = false
+sticky = false
 image_width = 350
 
 [tracker.aither]
@@ -174,15 +174,15 @@ mvr_title_replace_map = [
 ]
 mvr_title_colon_replace = 3
 api_key = ""
-anonymous = 0
-internal = 0
-personal_release = 0
-stream_optimized = 0
-opt_in_to_mod_queue = 0
-featured = 0
-free = 0
-double_up = 0
-sticky = 0
+anonymous = false
+internal = false
+personal_release = false
+stream_optimized = false
+opt_in_to_mod_queue = false
+featured = false
+free = false
+double_up = false
+sticky = false
 image_width = 350
 
 [tracker.huno]
@@ -211,9 +211,9 @@ mvr_title_replace_map = [
 ]
 mvr_title_colon_replace = 3
 api_key = ""
-anonymous = 0
-internal = 0
-stream_optimized = 0
+anonymous = false
+internal = false
+stream_optimized = false
 image_width = 350
 
 [tracker.lst]
@@ -242,15 +242,15 @@ mvr_title_replace_map = [
 ]
 mvr_title_colon_replace = 3
 api_key = ""
-anonymous = 0
-internal = 0
-personal_release = 0
-mod_queue_opt_in = 0
-draft_queue_opt_in = 0
-featured = 0
-free = 0
-double_up = 0
-sticky = 0
+anonymous = false
+internal = false
+personal_release = false
+mod_queue_opt_in = false
+draft_queue_opt_in = false
+featured = false
+free = false
+double_up = false
+sticky = false
 image_width = 500
 
 [tracker.dark_peers]
@@ -279,9 +279,9 @@ mvr_title_replace_map = [
 ]
 mvr_title_colon_replace = 3
 api_key = ""
-anonymous = 0
-internal = 0
-personal_release = 0
+anonymous = false
+internal = false
+personal_release = false
 image_width = 500
 
 [tracker.shareisland]
@@ -310,10 +310,10 @@ mvr_title_replace_map = [
 ]
 mvr_title_colon_replace = 3
 api_key = ""
-anonymous = 0
-internal = 0
-personal_release = 0
-opt_in_to_mod_queue = 0
+anonymous = false
+internal = false
+personal_release = false
+opt_in_to_mod_queue = false
 image_width = 350
 
 [tracker.uploadcx]
@@ -342,9 +342,9 @@ mvr_title_replace_map = [
 ]
 mvr_title_colon_replace = 3
 api_key = ""
-anonymous = 0
-internal = 0
-personal_release = 0
+anonymous = false
+internal = false
+personal_release = false
 image_width = 500
 
 [tracker.only_encodes]
@@ -373,9 +373,9 @@ mvr_title_replace_map = [
 ]
 mvr_title_colon_replace = 3
 api_key = ""
-anonymous = 0
-internal = 0
-personal_release = 0
+anonymous = false
+internal = false
+personal_release = false
 image_width = 500
 
 [torrent_client]

--- a/runtime/config/defaults/default_config.toml
+++ b/runtime/config/defaults/default_config.toml
@@ -97,6 +97,8 @@ promo = 0
 live_release = 1
 internal = false
 image_width = 350
+add_localization_to_custom_edition = false
+stream_optimized = false
 
 [tracker.pass_the_popcorn]
 upload_enabled = true

--- a/src/config/codec.py
+++ b/src/config/codec.py
@@ -62,6 +62,49 @@ class TomlConfigCodec:
                     cls.merge_defaults(current, value)
         return document
 
+    @classmethod
+    def coerce_bool_flags(
+        cls,
+        document: MutableMapping[str, Any],
+        defaults: Mapping[str, Any],
+    ) -> MutableMapping[str, Any]:
+        """Coerce persisted ints to ``bool`` where the default declares a bool.
+
+        Some boolean tracker flags (e.g. ``tracker.*.anonymous``) were shipped
+        in the packaged default as the int ``0`` while the model, the UI (a
+        ``QCheckBox``) and the write path all treat them as ``bool``. Once the
+        app wrote such a value back from its own model it became a TOML
+        ``true``/``false``, which `validate_types` -- which deliberately
+        refuses to treat ``bool`` as ``int`` -- would then reject on the next
+        load. The default now declares these as real booleans; this pass
+        normalizes any lingering integer ``0``/``1`` (from an older default, a
+        hand-edited profile, or a schema-1 migration that copied the tracker
+        section forward verbatim) to ``bool`` so both representations converge
+        on the default's type before `validate_types` runs. Non-0/1 integers
+        are left untouched so genuinely bad values still surface as a type
+        error rather than being silently coerced.
+        """
+        for key, expected in defaults.items():
+            if key not in document:
+                continue
+            if isinstance(expected, MutableMapping):
+                current = document.get(key)
+                if isinstance(current, MutableMapping):
+                    cls.coerce_bool_flags(current, expected)
+                continue
+            expected_value = (
+                expected.unwrap() if hasattr(expected, "unwrap") else expected
+            )
+            actual = document[key]
+            actual_value = actual.unwrap() if hasattr(actual, "unwrap") else actual
+            if (
+                type(expected_value) is bool
+                and type(actual_value) is int  # excludes bool, an int subclass
+                and actual_value in (0, 1)
+            ):
+                document[key] = bool(actual_value)
+        return document
+
     @staticmethod
     def dumps(document: Mapping[str, Any]) -> str:
         return tomlkit.dumps(document)

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -193,7 +193,8 @@ class ConfigManager(TypedTomlOperations):
     ) -> MutableMapping[str, Any]:
         """Run the validate/merge/decode sequence `load_profile` applies to
         a loaded profile: schema check, merge defaults (against a fresh
-        parse of ``default_toml``), per-key type validation against
+        parse of ``default_toml``), coerce legacy int 0/1 flags to bool where
+        the default is a bool, per-key type validation against
         ``self._default_document``, then `decode` (which also runs
         `validate_settings`).
 
@@ -208,6 +209,12 @@ class ConfigManager(TypedTomlOperations):
         """
         self.codec.validate_schema(document)
         merged = self.codec.merge_defaults(document, tomlkit.parse(default_toml))
+        # Normalize legacy integer 0/1 tracker flags to bool where the default
+        # declares a bool, before per-key type validation. This self-heals both
+        # a config the app previously wrote as a real bool (default now bool ->
+        # no-op) and one still holding the old int representation (e.g. a
+        # schema-1 migration that copied the tracker section forward verbatim).
+        self.codec.coerce_bool_flags(merged, self._default_document)
         self.codec.validate_types(merged, self._default_document)
         self.decode(merged, dry_run=dry_run)
         return merged

--- a/src/config/operations.py
+++ b/src/config/operations.py
@@ -309,6 +309,12 @@ class TypedTomlOperations:
             ).value
             bhd_data["internal"] = self.settings.trackers.beyond_hd.internal
             bhd_data["image_width"] = self.settings.trackers.beyond_hd.image_width
+            bhd_data["add_localization_to_custom_edition"] = (
+                self.settings.trackers.beyond_hd.add_localization_to_custom_edition
+            )
+            bhd_data["stream_optimized"] = (
+                self.settings.trackers.beyond_hd.stream_optimized
+            )
 
             # PassThePopcorn tracker
             ptp_data = self._ensure_toml_table(tracker_data, "pass_the_popcorn")
@@ -1223,6 +1229,10 @@ class TypedTomlOperations:
                 live_release=BHDLiveRelease(bhd_tracker_data["live_release"]),
                 internal=bhd_tracker_data["internal"],
                 image_width=bhd_tracker_data["image_width"],
+                add_localization_to_custom_edition=bhd_tracker_data[
+                    "add_localization_to_custom_edition"
+                ],
+                stream_optimized=bhd_tracker_data["stream_optimized"],
             )
 
             ptp_tracker_data = tracker_data["pass_the_popcorn"]

--- a/tests/test_config/test_manager.py
+++ b/tests/test_config/test_manager.py
@@ -656,6 +656,31 @@ def test_tracker_bool_flag_roundtrips_through_save(
     assert type(raw) is bool and raw is True
 
 
+def test_beyond_hd_stream_and_localization_flags_persist(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`BeyondHDInfo.add_localization_to_custom_edition` and `stream_optimized`
+    are real, user-facing checkboxes that persisted on release configs. The
+    typed-config refactor dropped both from the decode and save paths (and the
+    packaged default), so toggling them no longer survived a reload. They must
+    round-trip like every other tracker flag.
+    """
+    monkeypatch.setattr(
+        "src.config.config.FindDependencies.update_dependencies",
+        lambda self, dependencies: None,
+    )
+    paths = _paths(tmp_path)
+    manager = ConfigManager("test", paths)
+
+    manager.settings.trackers.beyond_hd.add_localization_to_custom_edition = True
+    manager.settings.trackers.beyond_hd.stream_optimized = True
+    manager.save()
+    manager.load_profile("test")  # must not raise
+
+    assert manager.settings.trackers.beyond_hd.add_localization_to_custom_edition is True
+    assert manager.settings.trackers.beyond_hd.stream_optimized is True
+
+
 def test_int_tracker_flag_is_coerced_and_persisted_as_bool(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_config/test_manager.py
+++ b/tests/test_config/test_manager.py
@@ -596,6 +596,167 @@ def test_atomic_write_failure_preserves_original(
     assert destination.read_text(encoding="utf-8") == "original"
 
 
+def test_bool_tracker_flag_config_loads(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A tracker flag persisted as a real boolean must load without raising.
+
+    Regression: `tracker.*.anonymous` (and the other tracker checkbox flags)
+    is a `bool` in the model, the UI (`QCheckBox.isChecked()`) and the write
+    path, but the packaged default shipped it as the int `0`. The moment the
+    app wrote the config back from its own model the value became a TOML
+    `true`/`false`, and `validate_types` -- which deliberately refuses to
+    treat `bool` as `int` -- then rejected the very config the app produced
+    with `Invalid type at tracker.more_than_tv.anonymous: expected int, got
+    bool` on the next launch.
+    """
+    monkeypatch.setattr(
+        "src.config.config.FindDependencies.update_dependencies",
+        lambda self, dependencies: None,
+    )
+    paths = _paths(tmp_path)
+    profile = paths.user_configs / "test.toml"
+    profile.parent.mkdir(parents=True)
+    document = tomlkit.parse(paths.default_config.read_text(encoding="utf-8"))
+    tracker = cast(MutableMapping[str, Any], document["tracker"])
+    more_than_tv = cast(MutableMapping[str, Any], tracker["more_than_tv"])
+    more_than_tv["anonymous"] = True  # a real bool, as the app writes it
+    profile.write_text(tomlkit.dumps(document), encoding="utf-8")
+
+    manager = ConfigManager("test", paths)  # must not raise
+
+    assert manager.settings.trackers.more_than_tv.anonymous is True
+
+
+def test_tracker_bool_flag_roundtrips_through_save(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Setting a tracker flag from the UI (`QCheckBox.isChecked()` -> a real
+    `bool`) and saving must produce a config that reloads cleanly -- the exact
+    write-then-relaunch sequence that first surfaced the bug."""
+    monkeypatch.setattr(
+        "src.config.config.FindDependencies.update_dependencies",
+        lambda self, dependencies: None,
+    )
+    paths = _paths(tmp_path)
+    manager = ConfigManager("test", paths)
+
+    manager.settings.trackers.more_than_tv.anonymous = True  # isChecked()
+    manager.save()
+    manager.load_profile("test")  # must not raise
+
+    assert manager.settings.trackers.more_than_tv.anonymous is True
+    saved = tomlkit.parse(
+        (paths.user_configs / "test.toml").read_text(encoding="utf-8")
+    )
+    tracker = cast(MutableMapping[str, Any], saved["tracker"])
+    more_than_tv = cast(MutableMapping[str, Any], tracker["more_than_tv"])
+    raw = more_than_tv["anonymous"]
+    raw = raw.unwrap() if hasattr(raw, "unwrap") else raw
+    assert type(raw) is bool and raw is True
+
+
+def test_int_tracker_flag_is_coerced_and_persisted_as_bool(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A profile still holding the legacy int `anonymous = 0` must self-heal
+    to a bool rather than fail `validate_types` against the now-boolean
+    default, and the healed value must be written back as a real TOML bool so
+    the two representations converge."""
+    monkeypatch.setattr(
+        "src.config.config.FindDependencies.update_dependencies",
+        lambda self, dependencies: None,
+    )
+    paths = _paths(tmp_path)
+    profile = paths.user_configs / "test.toml"
+    profile.parent.mkdir(parents=True)
+    document = tomlkit.parse(paths.default_config.read_text(encoding="utf-8"))
+    tracker = cast(MutableMapping[str, Any], document["tracker"])
+    more_than_tv = cast(MutableMapping[str, Any], tracker["more_than_tv"])
+    more_than_tv["anonymous"] = 0  # legacy int representation
+    profile.write_text(tomlkit.dumps(document), encoding="utf-8")
+
+    manager = ConfigManager("test", paths)  # must not raise
+
+    assert manager.settings.trackers.more_than_tv.anonymous is False
+    # the healed value is persisted as a real TOML boolean, not an int
+    saved = tomlkit.parse(profile.read_text(encoding="utf-8"))
+    saved_tracker = cast(MutableMapping[str, Any], saved["tracker"])
+    saved_mtv = cast(MutableMapping[str, Any], saved_tracker["more_than_tv"])
+    raw = saved_mtv["anonymous"]
+    raw = raw.unwrap() if hasattr(raw, "unwrap") else raw
+    assert type(raw) is bool
+    ConfigManager("test", paths)  # a fresh load of the healed file is clean
+
+
+def test_schema1_int_tracker_flags_load_as_bool(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Real release users are on schema 1, which stored the tracker flags as
+    the int `0`. Migrating to schema 2 -- whose default now declares them
+    `bool` -- must coerce them so the migrated document validates, instead of
+    tripping `validate_types` and forcing an archive+regenerate on upgrade.
+    """
+    monkeypatch.setattr(
+        "src.config.config.FindDependencies.update_dependencies",
+        lambda self, dependencies: None,
+    )
+    paths = _paths(tmp_path)
+    profile = paths.user_configs / "test.toml"
+    profile.parent.mkdir(parents=True)
+    fixture_text = Path("tests/test_config/fixtures/schema1_config.toml").read_text(
+        encoding="utf-8"
+    )
+    assert "anonymous = 0" in fixture_text  # guard: the fixture is the int form
+    profile.write_text(fixture_text, encoding="utf-8")
+
+    manager = ConfigManager("test", paths)  # must migrate + load, not raise
+
+    assert manager.settings.trackers.more_than_tv.anonymous is False
+    saved = tomlkit.parse(profile.read_text(encoding="utf-8"))
+    assert saved["schema_version"] == 2
+    saved_tracker = cast(MutableMapping[str, Any], saved["tracker"])
+    saved_mtv = cast(MutableMapping[str, Any], saved_tracker["more_than_tv"])
+    raw = saved_mtv["anonymous"]
+    raw = raw.unwrap() if hasattr(raw, "unwrap") else raw
+    assert type(raw) is bool
+
+
+def test_coerce_bool_flags_normalizes_int_flags() -> None:
+    """`coerce_bool_flags` turns a persisted int 0/1 into a bool where the
+    default declares a bool, and leaves genuine ints, enum-backed ints and
+    non-0/1 values alone (the latter so real corruption still surfaces as a
+    type error rather than being silently coerced)."""
+    defaults = {
+        "tracker": {
+            "more_than_tv": {
+                "anonymous": False,  # bool flag
+                "internal": False,  # bool flag
+                "row_space": 0,  # genuine int
+                "promo": 0,  # enum-backed int
+            }
+        }
+    }
+    document: dict[str, Any] = {
+        "tracker": {
+            "more_than_tv": {
+                "anonymous": 1,  # legacy int for a bool flag -> True
+                "internal": 5,  # not 0/1 -> left for validate_types to reject
+                "row_space": 0,  # int default -> untouched
+                "promo": 2,  # int default -> untouched
+            }
+        }
+    }
+
+    TomlConfigCodec.coerce_bool_flags(document, defaults)
+
+    mtv = document["tracker"]["more_than_tv"]
+    assert mtv["anonymous"] is True
+    assert type(mtv["internal"]) is int and mtv["internal"] == 5
+    assert type(mtv["row_space"]) is int and mtv["row_space"] == 0
+    assert type(mtv["promo"]) is int and mtv["promo"] == 2
+
+
 def test_default_season_folder_token_is_scene_style() -> None:
     defaults = tomlkit.parse(
         Path("runtime/config/defaults/default_config.toml").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

Two independent regressions in tracker config, both introduced by the typed-config refactor. Each is its own commit.

## 1. Tracker boolean flags rejected on relaunch

The tracker checkbox flags (`anonymous`, `internal`, `personal_release`, `stream_optimized`, the mod-queue opt-ins, `featured`, `free`, `double_up`, `sticky`) shipped in the default config as the int `0`, but they are `bool` in the model, the settings checkboxes and the write path. Once the app saved a profile from its own model, the values were written as TOML `true`/`false`, and the next launch failed type validation, leaving only the archive-and-regenerate path.

Fix: declare the flags as `bool` in the default so the persisted type matches the model, and add `coerce_bool_flags` to normalize a lingering int `0`/`1` to `bool` before `validate_types`, driven by the default document's types. A config still holding the old int form (including a schema-1 profile migrated forward) self-heals instead of being rejected. Non-`0`/`1` ints are left alone so genuine corruption still surfaces as a type error.

## 2. BHD stream-optimized and localization flags not persisted

`.add_localization_to_custom_edition` and `stream_optimized` are user-facing checkboxes, but the decode and save paths never read or wrote them and the default omitted them. The widget still set them on the model, so toggling either did nothing: the value reset to `False` on the next load. Both persisted on prior releases.

Fix: read and write both in the BHD decode/save blocks and add them as `bool`, matching how the other trackers handle `stream_optimized`.

## Verification

- New tests reproduce both bugs (fail before, pass after): bool-flag config load, model round-trip, int self-heal, schema-1 migration coercion, and BHD flag round-trip.
- Audited every tracker and collection-payload field against decode / save / default, plus a load -> save -> reload of the packaged default: no other gaps.
- Full suite: 376 passed. mypy clean on changed files, ruff clean.
