### PR TITLE
fix: Restore config migration chain broken by the schema 3 bump

### DIFF
--- a/src/config/config.py
+++ b/src/config/config.py
@@ -7,6 +7,7 @@ import tomlkit
 
 from src.config.codec import TomlConfigCodec
 from src.config.dependencies import FindDependencies
+from src.config.migrations import document_version, migrate_document
 from src.config.models import AppConfig, ProgramConfig
 from src.config.operations import TypedTomlOperations
 from src.config.paths import ConfigPaths
@@ -135,6 +136,30 @@ class ConfigManager(TypedTomlOperations):
             loaded_text = config_path.read_text(encoding="utf-8")
             loaded_document = tomlkit.parse(loaded_text)
 
+            try:
+                loaded_version: int | None = document_version(loaded_document)
+            except (TypeError, ValueError):
+                # A malformed `schema_version` (e.g. the string "two") is not
+                # migratable. Leave it for `validate_schema` below, which
+                # reports it as a `ConfigSchemaError` rather than letting a
+                # bare ValueError escape to the global excepthook.
+                loaded_version = None
+
+            if (
+                loaded_version is not None
+                and loaded_version < self.codec.SCHEMA_VERSION
+            ):
+                migrated_document = self._try_migrate_profile(
+                    loaded_document, default_toml
+                )
+                if migrated_document is not None:
+                    loaded_text = self.codec.dumps(migrated_document)
+                    atomic_write_text(config_path, loaded_text)
+                    # re-parse so downstream merge/validate/decode operate on
+                    # a real TOML document, consistent with the normal
+                    # (non-migration) load path
+                    loaded_document = tomlkit.parse(loaded_text)
+
             self._config_snapshot = loaded_text
             try:
                 # Assigned atomically: only if the full validate/merge/decode
@@ -185,6 +210,11 @@ class ConfigManager(TypedTomlOperations):
         ``self._default_document``, then `decode` (which also runs
         `validate_settings`).
 
+        Shared by `load_profile` (the real load, ``dry_run=False``) and
+        `_try_migrate_profile`'s trial validation (``dry_run=True``, never
+        persisted) so the two paths cannot drift apart if this sequence ever
+        changes.
+
         Returns the defaults-merged document. Raises whatever the
         underlying steps raise (e.g. `ConfigSchemaError`, `ConfigError`) on
         failure.
@@ -200,6 +230,50 @@ class ConfigManager(TypedTomlOperations):
         self.codec.validate_types(merged, self._default_document)
         self.decode(merged, dry_run=dry_run)
         return merged
+
+    def _try_migrate_profile(
+        self,
+        loaded_document: MutableMapping[str, Any],
+        default_toml: str,
+    ) -> MutableMapping[str, Any] | None:
+        """Attempt to migrate an older profile up to the current schema.
+
+        `migrate_document` applies every intermediate hop, so a profile
+        several versions behind is carried through each shape in turn rather
+        than being rejected.
+
+        Returns the migrated document on success -- but only after proving it
+        actually validates, by running it through the exact same validation
+        `load_profile` applies to a normal, already-current-schema config:
+        schema check, merge defaults, per-key type validation, and a decode
+        (which also runs `validate_settings`). That trial run happens on an
+        in-memory copy only (`decode(..., dry_run=True)`), never on the
+        document that gets persisted, so a migration that maps structurally
+        but produces an invalid document can't destroy the original file.
+
+        Returns ``None`` if migration is not possible (some section could
+        not be mapped), the migrated document fails validation, or anything
+        raised, in which case the caller must leave the original
+        document/file untouched and fall through to the normal
+        `ConfigSchemaError` path so the existing archive+regenerate flow can
+        take over.
+        """
+        try:
+            migrated_document, unmapped = migrate_document(
+                loaded_document, self._default_document
+            )
+        except Exception:
+            return None
+        if unmapped:
+            return None
+
+        try:
+            trial_document = tomlkit.parse(self.codec.dumps(migrated_document))
+            self._validate_document(trial_document, default_toml, dry_run=True)
+        except Exception:
+            return None
+
+        return migrated_document
 
     def save_as(self, save_path: Path) -> None:
         """Save the current settings under a new profile name."""

--- a/src/config/migrations.py
+++ b/src/config/migrations.py
@@ -1,29 +1,75 @@
-"""One-time migration from the unversioned ("schema 1") config layout to schema 2.
+"""Config schema migrations, applied as a chain of single-version hops.
+
+Each entry in `MIGRATIONS` is keyed by the schema version it accepts and
+produces the next version up: the migration keyed ``n`` takes a schema-``n``
+document to schema-``n+1``. `migrate_document` walks that chain from whatever
+version a loaded profile declares up to
+``TomlConfigCodec.SCHEMA_VERSION``, so a user who skipped several releases is
+migrated through every intermediate step rather than being rejected.
 
 Schema 1 configs predate the ``schema_version`` field entirely -- the key is
-simply absent from the document. Schema 2 introduced series/TV support and
-reorganized a handful of movie-rename settings (``[movie_rename]`` became
-``[movie_management]``, with the title-cleaning rules and dynamic-range
-settings split out into a new ``[global_management]`` section). This module
-maps a schema 1 document onto the schema 2 shape while preserving anything
-the user customized.
+simply absent from the document, so `document_version` reports such a
+document as version 1.
 
