### PR TITLE
feat: Highlight template tokens that will not resolve at render time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 - ImageViewer widget now has a draggable splitter, this way the user can resize/collapse the log/image portion of the widget.
 - Series support during flow to handle mapping/renaming
 - Now checks tracker health before attempting to upload
+- Template editor now highlights tokens that will not resolve when the template renders. The highlight color is configurable in Settings > Templates, and the save status tip reports how many were found.
 
 ### Changed
 

--- a/runtime/config/defaults/default_config.toml
+++ b/runtime/config/defaults/default_config.toml
@@ -560,6 +560,7 @@ pre_upload = ""
 block_syntax_color = "#A4036F"
 variable_syntax_color = "#048BA8"
 comment_syntax_color = "#16DB93"
+warning_syntax_color = "#E1401D"
 trim_blocks = 1
 lstrip_blocks = 1
 newline_sequence = "\n"

--- a/src/backend/utils/token_validation.py
+++ b/src/backend/utils/token_validation.py
@@ -1,0 +1,93 @@
+"""Detect template variables that will not resolve when the template renders.
+
+Jinja renders an unknown name as an empty string for plain substitution, so a
+template written against a renamed or removed token keeps rendering with the
+field silently blank. This module finds those names so the editor can mark
+them.
+
+Deliberately free of Qt, config, and media imports so it unit tests without a
+QApplication or a loaded profile.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+
+from jinja2 import Environment, meta, nodes
+from jinja2.exceptions import TemplateSyntaxError
+
+from src.backend.tokens import Tokens
+
+# Supplied per run rather than declared in `Tokens`: user tokens are always
+# `usr_` prefixed (see `TokenReplacer._parse_user_input`) and sandbox prompt
+# tokens are always `prompt_` prefixed, so a name carrying either prefix is
+# never reported as unknown.
+_RUNTIME_TOKEN_PREFIXES = ("usr_", "prompt_")
+
+
+def _bound_names(ast: nodes.Template) -> set[str]:
+    """Names the template binds itself via `{% set %}` or `{% for %}`.
+
+    `Node.find_all` yields descendants but not the node it is called on, and a
+    simple `{% set x = ... %}` target *is* a `nodes.Name`. Walking the target
+    alone therefore misses every simple assignment, so the target is
+    type-checked directly as well as walked (the walk covers tuple targets
+    such as `{% for a, b in pairs %}`).
+    """
+    bound: set[str] = set()
+    for assignment in ast.find_all((nodes.Assign, nodes.AssignBlock, nodes.For)):
+        target = assignment.target
+        if isinstance(target, nodes.Name):
+            bound.add(target.name)
+        bound.update(name.name for name in target.find_all(nodes.Name))
+    return bound
+
+
+def find_unknown_tokens(
+    template_text: str,
+    environment: Environment,
+    user_tokens: Iterable[str] | None = None,
+) -> set[str]:
+    """Names referenced by `template_text` that will not resolve at render time.
+
+    A name is known if it is a built-in token, a global registered on
+    `environment` (plugin jinja2 functions and the `nf_*` payloads), a name the
+    template binds itself, or a supplied/prefixed user token.
+
+    Returns an empty set when the template does not parse. An unparseable
+    template is already reported by the editor's syntax-error dialog, and this
+    must not compete with it.
+    """
+    try:
+        ast = environment.parse(template_text)
+    except TemplateSyntaxError:
+        return set()
+
+    known = (
+        Tokens.get_tokens()
+        | set(environment.globals)
+        | _bound_names(ast)
+        | set(user_tokens or ())
+    )
+    return {
+        name
+        for name in meta.find_undeclared_variables(ast)
+        if name not in known and not name.startswith(_RUNTIME_TOKEN_PREFIXES)
+    }
+
+
+def build_unknown_token_pattern(names: Iterable[str]) -> re.Pattern[str] | None:
+    """A regex matching each name in `names`, or None when there is nothing to match.
+
+    Matches the bare name rather than the surrounding delimiters, so a name is
+    marked wherever it appears, including inside `{% ... %}` blocks as well as
+    `{{ ... }}`. The word boundaries stop a short name matching inside a longer
+    one. A name appearing in the template's literal prose would also be marked;
+    that is rare, and marking it is harmless.
+    """
+    unique = sorted({name for name in names if name})
+    if not unique:
+        return None
+    alternation = "|".join(re.escape(name) for name in unique)
+    return re.compile(r"\b(?:" + alternation + r")\b")

--- a/src/backend/utils/token_validation.py
+++ b/src/backend/utils/token_validation.py
@@ -26,21 +26,37 @@ from src.backend.tokens import Tokens
 _RUNTIME_TOKEN_PREFIXES = ("usr_", "prompt_")
 
 
-def _bound_names(ast: nodes.Template) -> set[str]:
-    """Names the template binds itself via `{% set %}` or `{% for %}`.
+# `{% for %}`, `{% macro %}`, and `{% call %}` each open a scope: a name bound
+# inside one does not exist after the block ends. Bindings inside them are
+# therefore NOT collected as known -- such a name really does render blank
+# afterwards, which is exactly what this module exists to report.
+_SCOPE_OPENING_NODES = (nodes.For, nodes.Macro, nodes.CallBlock)
 
-    `Node.find_all` yields descendants but not the node it is called on, and a
-    simple `{% set x = ... %}` target *is* a `nodes.Name`. Walking the target
-    alone therefore misses every simple assignment, so the target is
-    type-checked directly as well as walked (the walk covers tuple targets
-    such as `{% for a, b in pairs %}`).
+
+def _bound_names(node: nodes.Node) -> set[str]:
+    """Names the template binds at a scope that outlives the binding.
+
+    `meta.find_undeclared_variables` is already scope-aware and omits most
+    `{% set %}` bindings by itself. It does still report one bound inside an
+    `{% if %}`, even though Jinja lets that binding leak out of the block, so
+    those are collected here to keep a working template from being flagged.
+
+    Recurses rather than using `find_all` so the walk can stop at a scope
+    boundary. `Node.find_all` yields descendants but not the node it is called
+    on, and a simple `{% set x = ... %}` target *is* a `nodes.Name`, so each
+    target is type-checked directly as well as walked (the walk covers tuple
+    targets such as `{% set a, b = 1, 2 %}`).
     """
     bound: set[str] = set()
-    for assignment in ast.find_all((nodes.Assign, nodes.AssignBlock, nodes.For)):
-        target = assignment.target
-        if isinstance(target, nodes.Name):
-            bound.add(target.name)
-        bound.update(name.name for name in target.find_all(nodes.Name))
+    for child in node.iter_child_nodes():
+        if isinstance(child, _SCOPE_OPENING_NODES):
+            continue
+        if isinstance(child, nodes.Assign | nodes.AssignBlock):
+            target = child.target
+            if isinstance(target, nodes.Name):
+                bound.add(target.name)
+            bound.update(name.name for name in target.find_all(nodes.Name))
+        bound |= _bound_names(child)
     return bound
 
 

--- a/src/backend/utils/token_validation.py
+++ b/src/backend/utils/token_validation.py
@@ -26,19 +26,29 @@ from src.backend.tokens import Tokens
 _RUNTIME_TOKEN_PREFIXES = ("usr_", "prompt_")
 
 
