### PR TITLE
fix: Make Rename Preview diff highlights legible in dark mode

### DIFF
--- a/src/frontend/custom_widgets/rename_preview_dialog.py
+++ b/src/frontend/custom_widgets/rename_preview_dialog.py
@@ -1,8 +1,10 @@
 from pathlib import Path
+from typing import cast
 
-from PySide6.QtCore import Qt
+from PySide6.QtCore import QEvent, Qt
 from PySide6.QtGui import QColor, QFont, QTextCharFormat, QTextCursor
 from PySide6.QtWidgets import (
+    QApplication,
     QDialog,
     QDialogButtonBox,
     QLabel,
@@ -16,6 +18,24 @@ from src.frontend.utils import set_top_parent_geometry
 
 class RenamePreviewDialog(QDialog):
     """Dialog to preview file/folder renames with diff-style visualization."""
+
+    THEMES = {
+        "dark": {
+            "removed_bg": "#5a2626",
+            "removed_fg": "#ffcdd2",
+            "added_bg": "#2a5233",
+            "added_fg": "#c8e6c9",
+        },
+        "light": {
+            "removed_bg": "#ffc8c8",
+            "removed_fg": "#6b1010",
+            "added_bg": "#c8ffc8",
+            "added_fg": "#0f5323",
+        },
+    }
+
+    # class level default so `event()` is safe if a palette change lands mid construction
+    _rename_map: dict[Path, Path] | None = None
 
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
@@ -61,6 +81,14 @@ class RenamePreviewDialog(QDialog):
         Args:
             rename_map: Dictionary mapping original paths to renamed paths
         """
+        self._rename_map = rename_map
+        self._render_renames()
+
+    def _render_renames(self) -> None:
+        """Render the stored rename map using colors for the active color scheme."""
+        rename_map = self._rename_map
+        self.text_viewer.clear()
+
         if not rename_map:
             self.text_viewer.setPlainText("No renames detected")
             self.button_box.button(QDialogButtonBox.StandardButton.Ok).setEnabled(False)
@@ -87,11 +115,17 @@ class RenamePreviewDialog(QDialog):
         bold_font.setBold(True)
         bold_format.setFont(bold_font)
 
+        # explicit foregrounds are required, the default text color is light in dark
+        # mode and would be unreadable against the highlight background
+        colors = self.get_theme_colors()
+
         removed_format = QTextCharFormat()
-        removed_format.setBackground(QColor(255, 200, 200))  # light red
+        removed_format.setBackground(QColor(colors["removed_bg"]))
+        removed_format.setForeground(QColor(colors["removed_fg"]))
 
         added_format = QTextCharFormat()
-        added_format.setBackground(QColor(200, 255, 200))  # light green
+        added_format.setBackground(QColor(colors["added_bg"]))
+        added_format.setForeground(QColor(colors["added_fg"]))
 
         normal_format = QTextCharFormat()
 
@@ -139,6 +173,19 @@ class RenamePreviewDialog(QDialog):
         # move cursor to start
         cursor.movePosition(QTextCursor.MoveOperation.Start)
         self.text_viewer.setTextCursor(cursor)
+
+    def event(self, e: QEvent) -> bool:
+        if e.type() == QEvent.Type.PaletteChange and self._rename_map is not None:
+            self._render_renames()
+        return super().event(e)
+
+    def get_theme_colors(self) -> dict[str, str]:
+        app = cast(QApplication | None, QApplication.instance())
+        if app:
+            color_scheme = app.styleHints().colorScheme()
+            scheme = "dark" if color_scheme == Qt.ColorScheme.Dark else "light"
+            return self.THEMES[scheme]
+        return self.THEMES["light"]
 
     def _get_diff_parts(
         self, old: str, new: str


### PR DESCRIPTION
Closes #248

## Problem

The diff highlights in the Rename Preview dialog set only a background colour:

```python
removed_format.setBackground(QColor(255, 200, 200))  # light red
added_format.setBackground(QColor(200, 255, 200))    # light green
```

With no foreground set, the highlighted filenames keep the editor's palette text
colour. In light mode that is near-black on pastel, which happens to work. In dark
mode it is near-white on the same pastel bands, so the changed portion of every
name, the part the preview exists to show, is the part you cannot read. The colours
were only ever valid for one of the two schemes.

## Fix

- `THEMES` dict holding a background **and** foreground per scheme. Light keeps the
  existing pastels with dark text; dark uses muted deep red/green bands with light text.
- `get_theme_colors()` reads `app.styleHints().colorScheme()`, so it tracks the
  Light, Dark and Automatic settings (Automatic calls `unsetColorScheme()`, so this
  follows the OS).
- Rendering moved into `_render_renames()` and re-run on `QEvent.Type.PaletteChange`,
  so the dialog stays correct if the scheme changes while it is open. That needed a
  `clear()` before rendering, which the original lacked; calling `set_renames` twice
  would previously have appended.

This follows the pattern already used by `CodeEditor` in `basic_code_editor.py`.

## Contrast

Sampled from rendered screenshots rather than from the constants, taking the most
common glyph pixel inside each highlight band against that band's background:

| Theme | Band | Text | Background | Ratio | WCAG |
|---|---|---|---|---|---|
| Light | removed | `#6b1010` | `#ffc8c8` | 8.41:1 | AAA |
| Light | added | `#0f5323` | `#c8ffc8` | 8.15:1 | AAA |
| Dark | removed | `#ffcdd2` | `#5a2626` | 8.57:1 | AAA |
| Dark | added | `#c8e6c9` | `#2a5233` | 6.64:1 | AA |

AA needs 4.5:1, AAA needs 7:1 for normal text.

Unchanged prefix and suffix runs and the `-`/`+` markers still use the default
palette colour, which reads fine on both grounds.

## Verification

`ruff check`, `ruff format --check`, `mypy` and `basedpyright` all clean on the
changed file; full suite 431 passed.