-This is deliberately kept free of any Qt/UI imports so it can be unit tested
-without launching the application; ``ConfigManager.load_profile`` is the only
-caller in the running app, and it decides what to do when migration fails.
+The versions so far:
+
+- 1 -> 2: series/TV support; ``[movie_rename]`` became ``[movie_management]``,
+  with title-cleaning rules and dynamic-range settings split out into a new
+  ``[global_management]`` section.
+- 2 -> 3: PTPIMG support removed, dropping ``[image_hosts.ptpimg]``.
+
+When does a bump warrant a migration?
+-------------------------------------
+Every `TomlConfigCodec.SCHEMA_VERSION` bump needs a matching `MIGRATIONS`
+entry -- `check_migration_chain` runs at import and refuses to let the module
+load otherwise. The prior question is whether the bump is warranted at all:
+
+- Renamed, moved, or retyped keys **do** need a bump. Nothing else can map
+  the old layout onto the new one.
+- Added keys **do not**. ``TomlConfigCodec.merge_defaults`` backfills any key
+  the packaged default declares but the user's profile lacks.
+- Removed keys **do not**. ``validate_types`` only iterates over keys present
+  in the default document, so a key the app no longer knows about is ignored
+  rather than rejected, and decoding reads known sections by name. A stale
+  section simply sits unread in the user's file.
+
+Bumping for an added or removed key costs every user their settings for no
+benefit, so prefer leaving the version alone and letting the merge/validate
+path absorb the change. The 2 -> 3 hop below exists because that bump was
+already released, not because removing a key required it.
+
+This module is deliberately kept free of any Qt/UI imports so it can be unit
+tested without launching the application; ``ConfigManager.load_profile`` is
+the only caller in the running app, and it decides what to do when a
+migration fails.
 """
 
 from __future__ import annotations
 
 import re
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from typing import Any
 
 import tomlkit
 
+from src.config.codec import TomlConfigCodec
 from src.config.paths import ConfigPaths
 
+# Schema 1 predates the `schema_version` field; a document without the key is
+# treated as this version.
+SCHEMA_1_VERSION = 1
 SCHEMA_2_VERSION = 2
+SCHEMA_3_VERSION = 3
+
+# A migration accepts (document, packaged_default) and returns the migrated
+# document plus a list of sections it could not account for.
+MigrationFn = Callable[
+    [Mapping[str, Any], Mapping[str, Any] | None],
+    "tuple[dict[str, Any], list[str]]",
+]
+
+# The `[image_hosts.*]` table dropped by the 2 -> 3 hop.
+_REMOVED_V3_IMAGE_HOST = "ptpimg"
 
 # The only schema 1 section that needs to be relocated/renamed rather than
 # copied forward unchanged.
@@ -302,3 +348,178 @@ def migrate_unversioned_to_v2(
         new_doc["series_management"] = _unwrap(defaults["series_management"])
 
     return new_doc, unmapped
+
+
+def migrate_v2_to_v3(
+    old_doc: Mapping[str, Any],
+    default_document: Mapping[str, Any] | None = None,
+) -> tuple[dict[str, Any], list[str]]:
+    """Migrate a schema 2 config document to schema 3.
+
+    Schema 3 removed PTPIMG support, so ``[image_hosts.ptpimg]`` is dropped.
+    Nothing else changed: every other section is copied forward by reference,
+    and no section can fail to map, so ``unmapped`` is always empty.
+
+    Dropping the section is housekeeping rather than a requirement --
+    ``validate_types`` ignores keys the packaged default no longer declares,
+    and image hosts are decoded by name -- but leaving it would strand a dead
+    table with a stale API key in every migrated profile.
+
+    Args:
+        old_doc: The parsed schema 2 config document.
+        default_document: Unused; accepted so every migration in
+            `MIGRATIONS` shares one signature.
+
+    Returns:
+        A ``(migrated_document, unmapped_sections)`` tuple.
+    """
+    del default_document  # signature parity across the registry
+
+    # `schema_version` is inserted first so it serializes above the tables --
+    # a top-level key emitted after a `[table]` header would be parsed back
+    # as a member of that table.
+    new_doc: dict[str, Any] = {"schema_version": SCHEMA_3_VERSION}
+    for key, value in old_doc.items():
+        if key == "schema_version":
+            continue
+        new_doc[key] = value
+
+    image_hosts = new_doc.get("image_hosts")
+    if isinstance(image_hosts, Mapping) and _REMOVED_V3_IMAGE_HOST in image_hosts:
+        # Rebuilt rather than mutated: sections are copied forward by
+        # reference above, so deleting in place would also strip the key from
+        # the caller's document.
+        new_doc["image_hosts"] = {
+            name: section
+            for name, section in image_hosts.items()
+            if name != _REMOVED_V3_IMAGE_HOST
+        }
+
+    return new_doc, []
+
+
+# Keyed by the schema version each migration accepts; each produces the next
+# version up. Add an entry here for every `SCHEMA_VERSION` bump -- see the
+# bump policy in this module's docstring.
+MIGRATIONS: dict[int, MigrationFn] = {
+    SCHEMA_1_VERSION: migrate_unversioned_to_v2,
+    SCHEMA_2_VERSION: migrate_v2_to_v3,
+}
+
+
+def check_migration_chain(
+    registry: Mapping[int, MigrationFn],
+    schema_version: int,
+    lowest: int = SCHEMA_1_VERSION,
+) -> None:
+    """Verify the registry can carry any supported document to the current
+    schema version.
+
+    Raises:
+        RuntimeError: If a hop is missing (some version cannot reach
+            ``schema_version``) or the registry holds a hop outside the
+            supported range.
+    """
+    expected = set(range(lowest, schema_version))
+    actual = set(registry)
+
+    missing = sorted(expected - actual)
+    if missing:
+        raise RuntimeError(
+            "Config migration chain is incomplete: no migration is registered "
+            f"for schema version(s) {missing}, so a profile at that version "
+            f"cannot reach schema_version {schema_version} and would be "
+            "rejected as unsupported at startup. Every SCHEMA_VERSION bump "
+            "needs a matching MIGRATIONS entry -- see the bump policy in "
+            "src/config/migrations.py."
+        )
+
+    unexpected = sorted(actual - expected)
+    if unexpected:
+        raise RuntimeError(
+            "Config migration chain registers hop(s) beyond the supported "
+            f"range: {unexpected}. The current schema_version is "
+            f"{schema_version}, so migrations may only be keyed "
+            f"{lowest}..{schema_version - 1}."
+        )
+
+
+def document_version(document: Mapping[str, Any]) -> int:
+    """The schema version a config document declares.
+
+    Schema 1 predates the field, so a document without ``schema_version`` is
+    reported as `SCHEMA_1_VERSION`.
+
+    Raises:
+        TypeError, ValueError: If the field is present but not an integer.
+    """
+    if "schema_version" not in document:
+        return SCHEMA_1_VERSION
+    raw = document["schema_version"]
+    return int(raw.unwrap() if hasattr(raw, "unwrap") else raw)
+
+
+def migrate_document(
+    document: Mapping[str, Any],
+    default_document: Mapping[str, Any] | None = None,
+    target_version: int | None = None,
+) -> tuple[dict[str, Any], list[str]]:
+    """Apply every migration needed to bring ``document`` up to the current
+    schema version.
+
+    Hops are applied in sequence, so a profile several versions behind is
+    carried through each intermediate shape rather than being rejected. A
+    document already at the target version is returned unchanged.
+
+    Args:
+        document: The parsed config document, at any supported version.
+        default_document: The packaged default, passed through to each
+            migration so they source brand new sections from the same
+            defaults the rest of the load path uses.
+        target_version: The version to migrate to. Defaults to
+            ``TomlConfigCodec.SCHEMA_VERSION``.
+
+    Returns:
+        A ``(migrated_document, unmapped_sections)`` tuple, with
+        ``unmapped_sections`` accumulated across every hop. A non-empty list
+        means some hop could not fully account for the user's settings and
+        the caller should discard the result in favor of archive+regenerate.
+
+    Raises:
+        RuntimeError: If a required hop is missing from `MIGRATIONS`. The
+            import-time `check_migration_chain` call makes this unreachable
+            for the real registry.
+    """
+    target = (
+        TomlConfigCodec.SCHEMA_VERSION if target_version is None else target_version
+    )
+    version = document_version(document)
+    unmapped: list[str] = []
+    current: Mapping[str, Any] = document
+
+    while version < target:
+        migration = MIGRATIONS.get(version)
+        if migration is None:
+            raise RuntimeError(
+                f"No config migration registered for schema version {version}; "
+                f"cannot reach schema_version {target}."
+            )
+        current, step_unmapped = migration(current, default_document)
+        unmapped.extend(step_unmapped)
+        version += 1
+
+    return dict(current), unmapped
+
+
+# Import-time invariant: a SCHEMA_VERSION bump without a matching migration
+# breaks every existing profile, and the symptom (an "unsupported schema"
+# dialog offering to wipe the user's settings) surfaces far from the cause.
+# Failing here means the developer who bumped the version hits it on their
+# next run instead. Both operands are source constants, so this cannot start
+# failing in the field for a build that imports cleanly.
+#
+# Deliberately an explicit raise rather than `assert`, which `python -O`
+# strips. The packaged default's `schema_version` is checked separately by
+# `ConfigManager.load_profile`, which validates the default document on every
+# load -- that one needs file I/O and so does not belong at import time.
+check_migration_chain(MIGRATIONS, TomlConfigCodec.SCHEMA_VERSION)

--- a/start_ui.py
+++ b/start_ui.py
@@ -132,10 +132,11 @@ class NfoForge:
     def _handle_config_schema_error(self, error: ConfigSchemaError) -> None:
         # note: by the time this fires, ConfigManager has already attempted
         # an automatic in-place migration (see `ConfigManager.load_profile`
-        # / `migrate_unversioned_to_v2`) and either it wasn't applicable
-        # (schema_version present but unsupported) or it failed to fully
-        # account for the user's settings. Either way, settings cannot be
-        # preserved from here, so this dialog makes that explicit.
+        # / `migrate_document`) and either it wasn't applicable (the config
+        # declares a version newer than this build supports, or a malformed
+        # one) or it failed to fully account for the user's settings. Either
+        # way, settings cannot be preserved from here, so this dialog makes
+        # that explicit.
         config_path = error.config_path
         if not config_path:
             self._error_on_splash(str(error))

--- a/tests/test_config/fixtures/schema2_config.toml
+++ b/tests/test_config/fixtures/schema2_config.toml
@@ -1,0 +1,581 @@
+schema_version = 2
+
+[general]
+ui_suffix = ""
+ui_scale_factor = 1.0
+nfo_forge_theme = 1
+enable_plugins = false
+releasers_name = "SchemaTwoUser"
+tmdb_language = "en-US"
+timeout = 60
+enable_prompt_overview = true
+enable_mkbrr = true
+log_level = 20
+log_total = 50
+working_dir = ""
+
+[dependencies]
+ffmpeg = ""
+ffprobe = ""
+frame_forge = ""
+mkbrr = ""
+
+[api_keys]
+tmdb_api_key = ""
+
+[tracker.settings]
+tracker_order = []
+last_used_img_host = {}
+
+[tracker.more_than_tv]
+upload_enabled = true
+announce_url = ""
+enabled = false
+source = "MTV"
+comments = ""
+nfo_template = ""
+max_piece_size = 8000000
+url_type = 1
+column_s = 1
+column_space = 1
+row_space = 0
+mvr_title_override_enabled = true
+mvr_title_colon_replace = 3
+mvr_title_token_override = ""
+mvr_title_replace_map = [['''\s''', "."]]
+anonymous = false
+api_key = ""
+username = ""
+password = ""
+totp = ""
+group_description = ""
+additional_tags = ""
+source_origin = 1
+image_width = 350
+
+[tracker.torrent_leech]
+upload_enabled = true
+announce_url = ""
+enabled = false
+source = "TorrentLeech.org"
+comments = ""
+nfo_template = ""
+max_piece_size = 0
+url_type = 2
+column_s = 1
+column_space = 1
+row_space = 0
+mvr_title_override_enabled = true
+mvr_title_token_override = ""
+mvr_title_replace_map = [["\\.", "[space]"]]
+mvr_title_colon_replace = 3
+username = ""
+password = ""
+torrent_passkey = ""
+alt_2_fa_token = ""
+
+[tracker.beyond_hd]
+upload_enabled = true
+announce_url = ""
+enabled = false
+source = "BHD"
+comments = ""
+nfo_template = ""
+max_piece_size = 0
+url_type = 1
+column_s = 1
+column_space = 1
+row_space = 0
+mvr_title_override_enabled = false
+mvr_title_token_override = ""
+mvr_title_replace_map = []
+mvr_title_colon_replace = 3
+anonymous = false
+api_key = ""
+rss_key = ""
+promo = 0
+live_release = 1
+internal = false
+image_width = 350
+add_localization_to_custom_edition = false
+stream_optimized = false
+
+[tracker.pass_the_popcorn]
+upload_enabled = true
+announce_url = ""
+enabled = false
+source = "PTP"
+comments = ""
+nfo_template = ""
+max_piece_size = 16777216
+url_type = 1
+column_s = 1
+column_space = 1
+row_space = 0
+mvr_title_override_enabled = false
+mvr_title_token_override = ""
+mvr_title_replace_map = []
+mvr_title_colon_replace = 3
+api_user = ""
+api_key = ""
+username = ""
+password = ""
+totp = ""
+
+[tracker.reelflix]
+upload_enabled = true
+announce_url = ""
+enabled = false
+source = "ReelFliX"
+comments = ""
+nfo_template = ""
+max_piece_size = 0
+url_type = 1
+column_s = 1
+column_space = 1
+row_space = 0
+mvr_title_override_enabled = false
+mvr_title_token_override = ""
+mvr_title_replace_map = []
+mvr_title_colon_replace = 3
+api_key = ""
+anonymous = false
+internal = false
+personal_release = false
+stream_optimized = false
+opt_in_to_mod_queue = false
+featured = false
+free = false
+double_up = false
+sticky = false
+image_width = 350
+
+[tracker.aither]
+upload_enabled = true
+announce_url = ""
+enabled = false
+source = "Aither"
+comments = ""
+nfo_template = ""
+max_piece_size = 0
+url_type = 1
+column_s = 1
+column_space = 1
+row_space = 0
+mvr_title_override_enabled = true
+mvr_title_token_override = "{title_clean} {release_year} {frame_size} {edition} {re_release} {resolution} {source} {audio_codec} {audio_channel_s} {video_dynamic_range_type_inc_sdr_over_1080} {video_codec}{:opt=-:release_group}"
+mvr_title_replace_map = [
+    [
+        '''(?<=\s)DDP(?=\s\d)''',
+        "DD+",
+    ],
+    [
+        '''(?i)hdr10plus''',
+        "HDR10+",
+    ],
+]
+mvr_title_colon_replace = 3
+api_key = ""
+anonymous = false
+internal = false
+personal_release = false
+stream_optimized = false
+opt_in_to_mod_queue = false
+featured = false
+free = false
+double_up = false
+sticky = false
+image_width = 350
+
+[tracker.huno]
+upload_enabled = true
+announce_url = ""
+enabled = false
+source = "HUNO"
+comments = ""
+nfo_template = ""
+max_piece_size = 0
+url_type = 1
+column_s = 1
+column_space = 1
+row_space = 0
+mvr_title_override_enabled = true
+mvr_title_token_override = "{title_clean} {release_year_parentheses} {edition} {frame_size} ({resolution} {source} {video_codec} {video_dynamic_range} {audio_codec} {audio_channel_s} {audio_language_1_full} - {release_group}) {:opt=[:re_release:opt=]:}"
+mvr_title_replace_map = [
+    [
+        '''(?<=\s)DDP(?=\s\d)''',
+        "DD+",
+    ],
+    [
+        '''(?i)hdr10plus''',
+        "HDR10+",
+    ],
+]
+mvr_title_colon_replace = 3
+api_key = ""
+anonymous = false
+internal = false
+stream_optimized = false
+image_width = 350
+
+[tracker.lst]
+upload_enabled = true
+announce_url = ""
+enabled = false
+source = "LST"
+comments = ""
+nfo_template = ""
+max_piece_size = 0
+url_type = 1
+column_s = 1
+column_space = 1
+row_space = 0
+mvr_title_override_enabled = true
+mvr_title_token_override = "{title_clean} {release_year} {frame_size} {edition} {re_release} {resolution} {source} {audio_codec} {audio_channel_s} {video_dynamic_range_type_inc_sdr_over_1080} {video_codec}{:opt=-:release_group}"
+mvr_title_replace_map = [
+    [
+        '''(?<=\s)DDP(?=\s\d)''',
+        "DD+",
+    ],
+    [
+        '''(?i)hdr10plus''',
+        "HDR10+",
+    ],
+]
+mvr_title_colon_replace = 3
+api_key = ""
+anonymous = false
+internal = false
+personal_release = false
+mod_queue_opt_in = false
+draft_queue_opt_in = false
+featured = false
+free = false
+double_up = false
+sticky = false
+image_width = 500
+
+[tracker.dark_peers]
+upload_enabled = true
+announce_url = ""
+enabled = false
+source = "DarkPeers"
+comments = ""
+nfo_template = ""
+max_piece_size = 0
+url_type = 1
+column_s = 1
+column_space = 1
+row_space = 0
+mvr_title_override_enabled = true
+mvr_title_token_override = "{title_clean} {release_year} {frame_size} {edition} {re_release} {resolution} {source} {audio_codec} {audio_channel_s} {video_dynamic_range_type_inc_sdr_over_1080} {video_codec}{:opt=-:release_group}"
+mvr_title_replace_map = [
+    [
+        '''(?<=\s)DDP(?=\s\d)''',
+        "DD+",
+    ],
+    [
+        '''(?i)hdr10plus''',
+        "HDR10+",
+    ],
+]
+mvr_title_colon_replace = 3
+api_key = ""
+anonymous = false
+internal = false
+personal_release = false
+image_width = 500
+
+[tracker.shareisland]
+upload_enabled = true
+announce_url = ""
+enabled = false
+source = "ShareIsland"
+comments = ""
+nfo_template = ""
+max_piece_size = 0
+url_type = 1
+column_s = 1
+column_space = 1
+row_space = 0
+mvr_title_override_enabled = true
+mvr_title_token_override = "{title_clean} {release_year} {audio_language_all_full|upper|replace(' ',' - ')} {frame_size} {edition} {re_release} {resolution} {source} {audio_codec} {audio_channel_s} {video_dynamic_range_type_inc_sdr_over_1080} {video_codec}{:opt=-:release_group}"
+mvr_title_replace_map = [
+    [
+        '''(?<=\s)DDP(?=\s\d)''',
+        "DD+",
+    ],
+    [
+        '''(?i)hdr10plus''',
+        "HDR10+",
+    ],
+]
+mvr_title_colon_replace = 3
+api_key = ""
+anonymous = false
+internal = false
+personal_release = false
+opt_in_to_mod_queue = false
+image_width = 350
+
+[tracker.uploadcx]
+upload_enabled = true
+announce_url = ""
+enabled = false
+source = "ULCX"
+comments = ""
+nfo_template = ""
+max_piece_size = 0
+url_type = 1
+column_s = 1
+column_space = 1
+row_space = 0
+mvr_title_override_enabled = true
+mvr_title_token_override = "{title_clean} {release_year} {frame_size} {edition} {re_release} {resolution} {source} {audio_codec} {audio_channel_s} {video_dynamic_range_type_inc_sdr_over_1080} {video_codec}{:opt=-:release_group}"
+mvr_title_replace_map = [
+    [
+        '''(?<=\s)DDP(?=\s\d)''',
+        "DD+",
+    ],
+    [
+        '''(?i)hdr10plus''',
+        "HDR10+",
+    ],
+]
+mvr_title_colon_replace = 3
+api_key = ""
+anonymous = false
+internal = false
+personal_release = false
+image_width = 500
+
+[tracker.only_encodes]
+upload_enabled = true
+announce_url = ""
+enabled = false
+source = "OE"
+comments = ""
+nfo_template = ""
+max_piece_size = 0
+url_type = 1
+column_s = 1
+column_space = 1
+row_space = 0
+mvr_title_override_enabled = true
+mvr_title_token_override = "{title_clean} {release_year} {frame_size} {edition} {re_release} {resolution} {source} {audio_codec} {audio_channel_s} {video_dynamic_range_type_inc_sdr_over_1080} {video_codec}{:opt=-:release_group}"
+mvr_title_replace_map = [
+    [
+        '''(?<=\s)DDP(?=\s\d)''',
+        "DD+",
+    ],
+    [
+        '''(?i)hdr10plus''',
+        "HDR10+",
+    ],
+]
+mvr_title_colon_replace = 3
+api_key = ""
+anonymous = false
+internal = false
+personal_release = false
+image_width = 500
+
+[torrent_client]
+
+[torrent_client.qbittorrent]
+enabled = false
+host = "http://127.0.0.1"
+port = 0
+user = ""
+password = ""
+specific_params = { "category" = "", "super_seeding" = false }
+
+[torrent_client.deluge]
+enabled = false
+host = "http://127.0.0.1"
+port = 0
+user = ""
+password = ""
+specific_params = { "label" = "", "path" = "" }
+
+[torrent_client.rtorrent]
+enabled = false
+host = "https://<user>:<password>@www.url.com/plugins/httprpc/action.php"
+port = 0
+user = ""
+password = ""
+specific_params = { "label" = "", "path" = "" }
+
+[torrent_client.transmission]
+enabled = false
+host = "http://<user>:<password>@127.0.0.1/transmission/rpc"
+port = 0
+user = ""
+password = ""
+specific_params = { "label" = "", "path" = "" }
+
+[watch_folder]
+enabled = false
+path = ""
+
+[movie_management]
+mvr_enabled = true
+mvr_replace_illegal_chars = true
+mvr_colon_replace_filename = 3
+mvr_colon_replace_title = 3
+mvr_parse_filename_attributes = true
+mvr_token = "{title_clean} {release_year} {re_release} {source} {resolution} {audio_codec} {audio_channel_s} {video_codec}{:opt=-:release_group}"
+mvr_title_token = "{title_clean} {release_year} {re_release} {source} {resolution} {audio_codec} {audio_channel_s} {video_codec}{:opt=-:release_group}"
+# TODO: move to global at the top?
+mvr_release_group = "SchemaTwoGroup"
+
+[series_management]
+tvr_enabled = true
+tvr_replace_illegal_chars = true
+tvr_colon_replace_filename = 3
+tvr_colon_replace_title = 3
+tvr_parse_filename_attributes = true
+tvr_standard_episode_token = "{title_clean} S{season_number|zfill(2)}E{episode_number|zfill(2)} {episode_title_clean} {re_release} {resolution} {source} {audio_codec} {audio_channel_s} {video_dynamic_range_type_inc_sdr_over_1080} {video_codec}{:opt=-:release_group}"
+tvr_daily_episode_token = "{title_clean} {episode_air_date} {episode_title_clean} {re_release} {resolution} {source} {audio_codec} {audio_channel_s} {video_dynamic_range_type_inc_sdr_over_1080} {video_codec}{:opt=-:release_group}"
+tvr_anime_episode_token = "{title_clean} S{season_number|zfill(2)}E{episode_number|zfill(2)} {episode_number_absolute|zfill(3)} {episode_title_clean} {re_release} {resolution} {source} {audio_codec} {audio_channel_s} {video_dynamic_range_type_inc_sdr_over_1080} {video_codec}{:opt=-:release_group}"
+tvr_season_folder_token = "{title_clean} S{season_number|zfill(2)} {re_release} {resolution} {source} {audio_codec} {audio_channel_s} {video_dynamic_range_type_inc_sdr_over_1080} {video_codec}{:opt=-:release_group}"
+tvr_multi_episode_style = 4
+tvr_standard_title_token = "{title_clean} S{season_number|zfill(2)}{:opt=E:episode_number|zfill(2)} {episode_title_clean} {re_release} {resolution} {source} {audio_codec} {audio_channel_s} {video_dynamic_range_type_inc_sdr_over_1080} {video_codec}{:opt=-:release_group}"
+tvr_daily_title_token = "{title_clean} {episode_air_date} {episode_title_clean} {re_release} {resolution} {source} {audio_codec} {audio_channel_s} {video_dynamic_range_type_inc_sdr_over_1080} {video_codec}{:opt=-:release_group}"
+tvr_anime_title_token = "{title_clean} S{season_number|zfill(2)}{:opt=E:episode_number|zfill(2)} {episode_number_absolute|zfill(3)} {episode_title_clean} {re_release} {resolution} {source} {audio_codec} {audio_channel_s} {video_dynamic_range_type_inc_sdr_over_1080} {video_codec}{:opt=-:release_group}"
+tvr_release_group = ""
+
+[global_management]
+title_clean_rules = [
+    [
+        "",
+        "[unidecode]",
+    ],
+    [
+        "&",
+        "and",
+    ],
+    [
+        "'",
+        "[remove]",
+    ],
+    [
+        "[^a-zA-Z0-9]",
+        "[space]",
+    ],
+    [
+        '\s{2,}',
+        "[space]",
+    ],
+]
+title_clean_rules_modified = false
+
+[global_management.video_dynamic_range.resolutions]
+720p = false
+1080p = false
+2160p = true
+
+[global_management.video_dynamic_range.hdr_types]
+SDR = true
+PQ = false
+HLG = false
+HDR10 = true
+"HDR10+" = true
+DV = true
+"DV HDR10" = true
+"DV HDR10+" = true
+
+[global_management.video_dynamic_range.custom_strings]
+SDR = "SDR"
+PQ = ""
+HLG = ""
+HDR10 = "HDR"
+"HDR10+" = "HDR10Plus"
+DV = "DV"
+"DV HDR10" = "DV HDR"
+"DV HDR10+" = "DV HDR10Plus"
+
+[user_tokens.tokens]
+
+[screenshots]
+crop_mode = 2
+screenshots_enabled = false
+screen_shot_count = 20
+ss_mode = 1
+sub_size_height_720 = 12
+sub_size_height_1080 = 16
+sub_size_height_2160 = 32
+subtitle_alignment = 7
+subtitle_color = "#f5c70a"
+subtitle_outline_color = "#000000"
+trim_start = 20
+trim_end = 20
+min_required_selected_screens = 4
+max_required_selected_screens = 12
+comparison_subtitles = true
+comparison_subtitle_source_name = "Source"
+comparison_subtitle_encode_name = "Encode"
+optimize_generated_images = true
+optimize_dl_url_images = true
+optimize_dl_url_images_percentage = 0.25
+indexer = 1
+image_plugin = 1
+
+[image_hosts.chevereto_v3]
+enabled = false
+base_url = ""
+user = ""
+password = ""
+
+[image_hosts.chevereto_v4]
+enabled = false
+base_url = ""
+api_key = ""
+
+[image_hosts.image_bb]
+enabled = false
+base_url = "https://api.imgbb.com/"
+api_key = ""
+
+[image_hosts.image_box]
+enabled = false
+base_url = "https://imgbox.com/"
+
+[image_hosts.ptpimg]
+enabled = false
+base_url = "https://ptpimg.me/"
+api_key = "dead-ptpimg-key"
+
+[urls]
+alt = ""
+columns = 1
+vertical = 1
+horizontal = 1
+mode = 0
+type = 1
+image_width = 0
+urls_manual = 0
+
+[plugins]
+wizard_page = ""
+token_replacer = ""
+pre_upload = ""
+
+[template_settings]
+block_syntax_color = "#A4036F"
+variable_syntax_color = "#048BA8"
+comment_syntax_color = "#16DB93"
+trim_blocks = 1
+lstrip_blocks = 1
+newline_sequence = "\n"
+keep_trailing_newline = 0
+enable_sandbox_prompt_tokens = true
+
+[release_notes]
+enable_release_notes = false
+last_used_release_note = ""
+
+[release_notes.notes]
+
+[widget_settings]
+prompt_token_editor_warn_on_missing = true

--- a/tests/test_config/test_manager.py
+++ b/tests/test_config/test_manager.py
@@ -347,32 +347,13 @@ def test_manager_rejects_invalid_newline_sequence(
         ConfigManager("test", paths)
 
 
-def test_load_profile_rejects_legacy_config_without_mutating(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    monkeypatch.setattr(
-        "src.config.config.FindDependencies.update_dependencies",
-        lambda self, dependencies: None,
-    )
-    paths = _paths(tmp_path)
-    profile = paths.user_configs / "test.toml"
-    profile.parent.mkdir(parents=True)
-    fixture_text = Path("tests/test_config/fixtures/schema1_config.toml").read_text(
-        encoding="utf-8"
-    )
-    profile.write_text(fixture_text, encoding="utf-8")
-
-    with pytest.raises(ConfigSchemaError, match="Missing configuration schema_version"):
-        ConfigManager("test", paths)
-
-    assert profile.read_text(encoding="utf-8") == fixture_text
-    assert not (profile.parent / "old_configs").exists()
-
-
 def test_load_profile_rejects_unversioned_config_without_mutating(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Unversioned configs are handed to the archive-and-regenerate flow."""