-# `{% for %}`, `{% macro %}`, and `{% call %}` each open a scope: a name bound
-# inside one does not exist after the block ends. Bindings inside them are
-# therefore NOT collected as known -- such a name really does render blank
-# afterwards, which is exactly what this module exists to report.
-_SCOPE_OPENING_NODES = (nodes.For, nodes.Macro, nodes.CallBlock)
+# `{% for %}`, `{% macro %}`, `{% call %}`, `{% with %}`, `{% filter %}`, and
+# `{% block %}` each open a scope: a name bound inside one does not exist
+# after the block ends. Bindings inside them are therefore NOT collected as
+# known -- such a name really does render blank afterwards, which is exactly
+# what this module exists to report.
+_SCOPE_OPENING_NODES = (
+    nodes.For,
+    nodes.Macro,
+    nodes.CallBlock,
+    nodes.With,
+    nodes.FilterBlock,
+    nodes.Block,
+)
 
 
 def _bound_names(node: nodes.Node) -> set[str]:
     """Names the template binds at a scope that outlives the binding.
 
     `meta.find_undeclared_variables` is already scope-aware and omits most
-    `{% set %}` bindings by itself. It does still report one bound inside an
-    `{% if %}`, even though Jinja lets that binding leak out of the block, so
+    `{% set %}` bindings by itself. It can still report one bound inside an
+    `{% if %}` -- Jinja lets that binding leak out of the block, but whether
+    the analyzer catches it depends on the condition not being constant-
+    folded and there being no same-named binding at an outer scope -- so
     those are collected here to keep a working template from being flagged.
 
     Recurses rather than using `find_all` so the walk can stop at a scope

--- a/src/backend/utils/token_validation.py
+++ b/src/backend/utils/token_validation.py
@@ -46,10 +46,10 @@ def _bound_names(node: nodes.Node) -> set[str]:
 
     `meta.find_undeclared_variables` is already scope-aware and omits most
     `{% set %}` bindings by itself. It can still report one bound inside an
-    `{% if %}` -- Jinja lets that binding leak out of the block, but whether
-    the analyzer catches it depends on the condition not being constant-
-    folded and there being no same-named binding at an outer scope -- so
-    those are collected here to keep a working template from being flagged.
+    `{% if %}` -- Jinja lets that binding leak out of the block, and the
+    analyzer only omits it when a same-named binding already exists at an
+    outer scope -- so those are collected here to keep a working template
+    from being flagged.
 
     Recurses rather than using `find_all` so the walk can stop at a scope
     boundary. `Node.find_all` yields descendants but not the node it is called

--- a/src/config/models.py
+++ b/src/config/models.py
@@ -355,6 +355,7 @@ class TemplateSettings:
     block_syntax_color: str
     variable_syntax_color: str
     comment_syntax_color: str
+    warning_syntax_color: str
     trim_blocks: bool
     lstrip_blocks: bool
     newline_sequence: str

--- a/src/config/operations.py
+++ b/src/config/operations.py
@@ -1011,6 +1011,9 @@ class TypedTomlOperations:
             template_settings["comment_syntax_color"] = (
                 self.settings.templates.comment_syntax_color
             )
+            template_settings["warning_syntax_color"] = (
+                self.settings.templates.warning_syntax_color
+            )
             template_settings["trim_blocks"] = int(self.settings.templates.trim_blocks)
             template_settings["lstrip_blocks"] = int(
                 self.settings.templates.lstrip_blocks
@@ -1796,6 +1799,7 @@ class TypedTomlOperations:
                         template_settings["variable_syntax_color"]
                     ),
                     comment_syntax_color=str(template_settings["comment_syntax_color"]),
+                    warning_syntax_color=str(template_settings["warning_syntax_color"]),
                     trim_blocks=bool(template_settings["trim_blocks"]),
                     lstrip_blocks=bool(template_settings["lstrip_blocks"]),
                     newline_sequence=str(template_settings["newline_sequence"]),

--- a/src/frontend/custom_widgets/template_selector.py
+++ b/src/frontend/custom_widgets/template_selector.py
@@ -110,7 +110,7 @@ class TemplateSelector(QWidget):
         self.template_index_map = self.create_template_index_map()
         self.old_text: str | None = None
         self._static_highlights: list[HighlightKeywords] = []
-        self._warning_color: str | None = None
+        self._warning_color: str = ""
         self.unknown_tokens: set[str] = set()
         self._unknown_token_timer = QTimer(self, singleShot=True, interval=400)
         self._unknown_token_timer.timeout.connect(self._refresh_unknown_tokens)
@@ -251,7 +251,7 @@ class TemplateSelector(QWidget):
         return self.template_combo.currentText()
 
     def set_syntax_highlights(
-        self, patterns: list[HighlightKeywords], warning_color: str | None = None
+        self, patterns: list[HighlightKeywords], warning_color: str
     ) -> None:
         """Set the editor's static highlight patterns.
 
@@ -259,10 +259,10 @@ class TemplateSelector(QWidget):
         highlight is appended to this list on every recompute and would
         otherwise be lost whenever a caller reapplies the static patterns.
 
-        `warning_color`, when given, overrides the configured warning color
-        so a picker widget can live-preview a change before it is saved. Pass
-        None (the default) to fall back to config, which is what the wizard
-        page does -- it has no picker widget of its own.
+        Every color, including `warning_color`, comes from the caller -- the
+        same as the three static delimiter colors, which arrive already
+        baked into `patterns`. This widget holds no config knowledge about
+        colors of its own.
         """
         self._static_highlights = list(patterns)
         self._warning_color = warning_color
@@ -288,22 +288,13 @@ class TemplateSelector(QWidget):
     def _apply_highlights(self) -> None:
         patterns = list(self._static_highlights)
         unknown_pattern = build_unknown_token_pattern(self.unknown_tokens)
-        if unknown_pattern is not None:
-            # `_warning_color` lets the settings picker live-preview a change
-            # before it is saved to config. Falls back to the packaged
-            # default when both that and config are blank, rather than
-            # handing the highlighter an empty string. The three static
-            # colors guard the same way with `if <color>:` at
-            # `settings/templates.py:563-590`.
-            color = (
-                self._warning_color
-                or self.config.settings.templates.warning_syntax_color
-                or self.config.defaults.templates.warning_syntax_color
-            )
+        if unknown_pattern is not None and self._warning_color:
             # Appended last so it overrides the variable color on the same
             # span: the highlighter applies patterns in order and later
             # `setFormat` calls overwrite earlier ones.
-            patterns.append(HighlightKeywords(unknown_pattern, color, False))
+            patterns.append(
+                HighlightKeywords(unknown_pattern, self._warning_color, False)
+            )
         self.text_edit.highlight_keywords(patterns)
 
     def create_template_index_map(self) -> dict[str, int]:

--- a/src/frontend/custom_widgets/template_selector.py
+++ b/src/frontend/custom_widgets/template_selector.py
@@ -110,6 +110,7 @@ class TemplateSelector(QWidget):
         self.template_index_map = self.create_template_index_map()
         self.old_text: str | None = None
         self._static_highlights: list[HighlightKeywords] = []
+        self._warning_color: str | None = None
         self.unknown_tokens: set[str] = set()
         self._unknown_token_timer = QTimer(self, singleShot=True, interval=400)
         self._unknown_token_timer.timeout.connect(self._refresh_unknown_tokens)
@@ -249,14 +250,22 @@ class TemplateSelector(QWidget):
     def get_selected_template_name(self) -> str:
         return self.template_combo.currentText()
 
-    def set_syntax_highlights(self, patterns: list[HighlightKeywords]) -> None:
+    def set_syntax_highlights(
+        self, patterns: list[HighlightKeywords], warning_color: str | None = None
+    ) -> None:
         """Set the editor's static highlight patterns.
 
         Stored rather than passed straight through, because the unknown-token
         highlight is appended to this list on every recompute and would
         otherwise be lost whenever a caller reapplies the static patterns.
+
+        `warning_color`, when given, overrides the configured warning colour
+        so a picker widget can live-preview a change before it is saved. Pass
+        None (the default) to fall back to config, which is what the wizard
+        page does -- it has no picker widget of its own.
         """
         self._static_highlights = list(patterns)
+        self._warning_color = warning_color
         self._apply_highlights()
 
     @Slot()
@@ -280,19 +289,21 @@ class TemplateSelector(QWidget):
         patterns = list(self._static_highlights)
         unknown_pattern = build_unknown_token_pattern(self.unknown_tokens)
         if unknown_pattern is not None:
-            # Falls back to the packaged default when the user has cleared the
-            # colour, rather than handing the highlighter an empty string. The
-            # three static colours guard the same way with `if <color>:` at
+            # `_warning_color` lets the settings picker live-preview a change
+            # before it is saved to config. Falls back to the packaged
+            # default when both that and config are blank, rather than
+            # handing the highlighter an empty string. The three static
+            # colours guard the same way with `if <color>:` at
             # `settings/templates.py:563-590`.
             color = (
-                self.config.settings.templates.warning_syntax_color
+                self._warning_color
+                or self.config.settings.templates.warning_syntax_color
                 or self.config.defaults.templates.warning_syntax_color
             )
             # Appended last so it overrides the variable colour on the same
             # span: the highlighter applies patterns in order and later
             # `setFormat` calls overwrite earlier ones.
             patterns.append(HighlightKeywords(unknown_pattern, color, False))
-        self.text_edit.clear_keyword_highlights()
         self.text_edit.highlight_keywords(patterns)
 
     def create_template_index_map(self) -> dict[str, int]:

--- a/src/frontend/custom_widgets/template_selector.py
+++ b/src/frontend/custom_widgets/template_selector.py
@@ -24,6 +24,10 @@ from src.backend.template_selector import TemplateSelectorBackEnd
 from src.backend.token_replacer import TokenReplacer
 from src.backend.tokens import Tokens, TokenType
 from src.backend.utils.token_utils import get_prompt_tokens
+from src.backend.utils.token_validation import (
+    build_unknown_token_pattern,
+    find_unknown_tokens,
+)
 from src.config.config import ConfigManager
 from src.context.processing_context import ProcessingContext
 from src.enums.media_type import MediaType
@@ -94,6 +98,9 @@ class TemplateSelector(QWidget):
         self.template_index_map = self.create_template_index_map()
         self.old_text: str | None = None
         self._static_highlights: list[HighlightKeywords] = []
+        self.unknown_tokens: set[str] = set()
+        self._unknown_token_timer = QTimer(self, singleShot=True, interval=400)
+        self._unknown_token_timer.timeout.connect(self._refresh_unknown_tokens)
         self.cached_sandbox_prompt_tokens: dict[str, str] | None = None
         self._del_timer = QTimer(self, singleShot=True, interval=3000)
         self._del_timer.timeout.connect(self._del_timer_done)
@@ -214,6 +221,7 @@ class TemplateSelector(QWidget):
             line_numbers=True, wrap_text=False, mono_font=True, parent=self
         )
         self.text_edit.save_contents.connect(self.save_template)
+        self.text_edit.textChanged.connect(self._unknown_token_timer.start)
 
         self.main_layout = QVBoxLayout(self)
         self.main_layout.addLayout(self.template_control_layout)
@@ -239,9 +247,41 @@ class TemplateSelector(QWidget):
         self._static_highlights = list(patterns)
         self._apply_highlights()
 
+    @Slot()
+    def _refresh_unknown_tokens(self) -> None:
+        """Recompute the unknown-token set and reapply the highlights.
+
+        Advisory only: this never blocks an edit, a save, or a preview. While
+        the preview is showing, the editor holds rendered output rather than
+        template source, so the check is skipped.
+        """
+        if self.preview_btn.isChecked():
+            return
+
+        self.unknown_tokens = find_unknown_tokens(
+            self.text_edit.toPlainText(),
+            self.context.jinja_engine.environment,
+        )
+        self._apply_highlights()
+
     def _apply_highlights(self) -> None:
+        patterns = list(self._static_highlights)
+        unknown_pattern = build_unknown_token_pattern(self.unknown_tokens)
+        if unknown_pattern is not None:
+            # Falls back to the packaged default when the user has cleared the
+            # colour, rather than handing the highlighter an empty string. The
+            # three static colours guard the same way with `if <color>:` at
+            # `settings/templates.py:563-590`.
+            color = (
+                self.config.settings.templates.warning_syntax_color
+                or self.config.defaults.templates.warning_syntax_color
+            )
+            # Appended last so it overrides the variable colour on the same
+            # span: the highlighter applies patterns in order and later
+            # `setFormat` calls overwrite earlier ones.
+            patterns.append(HighlightKeywords(unknown_pattern, color, False))
         self.text_edit.clear_keyword_highlights()
-        self.text_edit.highlight_keywords(list(self._static_highlights))
+        self.text_edit.highlight_keywords(patterns)
 
     def create_template_index_map(self) -> dict[str, int]:
         return {name: i for i, name in enumerate(self.backend.templates.keys())}

--- a/src/frontend/custom_widgets/template_selector.py
+++ b/src/frontend/custom_widgets/template_selector.py
@@ -51,12 +51,12 @@ def saved_status_message(unknown_count: int) -> str:
     """The status tip shown after a template is saved.
 
     The count is advisory: the save has already happened by the time this is
