### PR TITLE
fix: Screenshot comparison and image upload regressions

### DIFF
--- a/src/backend/process.py
+++ b/src/backend/process.py
@@ -877,6 +877,10 @@ class ProcessBackEnd:
                 if not img_from:
                     img_from = image_host_data.img_from
                 img_to = image_host_data.img_to
+                LOG.debug(
+                    LOG.LOG_SOURCE.BE,
+                    f"Image destination for {tracker_name}: {img_to!r} (from {image_host_data.img_from!r})",
+                )
 
                 # track the image host to be used for each tracker
                 if isinstance(img_to, ImageHost) and img_to is not ImageHost.DISABLED:
@@ -885,6 +889,14 @@ class ProcessBackEnd:
                     to_url = True
 
                 tracker_to_host_map[TrackerSelection(tracker_name)] = img_to
+            else:
+                # the tracker cannot be mapped to a destination at all, so it will
+                # reach the NFO stage with no images and no other explanation
+                LOG.warning(
+                    LOG.LOG_SOURCE.BE,
+                    f"No usable image host data for {tracker_name}, expected ImageUploadFromTo "
+                    f"and got {type(image_host_data).__name__}: {image_host_data!r}",
+                )
 
         # handle image host uploads
         if to_image_hosts or to_url:
@@ -913,6 +925,16 @@ class ProcessBackEnd:
                 )
             else:
                 files_to_upload = context.shared_data.loaded_images
+
+            if not files_to_upload:
+                LOG.warning(
+                    LOG.LOG_SOURCE.BE,
+                    f"No images available to upload to {len(to_image_hosts)} image host(s), "
+                    "every tracker will be processed without images",
+                )
+                queued_text_update(
+                    "<br />No images available to upload, continuing without images"
+                )
 
             if files_to_upload:
                 # optimize images if enabled
@@ -955,10 +977,21 @@ class ProcessBackEnd:
                 )
                 async_loop.close()
 
+                LOG.debug(
+                    LOG.LOG_SOURCE.BE,
+                    f"Upload results returned for image host(s): {sorted(str(h) for h in upload_results)}",
+                )
+
                 # map the uploaded image hosts to the appropriate trackers
                 for tracker, img_host in tracker_to_host_map.items():
                     if img_host in upload_results:
                         url_data[tracker] = upload_results[img_host]
+                    else:
+                        LOG.debug(
+                            LOG.LOG_SOURCE.BE,
+                            f"No uploaded images for {tracker}, its destination {img_host!r} "
+                            "was not part of this upload",
+                        )
 
         # using URLs as is
         if to_url:
@@ -974,6 +1007,24 @@ class ProcessBackEnd:
             queued_text_update(
                 f"<br />Using {len(context.shared_data.url_data)} URLs for {url_host_count} tracker(s)",
             )
+
+        # trackers missing here reach the NFO stage with no images, which is a
+        # supported outcome but an easy one to mistake for a failure, so say so
+        without_images = [
+            str(TrackerSelection(tracker_name))
+            for tracker_name in process_dict
+            if TrackerSelection(tracker_name) not in url_data
+        ]
+        if without_images:
+            LOG.info(
+                LOG.LOG_SOURCE.BE,
+                f"Tracker(s) with no images: {', '.join(without_images)}",
+            )
+        LOG.debug(
+            LOG.LOG_SOURCE.BE,
+            "Image handling resolved "
+            f"{ {str(tracker): len(imgs) for tracker, imgs in url_data.items()} }",
+        )
 
         return url_data
 

