### PR TITLE
fix: avoid mutating edition set during iteration in _frame_size

### DIFF
--- a/src/backend/token_replacer.py
+++ b/src/backend/token_replacer.py
@@ -1066,14 +1066,12 @@ class TokenReplacer:
 
         # normalize some editions
         if edition_set:
-            normalized_edition_set = set()
+            normalized_edition_set: set[object] = set()
             for item in edition_set:
-                item_lowered = str(item).lower()
-                if "imax" in item_lowered:
+                if "imax" in str(item).lower():
                     normalized_edition_set.add("IMAX")
                     break
-                edition_set.clear()
-                edition_set.add("IMAX")
+            edition_set = normalized_edition_set
 
         # convert the set back to a string, joining with spaces
         return self._optional_user_input(

--- a/tests/test_backend/test_token_replacer_movies.py
+++ b/tests/test_backend/test_token_replacer_movies.py
@@ -1,0 +1,52 @@
+from src.backend.token_replacer import TokenReplacer
+from src.backend.tokens import FileToken, TokenData
+from src.backend.utils.example_parsed_movie_data import (
+    EXAMPLE_MEDIA_INPUT_PAYLOAD,
+    EXAMPLE_SEARCH_PAYLOAD,
+)
+from src.enums.token_replacer import UnfilledTokenRemoval
+
+
+def _td() -> TokenData:
+    # bare TokenData() leaves pre_token/post_token as None, which
+    # _optional_user_input interpolates as the literal string "None" around
+    # the value; tests asserting exact output need the empty-string variant.
+    return TokenData(pre_token="", post_token="")
+
+
+def _movie_replacer() -> TokenReplacer:
+    # Mirrors the movies-management settings preview's TokenReplacer call
+    # (MoviesManagementSettings._update_example), so the test exercises the
+    # same path that runs when the Settings token preview renders on launch.
+    return TokenReplacer(
+        media_input_obj=EXAMPLE_MEDIA_INPUT_PAYLOAD,
+        token_string="{frame_size}",
+        media_search_obj=EXAMPLE_SEARCH_PAYLOAD,
+        flatten=True,
+        file_name_mode=True,
+        token_type=FileToken,
+        unfilled_token_mode=UnfilledTokenRemoval.TOKEN_ONLY,
+    )
+
+
+def test_frame_size_normalizes_imax_without_mutating_during_iteration() -> None:
+    # The example movie filename parses to two editions
+    # (["Director's Cut", "IMAX"]). _frame_size collapses any IMAX edition
+    # to "IMAX", and must do so without mutating the set it iterates.
+    #
+    # A dev regression cleared/added to `edition_set` mid-loop, raising
+    # "RuntimeError: Set changed size during iteration" whenever a non-IMAX
+    # edition was visited before IMAX. Because set iteration order is
+    # randomized per process, this crashed on roughly half of cold launches.
+    #
+    # Asserting the exact "IMAX" output fails deterministically on the buggy
+    # code under every ordering: either it raises, or (when IMAX is visited
+    # first) it returns the un-normalized "IMAX Director's Cut".
+    replacer = _movie_replacer()
+
+    editions = replacer.guess_name.get("edition")
+    assert isinstance(editions, list)
+    assert "IMAX" in editions
+    assert any("imax" not in str(e).lower() for e in editions)
+
+    assert replacer._frame_size(_td()) == "IMAX"


### PR DESCRIPTION
## Summary

`_frame_size` cleared and re-added to `edition_set` inside the loop that iterates it, raising `RuntimeError: Set changed size during iteration` whenever a non-IMAX edition was visited before IMAX. Set iteration order is randomized per process, so the Settings movie-management token preview crashed on roughly half of launches while rendering the example movie data, which parses to two editions ("Director's Cut" and "IMAX").

The loop also left the `normalized_edition_set` it built unused, so even when it did not crash it emitted the un-normalized `IMAX Director's Cut` instead of `IMAX`.

The fix builds the normalized set and reassigns `edition_set` after the loop completes, restoring the token to collapse any IMAX edition to `IMAX` (and empty otherwise).

## Testing

- Added a regression test that renders the example movie data through `_frame_size` and asserts it normalizes to `IMAX` without raising. It fails deterministically on the old code (either the crash, or the wrong `IMAX Director's Cut` value depending on set order) and passes across hash seeds after the fix.
- Full suite: 377 passed.
- `ruff` and `mypy` clean on the changed files.