-    shown, and an unrecognised token never prevents one.
+    shown, and an unrecognized token never prevents one.
     """
     if not unknown_count:
         return "Saved template"
     noun = "token" if unknown_count == 1 else "tokens"
-    return f"Saved template - {unknown_count} unrecognised {noun}"
+    return f"Saved template - {unknown_count} unrecognized {noun}"
 
 
 class TokenTableWindow(QWidget):

--- a/src/frontend/custom_widgets/template_selector.py
+++ b/src/frontend/custom_widgets/template_selector.py
@@ -28,7 +28,7 @@ from src.config.config import ConfigManager
 from src.context.processing_context import ProcessingContext
 from src.enums.media_type import MediaType
 from src.enums.tracker_selection import TrackerSelection
-from src.frontend.custom_widgets.basic_code_editor import CodeEditor
+from src.frontend.custom_widgets.basic_code_editor import CodeEditor, HighlightKeywords
 from src.frontend.custom_widgets.combo_box import CustomComboBox
 from src.frontend.custom_widgets.menu_button import CustomButtonMenu
 from src.frontend.custom_widgets.prompt_token_editor_dialog import (
@@ -93,6 +93,7 @@ class TemplateSelector(QWidget):
         self.templates = self.backend.templates
         self.template_index_map = self.create_template_index_map()
         self.old_text: str | None = None
+        self._static_highlights: list[HighlightKeywords] = []
         self.cached_sandbox_prompt_tokens: dict[str, str] | None = None
         self._del_timer = QTimer(self, singleShot=True, interval=3000)
         self._del_timer.timeout.connect(self._del_timer_done)
@@ -227,6 +228,20 @@ class TemplateSelector(QWidget):
 
     def get_selected_template_name(self) -> str:
         return self.template_combo.currentText()
+
+    def set_syntax_highlights(self, patterns: list[HighlightKeywords]) -> None:
+        """Set the editor's static highlight patterns.
+
+        Stored rather than passed straight through, because the unknown-token
+        highlight is appended to this list on every recompute and would
+        otherwise be lost whenever a caller reapplies the static patterns.
+        """
+        self._static_highlights = list(patterns)
+        self._apply_highlights()
+
+    def _apply_highlights(self) -> None:
+        self.text_edit.clear_keyword_highlights()
+        self.text_edit.highlight_keywords(list(self._static_highlights))
 
     def create_template_index_map(self) -> dict[str, int]:
         return {name: i for i, name in enumerate(self.backend.templates.keys())}

--- a/src/frontend/custom_widgets/template_selector.py
+++ b/src/frontend/custom_widgets/template_selector.py
@@ -47,6 +47,18 @@ if TYPE_CHECKING:
     from src.frontend.windows.main_window import MainWindow
 
 
+def saved_status_message(unknown_count: int) -> str:
+    """The status tip shown after a template is saved.
+
+    The count is advisory: the save has already happened by the time this is
+    shown, and an unrecognised token never prevents one.
+    """
+    if not unknown_count:
+        return "Saved template"
+    noun = "token" if unknown_count == 1 else "tokens"
+    return f"Saved template - {unknown_count} unrecognised {noun}"
+
+
 class TokenTableWindow(QWidget):
     def __init__(
         self, parent: QWidget, on_close: Callable[[QCloseEvent], None]
@@ -415,7 +427,10 @@ class TemplateSelector(QWidget):
                 self.template_combo.currentText()
             ]
             self.backend.save_template(selected_template, self.text_edit.toPlainText())
-            GSigs().main_window_update_status_tip.emit("Saved template", 3000)
+            self._refresh_unknown_tokens()
+            GSigs().main_window_update_status_tip.emit(
+                saved_status_message(len(self.unknown_tokens)), 3000
+            )
 
     @Slot()
     def delete_template(self) -> None:

--- a/src/frontend/custom_widgets/template_selector.py
+++ b/src/frontend/custom_widgets/template_selector.py
@@ -259,7 +259,7 @@ class TemplateSelector(QWidget):
         highlight is appended to this list on every recompute and would
         otherwise be lost whenever a caller reapplies the static patterns.
 
-        `warning_color`, when given, overrides the configured warning colour
+        `warning_color`, when given, overrides the configured warning color
         so a picker widget can live-preview a change before it is saved. Pass
         None (the default) to fall back to config, which is what the wizard
         page does -- it has no picker widget of its own.
@@ -293,14 +293,14 @@ class TemplateSelector(QWidget):
             # before it is saved to config. Falls back to the packaged
             # default when both that and config are blank, rather than
             # handing the highlighter an empty string. The three static
-            # colours guard the same way with `if <color>:` at
+            # colors guard the same way with `if <color>:` at
             # `settings/templates.py:563-590`.
             color = (
                 self._warning_color
                 or self.config.settings.templates.warning_syntax_color
                 or self.config.defaults.templates.warning_syntax_color
             )
-            # Appended last so it overrides the variable colour on the same
+            # Appended last so it overrides the variable color on the same
             # span: the highlighter applies patterns in order and later
             # `setFormat` calls overwrite earlier ones.
             patterns.append(HighlightKeywords(unknown_pattern, color, False))

--- a/src/frontend/stacked_windows/settings/templates.py
+++ b/src/frontend/stacked_windows/settings/templates.py
@@ -550,10 +550,7 @@ class TemplatesSettings(BaseSettings):
         self.update_template_selector_syntax()
 
     def update_template_selector_syntax(self) -> None:
-        self.template_selector.text_edit.clear_keyword_highlights()
-        self.template_selector.text_edit.highlight_keywords(
-            self.jinja_syntax_highlights()
-        )
+        self.template_selector.set_syntax_highlights(self.jinja_syntax_highlights())
 
     def _current_newline_sequence(self) -> str:
         value = self.newline_sequence.currentData()

--- a/src/frontend/stacked_windows/settings/templates.py
+++ b/src/frontend/stacked_windows/settings/templates.py
@@ -373,9 +373,9 @@ class TemplatesSettings(BaseSettings):
         # warning pair calls `_update_warning_entry_text_color` (which
         # pushes the live-preview override into the selector) BEFORE
         # `update_color` resets the swatch, so the selector is left holding
-        # the pre-reset colour -- and, being last, nothing after it re-syncs
+        # the pre-reset color -- and, being last, nothing after it re-syncs
         # the override. Re-run it explicitly so Cancel can't leave the
-        # embedded editor highlighting with a colour the user just backed
+        # embedded editor highlighting with a color the user just backed
         # out of.
         self.update_template_selector_syntax()
 

--- a/src/frontend/stacked_windows/settings/templates.py
+++ b/src/frontend/stacked_windows/settings/templates.py
@@ -369,6 +369,16 @@ class TemplatesSettings(BaseSettings):
 
         self.template_selector.load_templates()
 
+        # Every swatch above holds its reloaded value by this point. The
+        # warning pair calls `_update_warning_entry_text_color` (which
+        # pushes the live-preview override into the selector) BEFORE
+        # `update_color` resets the swatch, so the selector is left holding
+        # the pre-reset colour -- and, being last, nothing after it re-syncs
+        # the override. Re-run it explicitly so Cancel can't leave the
+        # embedded editor highlighting with a colour the user just backed
+        # out of.
+        self.update_template_selector_syntax()
+
     @Slot()
     def _save_settings(self) -> None:
         self._save_template_edited()

--- a/src/frontend/stacked_windows/settings/templates.py
+++ b/src/frontend/stacked_windows/settings/templates.py
@@ -550,7 +550,9 @@ class TemplatesSettings(BaseSettings):
         self.update_template_selector_syntax()
 
     def update_template_selector_syntax(self) -> None:
-        self.template_selector.set_syntax_highlights(self.jinja_syntax_highlights())
+        self.template_selector.set_syntax_highlights(
+            self.jinja_syntax_highlights(), self.warning_syntax_color.get_hex_color()
+        )
 
     def _current_newline_sequence(self) -> str:
         value = self.newline_sequence.currentData()

--- a/src/frontend/stacked_windows/settings/templates.py
+++ b/src/frontend/stacked_windows/settings/templates.py
@@ -153,7 +153,7 @@ class TemplatesSettings(BaseSettings):
             self._update_comment_entry_text_color
         )
 
-        self.warning_syntax_lbl = QLabel("Unrecognised Token", self)
+        self.warning_syntax_lbl = QLabel("Unrecognized Token", self)
         self.warning_syntax_lbl.setToolTip(
             "Sets the highlight color for tokens that will not resolve when "
             "the template renders"
@@ -167,7 +167,7 @@ class TemplatesSettings(BaseSettings):
             width=14, height=14, parent=self
         )
         self.warning_syntax_color.setToolTip(
-            "Sets syntax highlighting color for unrecognised tokens"
+            "Sets syntax highlighting color for unrecognized tokens"
         )
         self.warning_syntax_color.color_changed.connect(
             self._update_warning_entry_text_color

--- a/src/frontend/stacked_windows/settings/templates.py
+++ b/src/frontend/stacked_windows/settings/templates.py
@@ -153,6 +153,26 @@ class TemplatesSettings(BaseSettings):
             self._update_comment_entry_text_color
         )
 
+        self.warning_syntax_lbl = QLabel("Unrecognised Token", self)
+        self.warning_syntax_lbl.setToolTip(
+            "Sets the highlight color for tokens that will not resolve when "
+            "the template renders"
+        )
+        self.warning_syntax_entry = QLineEdit(
+            self, text="{{ unknown_token }}", readOnly=True, frame=False
+        )
+        self.warning_entries = (self.warning_syntax_entry,)
+
+        self.warning_syntax_color = ColorSelectionShape(
+            width=14, height=14, parent=self
+        )
+        self.warning_syntax_color.setToolTip(
+            "Sets syntax highlighting color for unrecognised tokens"
+        )
+        self.warning_syntax_color.color_changed.connect(
+            self._update_warning_entry_text_color
+        )
+
         self.trim_blocks_toggle = QCheckBox("Trim Blocks", self)
         self.trim_blocks_toggle.toggled.connect(self.update_jinja_engine_settings)
         self.trim_blocks_toggle.setToolTip(
@@ -269,6 +289,15 @@ class TemplatesSettings(BaseSettings):
             )
         )
 
+        self.add_layout(
+            create_form_layout(
+                self.combine_lbl_color_selection(
+                    self.warning_syntax_lbl, self.warning_syntax_color
+                ),
+                self.warning_syntax_entry,
+            )
+        )
+
         self.add_layout(toggle_layout)
         self.add_layout(
             create_form_layout(self.newline_sequence_lbl, self.newline_sequence)
@@ -301,6 +330,12 @@ class TemplatesSettings(BaseSettings):
             self._update_text_color(widget, color)
         self.update_template_selector_syntax()
 
+    @Slot(object)
+    def _update_warning_entry_text_color(self, color: QColor) -> None:
+        for widget in self.warning_entries:
+            self._update_text_color(widget, color)
+        self.update_template_selector_syntax()
+
     @Slot()
     def _load_saved_settings(self) -> None:
         payload = self.config.settings.templates
@@ -315,6 +350,10 @@ class TemplatesSettings(BaseSettings):
         comment_color = QColor(self.config.settings.templates.comment_syntax_color)
         self._update_comment_entry_text_color(comment_color)
         self.comment_syntax_color.update_color(comment_color)
+
+        warning_color = QColor(self.config.settings.templates.warning_syntax_color)
+        self._update_warning_entry_text_color(warning_color)
+        self.warning_syntax_color.update_color(warning_color)
 
         self.trim_blocks_toggle.setChecked(payload.trim_blocks)
         self.lstrip_blocks_toggle.setChecked(payload.lstrip_blocks)
@@ -348,6 +387,9 @@ class TemplatesSettings(BaseSettings):
         )
         self.config.settings.templates.comment_syntax_color = (
             self.comment_syntax_color.get_hex_color()
+        )
+        self.config.settings.templates.warning_syntax_color = (
+            self.warning_syntax_color.get_hex_color()
         )
 
         self.config.settings.templates.trim_blocks = self.trim_blocks_toggle.isChecked()
@@ -462,6 +504,10 @@ class TemplatesSettings(BaseSettings):
         comment_color = QColor(self.config.defaults.templates.comment_syntax_color)
         self._update_comment_entry_text_color(comment_color)
         self.comment_syntax_color.update_color(comment_color)
+
+        warning_color = QColor(self.config.defaults.templates.warning_syntax_color)
+        self._update_warning_entry_text_color(warning_color)
+        self.warning_syntax_color.update_color(warning_color)
 
         self.trim_blocks_toggle.setChecked(self.config.defaults.templates.trim_blocks)
         self.lstrip_blocks_toggle.setChecked(

--- a/src/frontend/wizards/nfo_template.py
+++ b/src/frontend/wizards/nfo_template.py
@@ -42,10 +42,7 @@ class NfoTemplate(BaseWizardPage):
 
     def initializePage(self) -> None:
         self.template_selector.load_templates()
-        self.template_selector.text_edit.clear_keyword_highlights()
-        self.template_selector.text_edit.highlight_keywords(
-            self.get_syntax_highlights()
-        )
+        self.template_selector.set_syntax_highlights(self.get_syntax_highlights())
 
         try:
             self.template_selector.read_template()

--- a/src/frontend/wizards/nfo_template.py
+++ b/src/frontend/wizards/nfo_template.py
@@ -42,7 +42,10 @@ class NfoTemplate(BaseWizardPage):
 
     def initializePage(self) -> None:
         self.template_selector.load_templates()
-        self.template_selector.set_syntax_highlights(self.get_syntax_highlights())
+        self.template_selector.set_syntax_highlights(
+            self.get_syntax_highlights(),
+            self.config.settings.templates.warning_syntax_color,
+        )
 
         try:
             self.template_selector.read_template()

--- a/tests/test_backend/test_utils/test_token_validation.py
+++ b/tests/test_backend/test_utils/test_token_validation.py
@@ -72,6 +72,18 @@ def test_macro_scoped_set_used_outside_the_macro_is_flagged() -> None:
     assert find_unknown_tokens(template, _env()) == {"q"}
 
 
+def test_call_scoped_set_used_outside_the_call_is_flagged() -> None:
+    # `{% call %}` is the third scope-opening construct in
+    # `_SCOPE_OPENING_NODES`; without this it is the one named case with no
+    # regression cover, so a change to the walk could silently reintroduce
+    # the false negative for it alone.
+    template = (
+        "{% macro m() %}{{ caller() }}{% endmacro %}"
+        "{% call m() %}{% set c = 1 %}{% endcall %}{{ c }}"
+    )
+    assert find_unknown_tokens(template, _env()) == {"c"}
+
+
 def test_user_and_prompt_prefixed_names_are_not_flagged() -> None:
     assert find_unknown_tokens("{{ usr_custom }}{{ prompt_note }}", _env()) == set()
 

--- a/tests/test_backend/test_utils/test_token_validation.py
+++ b/tests/test_backend/test_utils/test_token_validation.py
@@ -55,10 +55,9 @@ def test_for_loop_target_is_not_flagged() -> None:
 
 
 def test_if_nested_set_is_not_flagged() -> None:
-    # The leading top-level `{% set s = '' %}` means `s` is never reported by
-    # `find_undeclared_variables` in the first place, and the constant `{% if
-    # 1 %}` condition is folded away -- so this also passes regardless of
-    # `_bound_names`.
+    # The leading top-level `{% set s = '' %}` means `s` is already bound at
+    # an outer scope, so `find_undeclared_variables` never reports it in the
+    # first place -- this also passes regardless of `_bound_names`.
     template = "{% set s = '' %}{% if 1 %}{% set s = 'v' %}{% endif %}{{ s }}"
     assert find_unknown_tokens(template, _env()) == set()
 

--- a/tests/test_backend/test_utils/test_token_validation.py
+++ b/tests/test_backend/test_utils/test_token_validation.py
@@ -51,6 +51,27 @@ def test_for_loop_target_is_not_flagged() -> None:
     assert find_unknown_tokens(template, _env()) == set()
 
 
+def test_if_nested_set_is_not_flagged() -> None:
+    # Jinja lets a binding made inside `{% if %}` leak out of the block, so
+    # the later reference resolves. `find_undeclared_variables` reports it
+    # anyway, and flagging it would mark a working template. This is the
+    # shape used by a real user template.
+    template = "{% set s = '' %}{% if 1 %}{% set s = 'v' %}{% endif %}{{ s }}"
+    assert find_unknown_tokens(template, _env()) == set()
+
+
+def test_loop_scoped_set_used_outside_the_loop_is_flagged() -> None:
+    # The binding does not outlive the loop, so this really does render
+    # blank -- the exact silent-blank failure this module exists to catch.
+    template = "{% for i in ['A'] %}{% set y = i %}{% endfor %}{{ y }}"
+    assert find_unknown_tokens(template, _env()) == {"y"}
+
+
+def test_macro_scoped_set_used_outside_the_macro_is_flagged() -> None:
+    template = "{% macro m() %}{% set q = 1 %}{% endmacro %}{{ q }}"
+    assert find_unknown_tokens(template, _env()) == {"q"}
+
+
 def test_user_and_prompt_prefixed_names_are_not_flagged() -> None:
     assert find_unknown_tokens("{{ usr_custom }}{{ prompt_note }}", _env()) == set()
 

--- a/tests/test_backend/test_utils/test_token_validation.py
+++ b/tests/test_backend/test_utils/test_token_validation.py
@@ -1,0 +1,84 @@
+from jinja2 import Environment
+
+from src.backend.utils.token_validation import (
+    build_unknown_token_pattern,
+    find_unknown_tokens,
+)
+
+
+def _env() -> Environment:
+    return Environment()
+
+
+def test_known_token_is_not_flagged() -> None:
+    assert find_unknown_tokens("{{ video_bit_rate }}", _env()) == set()
+
+
+def test_stale_mi_token_is_flagged() -> None:
+    assert find_unknown_tokens("{{ mi_video_bit_rate }}", _env()) == {
+        "mi_video_bit_rate"
+    }
+
+
+def test_only_the_unknown_name_on_a_mixed_line_is_flagged() -> None:
+    template = (
+        "Video: {{ mi_video_codec }} / {{ video_frame_rate }} / {{ format_profile }}"
+    )
+    assert find_unknown_tokens(template, _env()) == {"mi_video_codec"}
+
+
+def test_environment_global_is_not_flagged() -> None:
+    env = _env()
+    env.globals["plugin_helper"] = object()
+    assert find_unknown_tokens("{{ plugin_helper }}", env) == set()
+
+
+def test_simple_set_binding_is_not_flagged() -> None:
+    # Regression guard: `Node.find_all` does not yield the node it is called
+    # on, and a simple `{% set %}` target *is* a `nodes.Name`. A walk-only
+    # implementation misses this and reports `scan_type` as unknown.
+    template = "{% set scan_type = 'Progressive' %}{{ scan_type }}"
+    assert find_unknown_tokens(template, _env()) == set()
+
+
+def test_set_block_binding_is_not_flagged() -> None:
+    template = "{% set body %}text{% endset %}{{ body }}"
+    assert find_unknown_tokens(template, _env()) == set()
+
+
+def test_for_loop_target_is_not_flagged() -> None:
+    template = "{% for item in [1, 2] %}{{ item }}{% endfor %}"
+    assert find_unknown_tokens(template, _env()) == set()
+
+
+def test_user_and_prompt_prefixed_names_are_not_flagged() -> None:
+    assert find_unknown_tokens("{{ usr_custom }}{{ prompt_note }}", _env()) == set()
+
+
+def test_explicitly_supplied_user_token_is_not_flagged() -> None:
+    result = find_unknown_tokens(
+        "{{ my_plugin_value }}", _env(), user_tokens=["my_plugin_value"]
+    )
+    assert result == set()
+
+
+def test_unparseable_template_returns_empty_set() -> None:
+    # The editor's existing TemplateSyntaxError dialog owns this case.
+    assert find_unknown_tokens("{% if %}", _env()) == set()
+
+
+def test_pattern_is_none_when_nothing_is_unknown() -> None:
+    assert build_unknown_token_pattern([]) is None
+
+
+def test_pattern_matches_each_unknown_name() -> None:
+    pattern = build_unknown_token_pattern(["mi_video_codec", "mi_video_bit_rate"])
+    assert pattern is not None
+    text = "{{ mi_video_codec }} / {{ mi_video_bit_rate }} / {{ video_frame_rate }}"
+    assert pattern.findall(text) == ["mi_video_codec", "mi_video_bit_rate"]
+
+
+def test_pattern_does_not_match_a_longer_name_by_prefix() -> None:
+    pattern = build_unknown_token_pattern(["mi_video_bit_rate"])
+    assert pattern is not None
+    assert pattern.search("{{ mi_video_bit_rate_num_only }}") is None

--- a/tests/test_backend/test_utils/test_token_validation.py
+++ b/tests/test_backend/test_utils/test_token_validation.py
@@ -34,14 +34,17 @@ def test_environment_global_is_not_flagged() -> None:
 
 
 def test_simple_set_binding_is_not_flagged() -> None:
-    # Regression guard: `Node.find_all` does not yield the node it is called
-    # on, and a simple `{% set %}` target *is* a `nodes.Name`. A walk-only
-    # implementation misses this and reports `scan_type` as unknown.
+    # `meta.find_undeclared_variables` never reports a top-level `{% set %}`
+    # target in the first place, so this pins the baseline behaviour and
+    # passes regardless of what `_bound_names` does.
     template = "{% set scan_type = 'Progressive' %}{{ scan_type }}"
     assert find_unknown_tokens(template, _env()) == set()
 
 
 def test_set_block_binding_is_not_flagged() -> None:
+    # As above: a top-level `{% set %}` target (block form included) is never
+    # reported by `find_undeclared_variables`, so this passes regardless of
+    # `_bound_names`.
     template = "{% set body %}text{% endset %}{{ body }}"
     assert find_unknown_tokens(template, _env()) == set()
 
@@ -52,11 +55,33 @@ def test_for_loop_target_is_not_flagged() -> None:
 
 
 def test_if_nested_set_is_not_flagged() -> None:
-    # Jinja lets a binding made inside `{% if %}` leak out of the block, so
-    # the later reference resolves. `find_undeclared_variables` reports it
-    # anyway, and flagging it would mark a working template. This is the
-    # shape used by a real user template.
+    # The leading top-level `{% set s = '' %}` means `s` is never reported by
+    # `find_undeclared_variables` in the first place, and the constant `{% if
+    # 1 %}` condition is folded away -- so this also passes regardless of
+    # `_bound_names`.
     template = "{% set s = '' %}{% if 1 %}{% set s = 'v' %}{% endif %}{{ s }}"
+    assert find_unknown_tokens(template, _env()) == set()
+
+
+def test_conditional_simple_set_is_not_flagged() -> None:
+    # Guards the `isinstance(target, nodes.Name)` branch: a conditional
+    # binding IS reported by find_undeclared_variables, so only _bound_names
+    # keeps it from being flagged. Non-constant condition, no outer binding.
+    template = "{% if video_height %}{% set s = 'v' %}{% endif %}{{ s }}"
+    assert find_unknown_tokens(template, _env()) == set()
+
+
+def test_conditional_tuple_set_is_not_flagged() -> None:
+    # Guards the `target.find_all(nodes.Name)` branch: tuple targets are
+    # reached only by the walk, not the isinstance check.
+    template = "{% if video_height %}{% set a, b = 1, 2 %}{% endif %}{{ a }}{{ b }}"
+    assert find_unknown_tokens(template, _env()) == set()
+
+
+def test_set_block_nested_binding_is_not_flagged() -> None:
+    # Guards the recursive descent: the inner binding is only reachable by
+    # recursing into the AssignBlock child.
+    template = "{% set body %}{% set inner = 1 %}{% endset %}{{ inner }}"
     assert find_unknown_tokens(template, _env()) == set()
 
 
@@ -82,6 +107,21 @@ def test_call_scoped_set_used_outside_the_call_is_flagged() -> None:
         "{% call m() %}{% set c = 1 %}{% endcall %}{{ c }}"
     )
     assert find_unknown_tokens(template, _env()) == {"c"}
+
+
+def test_with_scoped_set_used_outside_is_flagged() -> None:
+    template = "{% with %}{% set q = 1 %}{% endwith %}{{ q }}"
+    assert find_unknown_tokens(template, _env()) == {"q"}
+
+
+def test_filter_block_scoped_set_used_outside_is_flagged() -> None:
+    template = "{% filter upper %}{% set q = 1 %}{% endfilter %}{{ q }}"
+    assert find_unknown_tokens(template, _env()) == {"q"}
+
+
+def test_block_scoped_set_used_outside_is_flagged() -> None:
+    template = "{% block b %}{% set q = 1 %}{% endblock %}{{ q }}"
+    assert find_unknown_tokens(template, _env()) == {"q"}
 
 
 def test_user_and_prompt_prefixed_names_are_not_flagged() -> None:

--- a/tests/test_config/test_manager.py
+++ b/tests/test_config/test_manager.py
@@ -935,3 +935,28 @@ def test_schema1_int_tracker_flags_load_as_bool(
     raw = saved_mtv["anonymous"]
     raw = raw.unwrap() if hasattr(raw, "unwrap") else raw
     assert type(raw) is bool
+
+
+def test_warning_syntax_color_backfills_when_a_profile_lacks_it(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A profile written before this key existed gains it on load.
+
+    This is why the key needs no schema bump: `merge_defaults` backfills any
+    key the packaged default declares but the profile lacks. If this test ever
+    fails, the key would need a migration rather than a default.
+    """
+    monkeypatch.setattr(
+        "src.config.config.FindDependencies.update_dependencies",
+        lambda self, dependencies: None,
+    )
+    paths = _paths(tmp_path)
+    manager = ConfigManager("test", paths)
+    profile = paths.user_configs / "test.toml"
+    document = tomlkit.parse(profile.read_text(encoding="utf-8"))
+    del document["template_settings"]["warning_syntax_color"]
+    profile.write_text(tomlkit.dumps(document), encoding="utf-8")
+
+    manager.load_profile("test")
+
+    assert manager.settings.templates.warning_syntax_color == "#E1401D"