--- a/src/frontend/custom_widgets/combo_qtree.py
+++ b/src/frontend/custom_widgets/combo_qtree.py
@@ -17,6 +17,21 @@ from PySide6.QtWidgets import (
 from typing_extensions import override
 
 
+class _UserData:
+    """Holds combo box item data so Qt hands back the object that was stored.
+
+    PySide6 converts a sequence passed as ``userData`` into a plain list on the
+    way back out, so a NamedTuple such as ``ImageUploadFromTo`` returns as a
+    list and fails every ``isinstance`` check downstream. Qt passes an ordinary
+    Python object through untouched, so wrapping keeps the payload intact.
+    """
+
+    __slots__ = ("value",)
+
+    def __init__(self, value: Any) -> None:
+        self.value = value
+
+
 class ComboBoxTreeWidget(QTreeWidget):
     combo_changed = Signal(QComboBox, int)  # combobox widget, idx
 
@@ -127,7 +142,7 @@ class ComboBoxTreeWidget(QTreeWidget):
 
         option_set: set[str] = set()
         for txt, data in combo_items:
-            combo_box.addItem(txt, data)
+            combo_box.addItem(txt, _UserData(data))
             option_set.add(txt)
 
         self.combo_options.append(option_set)
@@ -147,6 +162,12 @@ class ComboBoxTreeWidget(QTreeWidget):
             if index != -1:
                 combo_box.setCurrentIndex(index)
 
+    @staticmethod
+    def _item_data(combo_box: QComboBox) -> Any:
+        """Unwrap the payload stored for the current item."""
+        data = combo_box.currentData()
+        return data.value if isinstance(data, _UserData) else data
+
     def get_item_values(self) -> list[tuple[str | tuple[str, Any], ...]]:
         values: list[tuple[str | tuple[str, Any], ...]] = []
         for idx in range(self.topLevelItemCount()):
@@ -159,7 +180,7 @@ class ComboBoxTreeWidget(QTreeWidget):
                 if (item, col_index) in self.combo_box_map:
                     combo_box = self.combo_box_map[(item, col_index)]
                     row_values.append(
-                        (combo_box.currentText(), combo_box.currentData())
+                        (combo_box.currentText(), self._item_data(combo_box))
                     )
                 else:
                     row_values.append(item.text(col_index))

--- a/src/frontend/wizards/images.py
+++ b/src/frontend/wizards/images.py
@@ -413,25 +413,27 @@ class ImagesPage(BaseWizardPage):
                 return
 
             if not self._compare_resolutions():
-                # if manual we will prompt the crop dialog widget
+                # a comparison script is the source of truth for cropping, so when
+                # it carries usable values apply them directly rather than asking
+                # the user to confirm crops they already described in the script
+                if crop_mode is not Cropping.DISABLED and comp_pair.script:
+                    parse_script = ScriptParser(
+                        comp_pair.script.read_text(encoding="utf-8")
+                    ).get_data()
+                    if not parse_script.all_zeros():
+                        self._execute_image_generation(script_values=parse_script)
+                        return
+
+                # without a script (or with one that has no crops in it) manual
+                # mode prompts the crop dialog widget
                 if crop_mode is Cropping.MANUAL:
                     dlg = CropWidgetDialog(self)
-                    # if we have the script pre-load it even if using manual
+                    # if we have the script pre-load it to work from
                     if comp_pair.script:
                         dlg.load_script(comp_pair.script)
                     script_values = dlg.exec_crop()
                     if script_values:
                         self._execute_image_generation(script_values=script_values)
-                        return
-                # if auto and there is a script already we can apply the values if they are valid
-                elif crop_mode is Cropping.AUTO and comp_pair.script:
-                    parse_script = ScriptParser(comp_pair.script.read_text()).get_data()
-                    if not parse_script.all_zeros():
-                        self._execute_image_generation(
-                            script_values=ScriptParser(
-                                comp_pair.script.read_text()
-                            ).get_data()
-                        )
                         return
 
         # if comparison logic was not needed just fall back to regular generation

--- a/src/frontend/wizards/rename_encode.py
+++ b/src/frontend/wizards/rename_encode.py
@@ -407,30 +407,11 @@ class RenameEncode(BaseWizardPage):
                     if not self._rename_mapping:
                         return False
 
-                    # update file_list with renamed paths
-                    for i, old_path in enumerate(self.context.media_input.file_list):
-                        if old_path in self._rename_mapping:
-                            self.context.media_input.file_list[i] = (
-                                self._rename_mapping[old_path]
-                            )
-
-                    # update file_list_mediainfo keys (MediaInfo objects stay same, just new keys)
-                    if self.context.media_input.file_list_mediainfo:
-                        new_mediainfo = {}
-                        for (
-                            old_path,
-                            mi_obj,
-                        ) in self.context.media_input.file_list_mediainfo.items():
-                            new_path = self._rename_mapping.get(old_path, old_path)
-                            new_mediainfo[new_path] = mi_obj
-                        self.context.media_input.file_list_mediainfo = new_mediainfo
-
-                    # update input_path if it changed
-                    if self._updated_input_path:
-                        self.context.media_input.input_path = self._updated_input_path
-
-                    # clear the rename map (renames are complete)
-                    self.context.media_input.file_list_rename_map.clear()
+                    # re-point file_list, file_list_mediainfo, the comparison
+                    # pair and input_path at the renamed files
+                    self.context.media_input.apply_rename_mapping(
+                        self._rename_mapping, self._updated_input_path
+                    )
 
                 except Exception as e:
                     QMessageBox.critical(

--- a/src/frontend/wizards/rename_encode_series.py
+++ b/src/frontend/wizards/rename_encode_series.py
@@ -485,41 +485,11 @@ class RenameEncodeSeries(BaseWizardPage):
                 if not self._rename_mapping:
                     return False
 
-                # Update file_list with renamed paths
-                for i, old_path in enumerate(self.context.media_input.file_list):
-                    if old_path in self._rename_mapping:
-                        self.context.media_input.file_list[i] = self._rename_mapping[
-                            old_path
-                        ]
-
-                # Update file_list_mediainfo keys
-                if self.context.media_input.file_list_mediainfo:
-                    new_mediainfo = {}
-                    for (
-                        old_path,
-                        mi_obj,
-                    ) in self.context.media_input.file_list_mediainfo.items():
-                        new_path = self._rename_mapping.get(old_path, old_path)
-                        new_mediainfo[new_path] = mi_obj
-                    self.context.media_input.file_list_mediainfo = new_mediainfo
-
-                # Update series_episode_map keys if it exists
-                if self.context.media_input.series_episode_map:
-                    new_episode_map = {}
-                    for (
-                        old_path,
-                        ep_data,
-                    ) in self.context.media_input.series_episode_map.items():
-                        new_path = self._rename_mapping.get(old_path, old_path)
-                        new_episode_map[new_path] = ep_data
-                    self.context.media_input.series_episode_map = new_episode_map
-
-                # Update input_path if it changed
-                if self._updated_input_path:
-                    self.context.media_input.input_path = self._updated_input_path
-
-                # Clear the rename map
-                self.context.media_input.file_list_rename_map.clear()
+                # Re-point file_list, file_list_mediainfo, series_episode_map,
+                # the comparison pair and input_path at the renamed files
+                self.context.media_input.apply_rename_mapping(
+                    self._rename_mapping, self._updated_input_path
+                )
 
             except Exception as e:
                 QMessageBox.critical(

--- a/src/payloads/media_inputs.py
+++ b/src/payloads/media_inputs.py
@@ -77,6 +77,59 @@ class MediaInputPayload:
             raise RuntimeError(f"Failed to get MediaInfo object for '{fp}'")
         return mi
 
+    def apply_rename_mapping(
+        self,
+        rename_mapping: dict[Path, Path],
+        updated_input_path: Path | None = None,
+    ) -> None:
+        """Re-point every path this payload holds at its renamed location.
+
+        Called after the renames have been executed on disk. Every field keyed
+        by (or holding) an input path has to move together, otherwise later
+        pages look up a path that no longer exists, e.g. the screenshots page
+        resolving `comparison_pair.media` against `file_list_mediainfo`.
+
+        Args:
+            rename_mapping: Map of old path -> new path for renamed files.
+            updated_input_path: New input path, when the rename moved it.
+        """
+        if not rename_mapping:
+            return
+
+        for i, old_path in enumerate(self.file_list):
+            if old_path in rename_mapping:
+                self.file_list[i] = rename_mapping[old_path]
+
+        if self.file_list_mediainfo:
+            self.file_list_mediainfo = {
+                rename_mapping.get(old_path, old_path): mi_obj
+                for old_path, mi_obj in self.file_list_mediainfo.items()
+            }
+
+        if self.series_episode_map:
+            self.series_episode_map = {
+                rename_mapping.get(old_path, old_path): ep_data
+                for old_path, ep_data in self.series_episode_map.items()
+            }
+
+        # the comparison media is one of the renamed files; the source usually
+        # sits outside the rename set but still moves when its folder is renamed
+        if self.comparison_pair:
+            self.comparison_pair = self.comparison_pair._replace(
+                source=rename_mapping.get(
+                    self.comparison_pair.source, self.comparison_pair.source
+                ),
+                media=rename_mapping.get(
+                    self.comparison_pair.media, self.comparison_pair.media
+                ),
+            )
+
+        if updated_input_path:
+            self.input_path = updated_input_path
+
+        # renames are complete
+        self.file_list_rename_map.clear()
+
     def reset(self, input_path: Path | None = None) -> None:
         """Reset all fields to initial state."""
         self.input_path = input_path

--- a/tests/test_frontend/test_combo_qtree.py
+++ b/tests/test_frontend/test_combo_qtree.py
@@ -1,0 +1,63 @@
+from src.enums.image_host import ImageHost, ImageSource
+from src.frontend.custom_widgets.combo_qtree import ComboBoxTreeWidget
+from src.packages.custom_types import ImageUploadFromTo
+
+
+def _tree_with_payload(payload: object) -> ComboBoxTreeWidget:
+    tree = ComboBoxTreeWidget(headers=("Tracker", "", "Status"))
+    tree.add_row(
+        headers=("MoreThanTV", "", "Queued"),
+        combo_data=[(1, [("IMGs ➔ Chevereto v4", payload)])],
+    )
+    return tree
+
+
+def test_get_item_values_preserves_named_tuple_payload() -> None:
+    """Regression guard: PySide6 6.10 converts a tuple stored as combo userData
+    into a plain list, which stripped ImageUploadFromTo down to a list and made
+    the isinstance check in handle_images_for_trackers fail, so every tracker
+    was processed with no images."""
+    upload_from_to = ImageUploadFromTo(ImageSource.IMAGES, ImageHost.CHEVERETO_V4)
+    tree = _tree_with_payload(
+        (upload_from_to, (ImageHost.CHEVERETO_V4, ImageHost.CHEVERETO_V4))
+    )
+
+    ((_tracker, (_text, data), _status),) = tree.get_item_values()
+
+    assert isinstance(data, tuple)
+    assert isinstance(data[0], ImageUploadFromTo)
+    assert data[0].img_from is ImageSource.IMAGES
+    assert data[0].img_to is ImageHost.CHEVERETO_V4
+
+
+def test_get_item_values_returns_the_same_object() -> None:
+    payload = ImageUploadFromTo(ImageSource.URLS, ImageHost.IMAGE_BB)
+    tree = _tree_with_payload(payload)
+
+    ((_tracker, (_text, data), _status),) = tree.get_item_values()
+
+    assert data is payload
+
+
+def test_get_item_values_preserves_scalar_payload() -> None:
+    tree = _tree_with_payload(ImageHost.DISABLED)
+
+    ((_tracker, (text, data), _status),) = tree.get_item_values()
+
+    assert text == "IMGs ➔ Chevereto v4"
+    assert data is ImageHost.DISABLED
+
+
+def test_get_item_values_preserves_none_payload() -> None:
+    tree = _tree_with_payload(None)
+
+    ((_tracker, (_text, data), _status),) = tree.get_item_values()
+
+    assert data is None
+
+
+def test_get_item_values_reads_plain_columns() -> None:
+    tree = ComboBoxTreeWidget(headers=("Tracker", "Status"))
+    tree.add_row(headers=("MoreThanTV", "Queued"))
+
+    assert tree.get_item_values() == [("MoreThanTV", "Queued")]

--- a/tests/test_frontend/test_images_page.py
+++ b/tests/test_frontend/test_images_page.py
@@ -1,0 +1,253 @@
+from pathlib import Path
+
+import pytest
+
+from src.config.config import ConfigManager
+from src.config.paths import ConfigPaths
+from src.context.processing_context import ProcessingContext
+from src.enums.cropping import Cropping
+from src.enums.media_type import MediaType
+from src.enums.screen_shot_mode import ScreenShotMode
+from src.frontend.wizards.images import ImagesPage
+from src.packages.custom_types import ComparisonPair
+from src.payloads.media_inputs import MediaInputPayload
+from src.payloads.media_search import MediaSearchPayload
+from src.payloads.script import ScriptValues
+
+VPY_WITH_CROP = (
+    "clip = core.lsmas.LWLibavSource(source)\n"
+    "clip = core.std.Crop(clip, left=0, right=0, top=138, bottom=138)\n"
+)
+VPY_WITHOUT_CROP = "clip = core.lsmas.LWLibavSource(source)\n"
+
+
+def _paths(tmp_path: Path) -> ConfigPaths:
+    defaults = tmp_path / "defaults"
+    defaults.mkdir()
+    source_defaults = Path("runtime/config/defaults")
+    default_config = defaults / "default_config.toml"
+    default_program = defaults / "default_program_conf.toml"
+    default_config.write_text(
+        (source_defaults / "default_config.toml").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    default_program.write_text(
+        (source_defaults / "default_program_conf.toml").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    return ConfigPaths(
+        default_config=default_config,
+        default_program=default_program,
+        program=tmp_path / "program/conf.toml",
+        user_configs=tmp_path / "user",
+        tracker_cookies=tmp_path / "cookies",
+    )
+
+
+class _DialogSpy:
+    """Stands in for CropWidgetDialog so tests can assert on prompting."""
+
+    instances: list["_DialogSpy"] = []
+    result: ScriptValues | None = None
+
+    def __init__(self, parent: object = None) -> None:
+        self.loaded_script: Path | None = None
+        _DialogSpy.instances.append(self)
+
+    def load_script(self, script_path: Path) -> None:
+        self.loaded_script = script_path
+
+    def exec_crop(self) -> ScriptValues | None:
+        return _DialogSpy.result
+
+
+def _make_images_page(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    crop_mode: Cropping,
+    ss_mode: ScreenShotMode = ScreenShotMode.ADV_SS_COMP,
+    script: Path | None = None,
+    comparison: bool = True,
+) -> tuple[ImagesPage, list[ScriptValues | None]]:
+    monkeypatch.setattr(
+        "src.config.config.FindDependencies.update_dependencies",
+        lambda self, dependencies: None,
+    )
+
+    manager = ConfigManager("test", _paths(tmp_path))
+    manager.settings.screenshots.mode = ss_mode
+    manager.settings.screenshots.crop_mode = crop_mode
+
+    encode = tmp_path / "Movie.2020.1080p.BluRay.x264-GRP.mkv"
+    source = tmp_path / "Movie.2020.1080p.remux.mkv"
+
+    media_input = MediaInputPayload(
+        input_path=encode,
+        media_type=MediaType.MOVIE,
+        file_list=[encode],
+        comparison_pair=(
+            ComparisonPair(source=source, media=encode, script=script)
+            if comparison
+            else None
+        ),
+    )
+    context = ProcessingContext(
+        media_input=media_input,
+        media_search=MediaSearchPayload(media_type=MediaType.MOVIE, title="Movie"),
+    )
+
+    page = ImagesPage(config=manager, context=context, parent=None)  # type: ignore[arg-type]
+
+    # the source and encode differ in resolution, which is what puts the crop
+    # logic in play at all
+    monkeypatch.setattr(ImagesPage, "_compare_resolutions", lambda self: False)
+
+    generated: list[ScriptValues | None] = []
+    monkeypatch.setattr(
+        ImagesPage,
+        "_execute_image_generation",
+        lambda self, script_values=None, re_sync=0: generated.append(script_values),
+    )
+
+    _DialogSpy.instances = []
+    _DialogSpy.result = None
+    monkeypatch.setattr("src.frontend.wizards.images.CropWidgetDialog", _DialogSpy)
+
+    return page, generated
+
+
+def test_manual_crop_with_script_applies_values_without_prompting(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Regression guard: with a comparison script supplying crop values, manual
+    crop mode opened the crop dialog pre-filled with the script instead of
+    applying it, so a flow that used to need one click on Generate now needed
+    the user to confirm the dialog too."""
+    script = tmp_path / "compare.vpy"
+    script.write_text(VPY_WITH_CROP, encoding="utf-8")
+    page, generated = _make_images_page(
+        tmp_path, monkeypatch, Cropping.MANUAL, script=script
+    )
+
+    page._generate_images()
+
+    assert not _DialogSpy.instances, "crop dialog must not be shown"
+    assert len(generated) == 1
+    script_values = generated[0]
+    assert script_values
+    assert script_values.crop_values
+    assert script_values.crop_values.top == 138
+    assert script_values.crop_values.bottom == 138
+
+
+def test_auto_crop_with_script_still_applies_values(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    script = tmp_path / "compare.vpy"
+    script.write_text(VPY_WITH_CROP, encoding="utf-8")
+    page, generated = _make_images_page(
+        tmp_path, monkeypatch, Cropping.AUTO, script=script
+    )
+
+    page._generate_images()
+
+    assert not _DialogSpy.instances
+    assert len(generated) == 1
+    assert generated[0]
+    assert generated[0].crop_values
+
+
+def test_manual_crop_without_script_prompts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    page, generated = _make_images_page(
+        tmp_path, monkeypatch, Cropping.MANUAL, script=None
+    )
+    _DialogSpy.result = ScriptValues()
+
+    page._generate_images()
+
+    assert len(_DialogSpy.instances) == 1
+    assert _DialogSpy.instances[0].loaded_script is None
+    assert generated == [ScriptValues()]
+
+
+def test_manual_crop_with_script_lacking_crop_values_prompts_prefilled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A script carrying no crop values can't drive the crop, so manual mode
+    still prompts, with the script pre-loaded for the user to work from."""
+    script = tmp_path / "compare.vpy"
+    script.write_text(VPY_WITHOUT_CROP, encoding="utf-8")
+    page, generated = _make_images_page(
+        tmp_path, monkeypatch, Cropping.MANUAL, script=script
+    )
+    _DialogSpy.result = ScriptValues()
+
+    page._generate_images()
+
+    assert len(_DialogSpy.instances) == 1
+    assert _DialogSpy.instances[0].loaded_script == script
+    assert generated == [ScriptValues()]
+
+
+def test_manual_crop_cancelled_dialog_falls_back_to_plain_generation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    page, generated = _make_images_page(
+        tmp_path, monkeypatch, Cropping.MANUAL, script=None
+    )
+    _DialogSpy.result = None
+
+    page._generate_images()
+
+    assert len(_DialogSpy.instances) == 1
+    assert generated == [None]
+
+
+def test_disabled_crop_ignores_script(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Crop disabled means disabled, even when a script carries crop values."""
+    script = tmp_path / "compare.vpy"
+    script.write_text(VPY_WITH_CROP, encoding="utf-8")
+    page, generated = _make_images_page(
+        tmp_path, monkeypatch, Cropping.DISABLED, script=script
+    )
+
+    page._generate_images()
+
+    assert not _DialogSpy.instances
+    assert generated == [None]
+
+
+def test_basic_mode_skips_crop_logic_entirely(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    script = tmp_path / "compare.vpy"
+    script.write_text(VPY_WITH_CROP, encoding="utf-8")
+    page, generated = _make_images_page(
+        tmp_path,
+        monkeypatch,
+        Cropping.MANUAL,
+        ss_mode=ScreenShotMode.BASIC_SS_GEN,
+        script=script,
+    )
+
+    page._generate_images()
+
+    assert not _DialogSpy.instances
+    assert generated == [None]
+
+
+def test_no_comparison_pair_skips_crop_logic(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    page, generated = _make_images_page(
+        tmp_path, monkeypatch, Cropping.MANUAL, comparison=False
+    )
+
+    page._generate_images()
+
+    assert not _DialogSpy.instances
+    assert generated == [None]

--- a/tests/test_payloads/test_media_inputs.py
+++ b/tests/test_payloads/test_media_inputs.py
@@ -1,0 +1,141 @@
+from pathlib import Path
+
+from src.enums.media_type import MediaType
+from src.packages.custom_types import ComparisonPair
+from src.payloads.media_inputs import MediaInputPayload
+
+SOURCE = Path("C:/enc/Movie.2016.remux.mkv")
+OLD = Path("C:/enc/Movie.2016.BluRay.1080p-old.mkv")
+NEW = Path("C:/enc/Movie.2016.1080p.BluRay.x264-GRP.mkv")
+
+
+def _movie_payload() -> MediaInputPayload:
+    return MediaInputPayload(
+        input_path=OLD,
+        media_type=MediaType.MOVIE,
+        file_list=[OLD],
+        file_list_mediainfo={OLD: "mi-encode", SOURCE: "mi-source"},  # type: ignore[dict-item]
+        file_list_rename_map={OLD: NEW},
+        comparison_pair=ComparisonPair(source=SOURCE, media=OLD, script=None),
+    )
+
+
+def test_apply_rename_mapping_updates_file_list_and_mediainfo() -> None:
+    payload = _movie_payload()
+
+    payload.apply_rename_mapping({OLD: NEW})
+
+    assert payload.file_list == [NEW]
+    assert payload.file_list_mediainfo == {NEW: "mi-encode", SOURCE: "mi-source"}
+    assert payload.file_list_rename_map == {}
+
+
+def test_apply_rename_mapping_repoints_comparison_pair_media() -> None:
+    """Regression guard: the comparison pair kept the pre-rename media path
+    while `file_list_mediainfo` was rekeyed to the renamed path, so the
+    screenshots page raised `KeyError` on `mi_list[comp_pair.media]`."""
+    payload = _movie_payload()
+
+    payload.apply_rename_mapping({OLD: NEW})
+
+    comp_pair = payload.comparison_pair
+    assert comp_pair
+    assert comp_pair.media == NEW
+    # the comparison source is not renamed, so it stays put
+    assert comp_pair.source == SOURCE
+    # both halves of the pair must resolve against the rekeyed MediaInfo dict
+    assert payload.file_list_mediainfo[comp_pair.media]
+    assert payload.file_list_mediainfo[comp_pair.source]
+
+
+def test_apply_rename_mapping_preserves_comparison_script() -> None:
+    script = Path("C:/enc/compare.vpy")
+    payload = _movie_payload()
+    payload.comparison_pair = ComparisonPair(source=SOURCE, media=OLD, script=script)
+
+    payload.apply_rename_mapping({OLD: NEW})
+
+    assert payload.comparison_pair
+    assert payload.comparison_pair.script == script
+
+
+def test_apply_rename_mapping_remaps_comparison_source_when_it_was_renamed() -> None:
+    """A comparison source living inside a renamed folder gets a new path too."""
+    new_source = Path("C:/enc/renamed/Movie.2016.remux.mkv")
+    payload = _movie_payload()
+
+    payload.apply_rename_mapping({OLD: NEW, SOURCE: new_source})
+
+    assert payload.comparison_pair
+    assert payload.comparison_pair.source == new_source
+
+
+def test_apply_rename_mapping_without_comparison_pair() -> None:
+    payload = _movie_payload()
+    payload.comparison_pair = None
+
+    payload.apply_rename_mapping({OLD: NEW})
+
+    assert payload.comparison_pair is None
+    assert payload.file_list == [NEW]
+
+
+def test_apply_rename_mapping_updates_series_episode_map_and_pair() -> None:
+    old_one = Path("C:/enc/Show.S01E01-old.mkv")
+    old_two = Path("C:/enc/Show.S01E02-old.mkv")
+    new_one = Path("C:/enc/Show.S01E01.1080p.BluRay.x264-GRP.mkv")
+    new_two = Path("C:/enc/Show.S01E02.1080p.BluRay.x264-GRP.mkv")
+    source = Path("C:/enc/Show.S01E01.remux.mkv")
+
+    payload = MediaInputPayload(
+        input_path=Path("C:/enc"),
+        media_type=MediaType.SERIES,
+        file_list=[old_one, old_two],
+        file_list_mediainfo={old_one: "mi-1", old_two: "mi-2", source: "mi-source"},  # type: ignore[dict-item]
+        file_list_rename_map={old_one: new_one, old_two: new_two},
+        comparison_pair=ComparisonPair(source=source, media=old_one, script=None),
+        series_episode_map={
+            old_one: {"season": 1, "episode": 1},
+            old_two: {"season": 1, "episode": 2},
+        },
+    )
+
+    payload.apply_rename_mapping({old_one: new_one, old_two: new_two})
+
+    assert payload.file_list == [new_one, new_two]
+    assert payload.series_episode_map == {
+        new_one: {"season": 1, "episode": 1},
+        new_two: {"season": 1, "episode": 2},
+    }
+    assert payload.comparison_pair
+    assert payload.comparison_pair.media == new_one
+    assert payload.file_list_mediainfo[payload.comparison_pair.media]
+
+
+def test_apply_rename_mapping_updates_input_path_when_provided() -> None:
+    payload = _movie_payload()
+    new_input = Path("C:/enc/renamed")
+
+    payload.apply_rename_mapping({OLD: NEW}, updated_input_path=new_input)
+
+    assert payload.input_path == new_input
+
+
+def test_apply_rename_mapping_keeps_input_path_when_not_provided() -> None:
+    payload = _movie_payload()
+
+    payload.apply_rename_mapping({OLD: NEW})
+
+    assert payload.input_path == OLD
+
+
+def test_apply_rename_mapping_leaves_unrenamed_entries_alone() -> None:
+    untouched = Path("C:/enc/Extra.mkv")
+    payload = _movie_payload()
+    payload.file_list.append(untouched)
+    payload.file_list_mediainfo[untouched] = "mi-extra"  # type: ignore[assignment]
+
+    payload.apply_rename_mapping({OLD: NEW})
+
+    assert payload.file_list == [NEW, untouched]
+    assert payload.file_list_mediainfo[untouched] == "mi-extra"


### PR DESCRIPTION
Four fixes to the comparison screenshot and image upload flow, each with regression tests.

## Comparison pair not re-pointed after a rename

The rename wizards updated `file_list`, `file_list_mediainfo`, the series episode map and `input_path` once renames landed on disk, but left `comparison_pair` holding the pre-rename paths. The screenshots page resolves `comparison_pair.media` against the rekeyed `file_list_mediainfo`, so any comparison release raised `KeyError` on the old filename as soon as image generation started. Movies and series were both affected, since comparison mode is not gated by media type.

Both wizards carried their own copy of the payload update block, which is how the two drifted apart: the series copy remembered `series_episode_map`, neither remembered `comparison_pair`. Moved into `MediaInputPayload.apply_rename_mapping()` so every path-keyed field moves together.

## Crop dialog prompting despite a comparison script

Manual crop mode always opened the crop dialog and used the comparison script only to pre-fill the editor, so a script that already described its crops still needed the user to confirm a dialog before images were generated. The script-driven path was reachable only under automatic crop mode.

The script is now consulted first for both crop modes, falling back to the dialog when there is no script or nothing to crop in it. Crop disabled keeps ignoring scripts entirely. This also drops a double parse on the automatic path.

## Combo box payload types lost through Qt

PySide6 6.10 converts a sequence passed as combo box `userData` into a plain list on the way back out, so the `ImageUploadFromTo` NamedTuple stored against each tracker returned as a list. The enum members survived but the type did not, which made the `isinstance` check in `handle_images_for_trackers` fail for every tracker: none were mapped to an image host, no upload ran, and each reached the token replacer with no images. The 6.8 to 6.10 bump is what exposed it.

Item data is now wrapped in a holder object, which Qt passes through untouched, and unwrapped on read so callers get back the object that was stored.

## Image handling was silent

`handle_images_for_trackers` could map no trackers at all, skip the upload block entirely and return an empty dict without emitting a single line, so the failure above only surfaced much later as a tracker reaching the NFO stage with no images. It now logs the resolved destination per tracker, warns when a tracker carries no usable image host data or when there is nothing to upload, records which hosts the upload returned, and summarises which trackers finished with no images.

## Testing

453 tests pass. `ruff check`, `ruff format --check` and `mypy` are clean.