+    """An unversioned config the migration chain cannot fully map (here: no
+    `[movie_rename]` section at all) is handed to the archive-and-regenerate
+    flow, with the original left untouched. ConfigManager never auto-archives.
+    """
     monkeypatch.setattr(
         "src.config.config.FindDependencies.update_dependencies",
         lambda self, dependencies: None,
@@ -674,29 +655,6 @@ def test_int_tracker_flag_is_coerced_and_persisted_as_bool(
     ConfigManager("test", paths)  # a fresh load of the healed file is clean
 
 
-def test_schema1_int_tracker_flags_are_rejected(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Breaking-schema profiles are rejected before legacy values are loaded."""
-    monkeypatch.setattr(
-        "src.config.config.FindDependencies.update_dependencies",
-        lambda self, dependencies: None,
-    )
-    paths = _paths(tmp_path)
-    profile = paths.user_configs / "test.toml"
-    profile.parent.mkdir(parents=True)
-    fixture_text = Path("tests/test_config/fixtures/schema1_config.toml").read_text(
-        encoding="utf-8"
-    )
-    assert "anonymous = 0" in fixture_text  # guard: the fixture is the int form
-    profile.write_text(fixture_text, encoding="utf-8")
-
-    with pytest.raises(ConfigSchemaError, match="Missing configuration schema_version"):
-        ConfigManager("test", paths)
-
-    assert profile.read_text(encoding="utf-8") == fixture_text
-
-
 def test_coerce_bool_flags_normalizes_int_flags() -> None:
     """`coerce_bool_flags` turns a persisted int 0/1 into a bool where the
     default declares a bool, and leaves genuine ints, enum-backed ints and
@@ -845,3 +803,135 @@ def test_default_season_folder_token_is_scene_style() -> None:
     # no episode tokens belong in a season-pack folder name
     assert "{episode_number" not in token
     assert "{episode_title_clean}" not in token
+
+
+def _write_fixture_profile(paths: ConfigPaths, fixture: str) -> tuple[Path, str]:
+    """Install a fixture config as the "test" profile. Returns the profile
+    path and the exact text written, so a test can assert the file was left
+    byte-for-byte untouched."""
+    profile = paths.user_configs / "test.toml"
+    profile.parent.mkdir(parents=True, exist_ok=True)
+    text = Path(f"tests/test_config/fixtures/{fixture}").read_text(encoding="utf-8")
+    profile.write_text(text, encoding="utf-8")
+    return profile, text
+
+
+def test_load_profile_migrates_schema1_in_place(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A schema-1 profile must be carried all the way to the current schema
+    version by the migration chain, not just to the next version up."""
+    monkeypatch.setattr(
+        "src.config.config.FindDependencies.update_dependencies",
+        lambda self, dependencies: None,
+    )
+    paths = _paths(tmp_path)
+    profile, _ = _write_fixture_profile(paths, "schema1_config.toml")
+
+    manager = ConfigManager("test", paths)  # should migrate, not raise
+
+    reloaded = tomlkit.parse(profile.read_text(encoding="utf-8"))
+    assert reloaded["schema_version"] == TomlConfigCodec.SCHEMA_VERSION
+    assert reloaded["movie_management"]["mvr_release_group"] == "CustomReleaseGroup"
+    assert "movie_rename" not in reloaded
+    # migrated in place; the archive/backup path must not have been taken
+    assert not (profile.parent / "old_configs").exists()
+    assert manager.settings.movie.release_group == "CustomReleaseGroup"
+    assert manager.settings.trackers.more_than_tv.username == "custom_mtv_user"
+
+
+def test_load_profile_migrates_schema2_to_current(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The reported regression: a schema-2 profile (every user who ran a
+    build between the two bumps) must migrate rather than being rejected as
+    unsupported and offered an archive+regenerate."""
+    monkeypatch.setattr(
+        "src.config.config.FindDependencies.update_dependencies",
+        lambda self, dependencies: None,
+    )
+    paths = _paths(tmp_path)
+    profile, _ = _write_fixture_profile(paths, "schema2_config.toml")
+
+    manager = ConfigManager("test", paths)  # should migrate, not raise
+
+    reloaded = tomlkit.parse(profile.read_text(encoding="utf-8"))
+    assert reloaded["schema_version"] == TomlConfigCodec.SCHEMA_VERSION
+    # user settings survive the hop
+    assert manager.settings.general.releasers_name == "SchemaTwoUser"
+    assert manager.settings.movie.release_group == "SchemaTwoGroup"
+    # the removed image host is dropped, taking its stale API key with it
+    image_hosts = cast(MutableMapping[str, Any], reloaded["image_hosts"])
+    assert "ptpimg" not in image_hosts
+    assert "dead-ptpimg-key" not in profile.read_text(encoding="utf-8")
+    assert not (profile.parent / "old_configs").exists()
+
+
+def test_migration_validation_failure_preserves_original(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A config that migrates structurally (no `unmapped` sections) but whose
+    resulting document fails validation must NOT be written to disk. The
+    manager must fall through to the same `ConfigSchemaError`
+    archive/regenerate path used when migration can't map sections at all,
+    leaving the original file byte-for-byte untouched.
+    """
+    monkeypatch.setattr(
+        "src.config.config.FindDependencies.update_dependencies",
+        lambda self, dependencies: None,
+    )
+    paths = _paths(tmp_path)
+    profile, fixture_text = _write_fixture_profile(paths, "schema1_config.toml")
+
+    # Force the post-migration validation step to fail, simulating a
+    # migrated document that maps structurally but doesn't actually
+    # validate (e.g. a bad type/value that survived the section mapping).
+    original_decode = ConfigManager.decode
+
+    def fake_decode(
+        self: object,
+        toml_data: object,
+        build_defaults: bool = False,
+        dry_run: bool = False,
+    ) -> None:
+        if dry_run:
+            raise ConfigError("forced migration validation failure")
+        return original_decode(self, toml_data, build_defaults=build_defaults)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(ConfigManager, "decode", fake_decode)
+
+    with pytest.raises(ConfigError, match="Missing configuration schema_version"):
+        ConfigManager("test", paths)
+
+    # the original schema-1 file must be left completely untouched -- no
+    # partial/invalid migrated document was ever persisted
+    assert profile.read_text(encoding="utf-8") == fixture_text
+    assert not (profile.parent / "old_configs").exists()
+
+
+def test_schema1_int_tracker_flags_load_as_bool(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Real release users are on schema 1, which stored the tracker flags as
+    the int `0`. Migrating -- to a schema whose default declares them `bool`
+    -- must coerce them so the migrated document validates, instead of
+    tripping `validate_types` and forcing an archive+regenerate on upgrade.
+    """
+    monkeypatch.setattr(
+        "src.config.config.FindDependencies.update_dependencies",
+        lambda self, dependencies: None,
+    )
+    paths = _paths(tmp_path)
+    profile, fixture_text = _write_fixture_profile(paths, "schema1_config.toml")
+    assert "anonymous = 0" in fixture_text  # guard: the fixture is the int form
+
+    manager = ConfigManager("test", paths)  # must migrate + load, not raise
+
+    assert manager.settings.trackers.more_than_tv.anonymous is False
+    saved = tomlkit.parse(profile.read_text(encoding="utf-8"))
+    assert saved["schema_version"] == TomlConfigCodec.SCHEMA_VERSION
+    saved_tracker = cast(MutableMapping[str, Any], saved["tracker"])
+    saved_mtv = cast(MutableMapping[str, Any], saved_tracker["more_than_tv"])
+    raw = saved_mtv["anonymous"]
+    raw = raw.unwrap() if hasattr(raw, "unwrap") else raw
+    assert type(raw) is bool

--- a/tests/test_config/test_migration_invariants.py
+++ b/tests/test_config/test_migration_invariants.py
@@ -1,0 +1,143 @@
+"""Invariants that must hold for the migration chain itself.
+
+These guard the failure mode where `TomlConfigCodec.SCHEMA_VERSION` is bumped
+without a corresponding migration being written -- which silently turns every
+existing user profile into an "unsupported schema" error at startup, with no
+recovery path other than archive+regenerate.
+"""
+
+import re
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+import pytest
+import tomlkit
+
+from src.config.codec import TomlConfigCodec
+from src.config.migrations import (
+    MIGRATIONS,
+    SCHEMA_1_VERSION,
+    check_migration_chain,
+    document_version,
+    migrate_document,
+)
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _noop(
+    old_doc: Mapping[str, Any],
+    default_document: Mapping[str, Any] | None = None,
+) -> tuple[dict[str, Any], list[str]]:
+    return dict(old_doc), []
+
+
+def _load_fixture(name: str) -> tomlkit.TOMLDocument:
+    return tomlkit.parse((FIXTURES / name).read_text(encoding="utf-8"))
+
+
+def test_registry_covers_every_version_below_current_schema() -> None:
+    """The registry must hold exactly one hop per version gap: a migration
+    keyed `n` takes a schema-`n` document to schema-`n+1`, so the keys must be
+    `SCHEMA_1_VERSION .. SCHEMA_VERSION - 1` with no gaps and nothing past the
+    current version."""
+    assert set(MIGRATIONS) == set(
+        range(SCHEMA_1_VERSION, TomlConfigCodec.SCHEMA_VERSION)
+    )
+
+
+def test_check_migration_chain_accepts_the_real_registry() -> None:
+    check_migration_chain(MIGRATIONS, TomlConfigCodec.SCHEMA_VERSION)
+
+
+def test_check_migration_chain_rejects_a_missing_terminal_hop() -> None:
+    """The exact regression: SCHEMA_VERSION bumped to 3, but the registry
+    still only knows how to reach 2."""
+    with pytest.raises(RuntimeError, match=r"no migration is registered.*\[2\]"):
+        check_migration_chain({1: _noop}, 3)
+
+
+def test_check_migration_chain_rejects_a_gap() -> None:
+    with pytest.raises(RuntimeError, match=r"no migration is registered.*\[2\]"):
+        check_migration_chain({1: _noop, 3: _noop}, 4)
+
+
+def test_check_migration_chain_rejects_a_hop_past_the_current_schema() -> None:
+    """A migration keyed at or above SCHEMA_VERSION would produce a document
+    newer than the app supports."""
+    with pytest.raises(RuntimeError, match="beyond"):
+        check_migration_chain({1: _noop, 2: _noop}, 2)
+
+
+def test_document_version_treats_a_missing_field_as_schema_1() -> None:
+    assert document_version({}) == SCHEMA_1_VERSION
+    assert document_version({"schema_version": 2}) == 2
+
+
+def test_migrate_document_chains_schema_1_to_the_current_version() -> None:
+    """Version-agnostic on purpose: this must keep passing after every future
+    bump, which is only possible if a migration was added alongside it."""
+    old = _load_fixture("schema1_config.toml")
+
+    new, unmapped = migrate_document(old)
+
+    assert new["schema_version"] == TomlConfigCodec.SCHEMA_VERSION
+    assert not unmapped
+
+
+def test_migrate_document_is_a_no_op_for_a_current_version_document() -> None:
+    current = {"schema_version": TomlConfigCodec.SCHEMA_VERSION, "general": {}}
+
+    new, unmapped = migrate_document(current)
+
+    assert new["schema_version"] == TomlConfigCodec.SCHEMA_VERSION
+    assert not unmapped
+
+
+def _version_fixtures() -> list[Path]:
+    return sorted(FIXTURES.glob("schema*_config.toml"))
+
+
+def _fixture_version(fixture: Path) -> int:
+    match = re.fullmatch(r"schema(\d+)_config", fixture.stem)
+    assert match, f"unexpected fixture name: {fixture.name}"
+    return int(match.group(1))
+
+
+def test_a_fixture_exists_for_every_migratable_schema_version() -> None:
+    """Each bump must land a fixture for the version being migrated away
+    from, otherwise the round-trip test below silently stops covering it and
+    the chain is only verified by its version numbers."""
+    present = {_fixture_version(fixture) for fixture in _version_fixtures()}
+    required = set(range(SCHEMA_1_VERSION, TomlConfigCodec.SCHEMA_VERSION))
+
+    assert required <= present, (
+        f"missing config fixture(s) for schema version(s) {sorted(required - present)}"
+    )
+
+
+@pytest.mark.parametrize(
+    "fixture", _version_fixtures(), ids=lambda fixture: fixture.stem
+)
+def test_every_version_fixture_migrates_to_the_current_schema(fixture: Path) -> None:
+    """A real config at each historical version must survive the full chain.
+
+    This is what keeps the chain honest: the registry can look complete by
+    its keys alone while a hop still mangles a document it is handed.
+    """
+    old = tomlkit.parse(fixture.read_text(encoding="utf-8"))
+
+    new, unmapped = migrate_document(old)
+
+    assert not unmapped
+    assert new["schema_version"] == TomlConfigCodec.SCHEMA_VERSION
+
+
+def test_packaged_default_declares_the_current_schema_version() -> None:
+    """`default_config.toml` and `codec.SCHEMA_VERSION` are edited by hand in
+    two separate files; nothing else ties them together."""
+    default_config = Path("runtime/config/defaults/default_config.toml")
+    document = tomlkit.parse(default_config.read_text(encoding="utf-8"))
+
+    assert document["schema_version"] == TomlConfigCodec.SCHEMA_VERSION


### PR DESCRIPTION
## Problem

`SCHEMA_VERSION` was raised from 2 to 3, but the only migration in the tree still produced schema 2, and the code that invoked it was removed at the same time. `src/config/migrations.py` was left with no callers.

The result is that every existing profile fails `validate_schema` at startup and is handed the archive-and-regenerate dialog, which discards the user's settings:

```
Unsupported configuration schema_version: 2. Expected schema_version: 3.
Please generate a new config file.
```

This hits schema 2 profiles directly, and schema 1 profiles too, since the unversioned migration path was removed alongside it.

The existing tests did not catch it because they asserted hardcoded literals rather than `SCHEMA_VERSION`: the migration test asserted `== 2` (still true, but for a function nothing called), and the schema-1 rejection test asserted `1` is unsupported (still true, since `1 < 3` as well as `1 < 2`). Two tests had also been rewritten to assert that schema-1 configs *should* be rejected, encoding the broken behavior.

## Fix

- **Migration chain.** `MIGRATIONS` maps each source version to the hop that takes it one version up; `migrate_document` walks from whatever version a profile declares to `SCHEMA_VERSION`. A profile several versions behind now goes through every intermediate shape instead of being rejected. This replaces the single-hop `if "schema_version" not in loaded_document` dispatch, which could only ever handle the unversioned case.
- **Import-time guard.** `check_migration_chain` runs at module import and refuses to load when a version has no migration, so an unaccompanied bump fails for the developer who made it rather than silently reaching users. It is an explicit `raise` rather than `assert`, so `-O` cannot strip it. Both operands are source constants, so it cannot begin failing in the field for a build that imports cleanly.
- **Call path and trial validation restored.** `_try_migrate_profile` proves a migrated document validates on an in-memory copy (`decode(..., dry_run=True)`) before anything touches disk. A migration that maps structurally but produces an invalid document leaves the original file byte-for-byte intact and falls through to the existing archive-and-regenerate flow.
- **2 to 3 migration.** Drops the removed `[image_hosts.ptpimg]` table, taking its stale API key with it.
- **Fixtures and tests.** Adds `schema2_config.toml` (generated from the packaged default of that era). One test requires a fixture per migratable version; another runs each fixture through the full chain. All assertions compare against `SCHEMA_VERSION` rather than literals.

## Bump policy

Documented in the migrations module docstring, since the bump that caused this was avoidable:

- Renames, moves, and retypes **need** a bump — nothing else can map the old layout.
- Additions **do not** — `merge_defaults` backfills them.
- Removals **do not** — `validate_types` only iterates keys the default declares, and image hosts decode by name, so a stale section sits unread.

Removing `ptpimg` fell in the last category, so schema 2 profiles would have loaded against the new default unchanged. The 2 to 3 hop exists here because the bump already shipped.

## Verification

- 431 tests pass (config suite: 43 to 57)
- `ruff check`, `ruff format --check`, and `mypy src/config` clean; the 4 pre-existing `mypy` findings in `start_ui.py` are unchanged from the committed baseline
- Reproduced the regression against the guard (raise `SCHEMA_VERSION` to 4 with no new migration): `import src.config.config` fails immediately and the test suite cannot collect
- Five real user profiles (one at schema 2, four unversioned) migrate to schema 3 with settings preserved, verified on copies with the originals confirmed unchanged