--- a/tests/test_config/test_manager.py
+++ b/tests/test_config/test_manager.py
@@ -960,3 +960,25 @@ def test_warning_syntax_color_backfills_when_a_profile_lacks_it(
     manager.load_profile("test")
 
     assert manager.settings.templates.warning_syntax_color == "#E1401D"
+
+
+def test_warning_syntax_color_is_written_on_save(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Covers the write path the read-back test above does not: setting the
+    key and saving must persist the value to the profile TOML.
+    """
+    monkeypatch.setattr(
+        "src.config.config.FindDependencies.update_dependencies",
+        lambda self, dependencies: None,
+    )
+    paths = _paths(tmp_path)
+    manager = ConfigManager("test", paths)
+
+    manager.settings.templates.warning_syntax_color = "#123ABC"
+    manager.save()
+
+    profile = paths.user_configs / "test.toml"
+    saved = tomlkit.parse(profile.read_text(encoding="utf-8"))
+    template_settings = cast(MutableMapping[str, Any], saved["template_settings"])
+    assert template_settings["warning_syntax_color"] == "#123ABC"

--- a/tests/test_frontend/test_template_selector_widget.py
+++ b/tests/test_frontend/test_template_selector_widget.py
@@ -7,7 +7,7 @@ from src.config.config import ConfigManager
 from src.config.paths import ConfigPaths
 from src.context.processing_context import ProcessingContext
 from src.frontend.custom_widgets.basic_code_editor import HighlightKeywords
-from src.frontend.custom_widgets.template_selector import TemplateSelector
+from src.frontend.custom_widgets.template_selector import TemplateSelector, saved_status_message
 
 
 def _paths(tmp_path: Path) -> ConfigPaths:
@@ -147,3 +147,15 @@ def test_blank_warning_colour_falls_back_to_the_default(
 
     applied = selector.text_edit.highlighter.patterns_colors
     assert applied[-1].color.lower() == "#e1401d"
+
+
+def test_status_message_is_unchanged_when_everything_resolves() -> None:
+    assert saved_status_message(0) == "Saved template"
+
+
+def test_status_message_is_singular_for_one_unknown_token() -> None:
+    assert saved_status_message(1) == "Saved template - 1 unrecognised token"
+
+
+def test_status_message_is_plural_for_several_unknown_tokens() -> None:
+    assert saved_status_message(3) == "Saved template - 3 unrecognised tokens"

--- a/tests/test_frontend/test_template_selector_widget.py
+++ b/tests/test_frontend/test_template_selector_widget.py
@@ -77,3 +77,73 @@ def test_set_syntax_highlights_replaces_rather_than_accumulates(
     selector.set_syntax_highlights(_static_patterns())
 
     assert len(selector.text_edit.highlighter.patterns_colors) == 2
+
+
+def test_unknown_token_pattern_is_appended_after_the_static_patterns(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Order matters: the highlighter applies patterns in list order and later
+    # `setFormat` calls overwrite earlier ones for the same span, so the
+    # warning colour must be applied after the variable colour to win.
+    selector = _make_selector(tmp_path, monkeypatch)
+    selector.set_syntax_highlights(_static_patterns())
+    selector.text_edit.setPlainText("{{ mi_video_codec }}")
+
+    selector._refresh_unknown_tokens()
+
+    applied = selector.text_edit.highlighter.patterns_colors
+    assert len(applied) == 3
+    assert applied[-1].color.lower() == "#e1401d"
+    assert applied[-1].pattern.findall("{{ mi_video_codec }}") == ["mi_video_codec"]
+
+
+def test_no_extra_pattern_when_every_token_resolves(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    selector = _make_selector(tmp_path, monkeypatch)
+    selector.set_syntax_highlights(_static_patterns())
+    selector.text_edit.setPlainText("{{ video_bit_rate }}")
+
+    selector._refresh_unknown_tokens()
+
+    assert len(selector.text_edit.highlighter.patterns_colors) == 2
+    assert selector.unknown_tokens == set()
+
+
+def test_unknown_tokens_are_recorded(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    selector = _make_selector(tmp_path, monkeypatch)
+    selector.text_edit.setPlainText(
+        "{{ mi_video_codec }} / {{ video_bit_rate }} / {{ mi_video_bit_rate }}"
+    )
+
+    selector._refresh_unknown_tokens()
+
+    assert selector.unknown_tokens == {"mi_video_codec", "mi_video_bit_rate"}
+
+
+def test_unparseable_template_clears_the_warning(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    selector = _make_selector(tmp_path, monkeypatch)
+    selector.set_syntax_highlights(_static_patterns())
+    selector.text_edit.setPlainText("{% if %}")
+
+    selector._refresh_unknown_tokens()
+
+    assert selector.unknown_tokens == set()
+    assert len(selector.text_edit.highlighter.patterns_colors) == 2
+
+
+def test_blank_warning_colour_falls_back_to_the_default(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    selector = _make_selector(tmp_path, monkeypatch)
+    selector.config.settings.templates.warning_syntax_color = ""
+    selector.text_edit.setPlainText("{{ mi_video_codec }}")
+
+    selector._refresh_unknown_tokens()
+
+    applied = selector.text_edit.highlighter.patterns_colors
+    assert applied[-1].color.lower() == "#e1401d"

--- a/tests/test_frontend/test_template_selector_widget.py
+++ b/tests/test_frontend/test_template_selector_widget.py
@@ -7,7 +7,10 @@ from src.config.config import ConfigManager
 from src.config.paths import ConfigPaths
 from src.context.processing_context import ProcessingContext
 from src.frontend.custom_widgets.basic_code_editor import HighlightKeywords
-from src.frontend.custom_widgets.template_selector import TemplateSelector, saved_status_message
+from src.frontend.custom_widgets.template_selector import (
+    TemplateSelector,
+    saved_status_message,
+)
 
 
 def _paths(tmp_path: Path) -> ConfigPaths:
@@ -33,9 +36,7 @@ def _paths(tmp_path: Path) -> ConfigPaths:
     )
 
 
-def _make_selector(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> TemplateSelector:
+def _make_selector(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TemplateSelector:
     monkeypatch.setattr(
         "src.config.config.FindDependencies.update_dependencies",
         lambda self, dependencies: None,

--- a/tests/test_frontend/test_template_selector_widget.py
+++ b/tests/test_frontend/test_template_selector_widget.py
@@ -105,7 +105,7 @@ def test_unknown_token_pattern_is_appended_after_the_static_patterns(
 ) -> None:
     # Order matters: the highlighter applies patterns in list order and later
     # `setFormat` calls overwrite earlier ones for the same span, so the
-    # warning colour must be applied after the variable colour to win.
+    # warning color must be applied after the variable color to win.
     selector = _make_selector(tmp_path, monkeypatch)
     selector.set_syntax_highlights(_static_patterns())
     selector.text_edit.setPlainText("{{ mi_video_codec }}")
@@ -157,7 +157,7 @@ def test_unparseable_template_clears_the_warning(
     assert len(selector.text_edit.highlighter.patterns_colors) == 2
 
 
-def test_blank_warning_colour_falls_back_to_the_default(
+def test_blank_warning_color_falls_back_to_the_default(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     selector = _make_selector(tmp_path, monkeypatch)
@@ -170,7 +170,7 @@ def test_blank_warning_colour_falls_back_to_the_default(
     assert applied[-1].color.lower() == "#e1401d"
 
 
-def test_warning_colour_override_wins_over_config(
+def test_warning_color_override_wins_over_config(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     # The settings picker passes its own value so the editor can live-preview

--- a/tests/test_frontend/test_template_selector_widget.py
+++ b/tests/test_frontend/test_template_selector_widget.py
@@ -80,6 +80,26 @@ def test_set_syntax_highlights_replaces_rather_than_accumulates(
     assert len(selector.text_edit.highlighter.patterns_colors) == 2
 
 
+def test_set_syntax_highlights_replaces_rather_than_accumulates_the_warning_pattern(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The invariant above is meaningless while `unknown_tokens` is empty, since
+    # there is no warning pattern either way. With one present and refreshed,
+    # reapplying the static patterns must rebuild -- not lose or duplicate --
+    # the warning pattern.
+    selector = _make_selector(tmp_path, monkeypatch)
+    selector.set_syntax_highlights(_static_patterns())
+    selector.text_edit.setPlainText("{{ mi_video_codec }}")
+    selector._refresh_unknown_tokens()
+
+    selector.set_syntax_highlights(_static_patterns())
+
+    assert (
+        len(selector.text_edit.highlighter.patterns_colors)
+        == len(_static_patterns()) + 1
+    )
+
+
 def test_unknown_token_pattern_is_appended_after_the_static_patterns(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -148,6 +168,22 @@ def test_blank_warning_colour_falls_back_to_the_default(
 
     applied = selector.text_edit.highlighter.patterns_colors
     assert applied[-1].color.lower() == "#e1401d"
+
+
+def test_warning_colour_override_wins_over_config(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The settings picker passes its own value so the editor can live-preview
+    # a change before it is saved; config (unchanged here) must not win.
+    selector = _make_selector(tmp_path, monkeypatch)
+    assert selector.config.settings.templates.warning_syntax_color.lower() != "#00ff00"
+    selector.set_syntax_highlights(_static_patterns(), "#00ff00")
+    selector.text_edit.setPlainText("{{ mi_video_codec }}")
+
+    selector._refresh_unknown_tokens()
+
+    applied = selector.text_edit.highlighter.patterns_colors
+    assert applied[-1].color.lower() == "#00ff00"
 
 
 def test_status_message_is_unchanged_when_everything_resolves() -> None:

--- a/tests/test_frontend/test_template_selector_widget.py
+++ b/tests/test_frontend/test_template_selector_widget.py
@@ -1,0 +1,79 @@
+import re
+from pathlib import Path
+
+import pytest
+
+from src.config.config import ConfigManager
+from src.config.paths import ConfigPaths
+from src.context.processing_context import ProcessingContext
+from src.frontend.custom_widgets.basic_code_editor import HighlightKeywords
+from src.frontend.custom_widgets.template_selector import TemplateSelector
+
+
+def _paths(tmp_path: Path) -> ConfigPaths:
+    defaults = tmp_path / "defaults"
+    defaults.mkdir()
+    source_defaults = Path("runtime/config/defaults")
+    default_config = defaults / "default_config.toml"
+    default_program = defaults / "default_program_conf.toml"
+    default_config.write_text(
+        (source_defaults / "default_config.toml").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    default_program.write_text(
+        (source_defaults / "default_program_conf.toml").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    return ConfigPaths(
+        default_config=default_config,
+        default_program=default_program,
+        program=tmp_path / "program/conf.toml",
+        user_configs=tmp_path / "user",
+        tracker_cookies=tmp_path / "cookies",
+    )
+
+
+def _make_selector(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> TemplateSelector:
+    monkeypatch.setattr(
+        "src.config.config.FindDependencies.update_dependencies",
+        lambda self, dependencies: None,
+    )
+    manager = ConfigManager("test", _paths(tmp_path))
+    return TemplateSelector(
+        config=manager,
+        context=ProcessingContext(),
+        sandbox=False,
+        main_window=None,
+        parent=None,
+    )
+
+
+def _static_patterns() -> list[HighlightKeywords]:
+    return [
+        HighlightKeywords(re.compile(r"\{%.*?%\}"), "#A4036F", False),
+        HighlightKeywords(re.compile(r"\{\{.*?\}\}"), "#048BA8", False),
+    ]
+
+
+def test_set_syntax_highlights_applies_the_patterns(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    selector = _make_selector(tmp_path, monkeypatch)
+    patterns = _static_patterns()
+
+    selector.set_syntax_highlights(patterns)
+
+    assert selector.text_edit.highlighter.patterns_colors == patterns
+
+
+def test_set_syntax_highlights_replaces_rather_than_accumulates(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    selector = _make_selector(tmp_path, monkeypatch)
+
+    selector.set_syntax_highlights(_static_patterns())
+    selector.set_syntax_highlights(_static_patterns())
+
+    assert len(selector.text_edit.highlighter.patterns_colors) == 2

--- a/tests/test_frontend/test_template_selector_widget.py
+++ b/tests/test_frontend/test_template_selector_widget.py
@@ -191,8 +191,8 @@ def test_status_message_is_unchanged_when_everything_resolves() -> None:
 
 
 def test_status_message_is_singular_for_one_unknown_token() -> None:
-    assert saved_status_message(1) == "Saved template - 1 unrecognised token"
+    assert saved_status_message(1) == "Saved template - 1 unrecognized token"
 
 
 def test_status_message_is_plural_for_several_unknown_tokens() -> None:
-    assert saved_status_message(3) == "Saved template - 3 unrecognised tokens"
+    assert saved_status_message(3) == "Saved template - 3 unrecognized tokens"

--- a/tests/test_frontend/test_template_selector_widget.py
+++ b/tests/test_frontend/test_template_selector_widget.py
@@ -51,6 +51,9 @@ def _make_selector(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TemplateS
     )
 
 
+WARNING_COLOR = "#e1401d"
+
+
 def _static_patterns() -> list[HighlightKeywords]:
     return [
         HighlightKeywords(re.compile(r"\{%.*?%\}"), "#A4036F", False),
@@ -64,7 +67,7 @@ def test_set_syntax_highlights_applies_the_patterns(
     selector = _make_selector(tmp_path, monkeypatch)
     patterns = _static_patterns()
 
-    selector.set_syntax_highlights(patterns)
+    selector.set_syntax_highlights(patterns, WARNING_COLOR)
 
     assert selector.text_edit.highlighter.patterns_colors == patterns
 
@@ -74,8 +77,8 @@ def test_set_syntax_highlights_replaces_rather_than_accumulates(
 ) -> None:
     selector = _make_selector(tmp_path, monkeypatch)
 
-    selector.set_syntax_highlights(_static_patterns())
-    selector.set_syntax_highlights(_static_patterns())
+    selector.set_syntax_highlights(_static_patterns(), WARNING_COLOR)
+    selector.set_syntax_highlights(_static_patterns(), WARNING_COLOR)
 
     assert len(selector.text_edit.highlighter.patterns_colors) == 2
 
@@ -88,11 +91,11 @@ def test_set_syntax_highlights_replaces_rather_than_accumulates_the_warning_patt
     # reapplying the static patterns must rebuild -- not lose or duplicate --
     # the warning pattern.
     selector = _make_selector(tmp_path, monkeypatch)
-    selector.set_syntax_highlights(_static_patterns())
+    selector.set_syntax_highlights(_static_patterns(), WARNING_COLOR)
     selector.text_edit.setPlainText("{{ mi_video_codec }}")
     selector._refresh_unknown_tokens()
 
-    selector.set_syntax_highlights(_static_patterns())
+    selector.set_syntax_highlights(_static_patterns(), WARNING_COLOR)
 
     assert (
         len(selector.text_edit.highlighter.patterns_colors)
@@ -107,7 +110,7 @@ def test_unknown_token_pattern_is_appended_after_the_static_patterns(
     # `setFormat` calls overwrite earlier ones for the same span, so the
     # warning color must be applied after the variable color to win.
     selector = _make_selector(tmp_path, monkeypatch)
-    selector.set_syntax_highlights(_static_patterns())
+    selector.set_syntax_highlights(_static_patterns(), WARNING_COLOR)
     selector.text_edit.setPlainText("{{ mi_video_codec }}")
 
     selector._refresh_unknown_tokens()
@@ -122,7 +125,7 @@ def test_no_extra_pattern_when_every_token_resolves(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     selector = _make_selector(tmp_path, monkeypatch)
-    selector.set_syntax_highlights(_static_patterns())
+    selector.set_syntax_highlights(_static_patterns(), WARNING_COLOR)
     selector.text_edit.setPlainText("{{ video_bit_rate }}")
 
     selector._refresh_unknown_tokens()
@@ -148,7 +151,7 @@ def test_unparseable_template_clears_the_warning(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     selector = _make_selector(tmp_path, monkeypatch)
-    selector.set_syntax_highlights(_static_patterns())
+    selector.set_syntax_highlights(_static_patterns(), WARNING_COLOR)
     selector.text_edit.setPlainText("{% if %}")
 
     selector._refresh_unknown_tokens()
@@ -157,26 +160,30 @@ def test_unparseable_template_clears_the_warning(
     assert len(selector.text_edit.highlighter.patterns_colors) == 2
 
 
-def test_blank_warning_color_falls_back_to_the_default(
+def test_blank_warning_color_skips_the_warning_pattern(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    # Mirrors the `if <color>:` guard the three static colors already use in
+    # `jinja_syntax_highlights`: a blank color means no highlight pattern,
+    # not a fallback lookup. The selector holds no config knowledge of its
+    # own to fall back to.
     selector = _make_selector(tmp_path, monkeypatch)
-    selector.config.settings.templates.warning_syntax_color = ""
+    patterns = _static_patterns()
+    selector.set_syntax_highlights(patterns, "")
     selector.text_edit.setPlainText("{{ mi_video_codec }}")
 
     selector._refresh_unknown_tokens()
 
     applied = selector.text_edit.highlighter.patterns_colors
-    assert applied[-1].color.lower() == "#e1401d"
+    assert applied == patterns
 
 
-def test_warning_color_override_wins_over_config(
+def test_warning_color_comes_from_the_caller(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    # The settings picker passes its own value so the editor can live-preview
-    # a change before it is saved; config (unchanged here) must not win.
+    # There is no config path left to override: every color, including the
+    # warning color, is supplied by the caller.
     selector = _make_selector(tmp_path, monkeypatch)
-    assert selector.config.settings.templates.warning_syntax_color.lower() != "#00ff00"
     selector.set_syntax_highlights(_static_patterns(), "#00ff00")
     selector.text_edit.setPlainText("{{ mi_video_codec }}")
 

--- a/tests/test_frontend/test_template_settings.py
+++ b/tests/test_frontend/test_template_settings.py
@@ -81,3 +81,30 @@ def test_warning_swatch_change_live_previews_the_editor_highlight(
 
     applied = widget.template_selector.text_edit.highlighter.patterns_colors
     assert applied[-1].color.lower() == "#00ff00"
+
+
+def test_reload_after_cancel_resyncs_the_live_preview_override(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Guards the Cancel/reload desync: `_load_saved_settings` writes the
+    # warning pair last, and `_update_warning_entry_text_color` (called
+    # before the swatch itself is reset) pushes the live-preview override
+    # into the selector using the swatch's PRE-reset colour. Without an
+    # explicit re-sync after every swatch holds its final value, the
+    # embedded editor keeps highlighting with the colour the user backed
+    # out of.
+    widget, _ = _make_templates_settings(tmp_path, monkeypatch)
+    widget.template_selector.text_edit.setPlainText("{{ mi_video_codec }}")
+    widget.template_selector._refresh_unknown_tokens()
+
+    widget.warning_syntax_color.update_color(QColor("#00ff00"))
+    widget.warning_syntax_color.color_changed.emit(QColor("#00ff00"))
+
+    applied = widget.template_selector.text_edit.highlighter.patterns_colors
+    assert applied[-1].color.lower() == "#00ff00"
+
+    # Cancel calls `SettingsWindow._reload_settings()`, which emits this.
+    widget.load_saved_settings.emit()
+
+    applied = widget.template_selector.text_edit.highlighter.patterns_colors
+    assert applied[-1].color.lower() == "#e1401d"

--- a/tests/test_frontend/test_template_settings.py
+++ b/tests/test_frontend/test_template_settings.py
@@ -69,7 +69,7 @@ def test_apply_defaults_restores_warning_color(
 def test_warning_swatch_change_live_previews_the_editor_highlight(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    # The embedded editor must recolour from the widget, not from config --
+    # The embedded editor must recolor from the widget, not from config --
     # config is only written in `_save_settings`, so this is what proves the
     # sample line and the editor stay in sync before the user saves.
     widget, _ = _make_templates_settings(tmp_path, monkeypatch)
@@ -110,9 +110,9 @@ def test_reload_after_cancel_resyncs_the_live_preview_override(
     # Guards the Cancel/reload desync: `_load_saved_settings` writes the
     # warning pair last, and `_update_warning_entry_text_color` (called
     # before the swatch itself is reset) pushes the live-preview override
-    # into the selector using the swatch's PRE-reset colour. Without an
+    # into the selector using the swatch's PRE-reset color. Without an
     # explicit re-sync after every swatch holds its final value, the
-    # embedded editor keeps highlighting with the colour the user backed
+    # embedded editor keeps highlighting with the color the user backed
     # out of.
     widget, _ = _make_templates_settings(tmp_path, monkeypatch)
     widget.template_selector.text_edit.setPlainText("{{ mi_video_codec }}")

--- a/tests/test_frontend/test_template_settings.py
+++ b/tests/test_frontend/test_template_settings.py
@@ -64,3 +64,20 @@ def test_apply_defaults_restores_warning_color(
     widget.apply_defaults()
 
     assert widget.warning_syntax_color.get_hex_color().lower() == "#e1401d"
+
+
+def test_warning_swatch_change_live_previews_the_editor_highlight(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The embedded editor must recolour from the widget, not from config --
+    # config is only written in `_save_settings`, so this is what proves the
+    # sample line and the editor stay in sync before the user saves.
+    widget, _ = _make_templates_settings(tmp_path, monkeypatch)
+    widget.template_selector.text_edit.setPlainText("{{ mi_video_codec }}")
+    widget.template_selector._refresh_unknown_tokens()
+
+    widget.warning_syntax_color.update_color(QColor("#00ff00"))
+    widget.warning_syntax_color.color_changed.emit(QColor("#00ff00"))
+
+    applied = widget.template_selector.text_edit.highlighter.patterns_colors
+    assert applied[-1].color.lower() == "#00ff00"

--- a/tests/test_frontend/test_template_settings.py
+++ b/tests/test_frontend/test_template_settings.py
@@ -1,0 +1,66 @@
+from pathlib import Path
+
+import pytest
+from PySide6.QtGui import QColor
+from PySide6.QtWidgets import QWidget
+
+from src.config.config import ConfigManager
+from src.config.paths import ConfigPaths
+from src.frontend.stacked_windows.settings.templates import TemplatesSettings
+
+
+def _paths(tmp_path: Path) -> ConfigPaths:
+    defaults = tmp_path / "defaults"
+    defaults.mkdir()
+    source_defaults = Path("runtime/config/defaults")
+    default_config = defaults / "default_config.toml"
+    default_program = defaults / "default_program_conf.toml"
+    default_config.write_text(
+        (source_defaults / "default_config.toml").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    default_program.write_text(
+        (source_defaults / "default_program_conf.toml").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    return ConfigPaths(
+        default_config=default_config,
+        default_program=default_program,
+        program=tmp_path / "program/conf.toml",
+        user_configs=tmp_path / "user",
+        tracker_cookies=tmp_path / "cookies",
+    )
+
+
+def _make_templates_settings(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> tuple[TemplatesSettings, ConfigManager]:
+    monkeypatch.setattr(
+        "src.config.config.FindDependencies.update_dependencies",
+        lambda self, dependencies: None,
+    )
+    manager = ConfigManager("test", _paths(tmp_path))
+    fake_settings_window = QWidget()
+    widget = TemplatesSettings(
+        config=manager, main_window=None, parent=fake_settings_window
+    )
+    return widget, manager
+
+
+def test_warning_color_loads_from_config(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    widget, _ = _make_templates_settings(tmp_path, monkeypatch)
+    assert widget.warning_syntax_color.get_hex_color().lower() == "#e1401d"
+
+
+def test_apply_defaults_restores_warning_color(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    widget, _ = _make_templates_settings(tmp_path, monkeypatch)
+    widget.warning_syntax_color.update_color(QColor("#123456"))
+    assert widget.warning_syntax_color.get_hex_color().lower() == "#123456"
+
+    widget.apply_defaults()
+
+    assert widget.warning_syntax_color.get_hex_color().lower() == "#e1401d"

--- a/tests/test_frontend/test_template_settings.py
+++ b/tests/test_frontend/test_template_settings.py
@@ -83,6 +83,27 @@ def test_warning_swatch_change_live_previews_the_editor_highlight(
     assert applied[-1].color.lower() == "#00ff00"
 
 
+def test_color_changed_signal_is_wired_to_the_live_preview_slot(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Pins the `color_changed.connect(...)` wiring itself, rather than only
+    # the effect of manually emitting the signal: a test that only emits
+    # `color_changed` and checks the result would stay green even if that
+    # connect call were deleted, since nothing forces the emit to travel
+    # through the real connection. `SignalInstance.disconnect` returns
+    # whether it actually removed a connection, so this fails loudly if the
+    # slot was never wired up.
+    widget, _ = _make_templates_settings(tmp_path, monkeypatch)
+    was_connected = widget.warning_syntax_color.color_changed.disconnect(
+        widget._update_warning_entry_text_color
+    )
+    assert was_connected
+    # restore the connection so the widget behaves normally if reused
+    widget.warning_syntax_color.color_changed.connect(
+        widget._update_warning_entry_text_color
+    )
+
+
 def test_reload_after_cancel_resyncs_the_live_preview_override(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

A template can reference a token that no longer exists. Jinja renders an unknown name as an empty string for plain substitution, so the field silently disappears from the generated NFO with no error, no warning, and no log line. That is how the `mi_` prefix removal reached uploads: templates written against the old names kept rendering, just with blank fields.

This adds edit-time detection. Names that will not resolve are marked in the template editor in a configurable color, and the save status tip reports how many were found. Nothing is blocked: saving, previewing, and processing behave exactly as they do today.

## What is included

- `src/backend/utils/token_validation.py` — pure detection, free of Qt, config, and media imports so it unit tests without a `QApplication`.
- `warning_syntax_color` config key (default `#E1401D`) with a picker in Settings > Templates, sitting alongside the three existing syntax colors and behaving the same way (load, save, apply-defaults, live preview).
- `TemplateSelector` now owns the editor's highlight pattern list. Both existing callers route through `set_syntax_highlights`, which is what lets a dynamic pattern be appended without being wiped when a caller reapplies the static ones.
- A debounced recompute (400 ms) so a half-typed `{{ mi_vi` does not flash as an error on every keystroke.
- The unrecognized-token count appended to the status tip that the save already emits.

## Detection

A name is known if it is a built-in token, a global registered on the Jinja environment (plugin `jinja2_functions` and the `nf_*` payloads), a name the template binds at a scope that outlives the binding, or a `usr_` / `prompt_` token. An unparseable template returns no results, so this never competes with the existing syntax-error dialog.

Scope handling is the subtle part, and it is covered by tests that fail if the mechanism is removed:

- `meta.find_undeclared_variables` is already scope-aware, but it still reports a name bound inside `{% if %}` even though Jinja lets that binding leak out of the block. Those are collected, otherwise a working template would be flagged permanently.
- Collection stops at `{% for %}`, `{% macro %}`, `{% call %}`, `{% with %}`, `{% filter %}`, and `{% block %}`. A name bound inside one of those does not exist afterwards, so a later reference genuinely renders blank and should stay flagged.

## No config schema bump

`TomlConfigCodec.SCHEMA_VERSION` stays at 3 and `MIGRATIONS` is untouched. Added keys are backfilled by `merge_defaults`, per the policy documented in `src/config/migrations.py`. A test asserts that backfill against a profile with the key removed, rather than restating the policy.

## Testing

- 30 new tests.
- Full suite: 501 passing.
- `ruff check`, `ruff format --check`, and `mypy` all clean.

`tests/test_backend/test_tracker_health.py::test_health_check_blocks_request_failures` currently fails on `dev` independently of this branch. I confirmed it fails on a clean `dev` checkout with none of this branch's code present, so it is untouched here.

## Not covered by automated tests

The Qt timer wiring and the visual result need a manual pass: the highlight appearing after a typing pause, the color picker updating the embedded editor immediately, the count in the save status tip, and whether the default `#E1401D` reads well against both themes.
