### PR TITLE
fix: Run token replacer plugins in the template preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,9 @@
 - Plugin Changes:
   - `pre_upload` plugin is no longer passed kwargs `media_file, mi_obj, source_path`. These can be gathered from the context object easily.
     - You now can access these payloads via the passed `context`.
+  - Run state has moved off of `ConfigManager` and on to the `ProcessingContext` that plugins are passed. `config.shared_data` and `config.media_input_payload` no longer exist - use `context.shared_data`, `context.media_input`, `context.media_search` and `context.jinja_engine` instead.
+  - `MediaInputPayload` no longer describes a single encode. `encode_file_mi_obj` has been replaced by `file_list`, `file_list_mediainfo` _(keyed by path)_ and `comparison_pair`, so a plugin can reach every file in a series pack rather than only one.
+    - Input paths are **not** stable for the length of a run. The rename page renames the media and re-points `file_list`, `file_list_mediainfo`, `series_episode_map` and `comparison_pair` at the new paths. A plugin holding its own data keyed by an input path has to re-key it when that happens, or keep what it needs directly rather than looking it up again later.
 - Improved the visuals of tracker format override widget.
 - File rename no longer happens during processing stage.
 - Updated dependencies:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,10 @@
   - Run state has moved off of `ConfigManager` and on to the `ProcessingContext` that plugins are passed. `config.shared_data` and `config.media_input_payload` no longer exist - use `context.shared_data`, `context.media_input`, `context.media_search` and `context.jinja_engine` instead.
   - `MediaInputPayload` no longer describes a single encode. `encode_file_mi_obj` has been replaced by `file_list`, `file_list_mediainfo` _(keyed by path)_ and `comparison_pair`, so a plugin can reach every file in a series pack rather than only one.
     - Input paths are **not** stable for the length of a run. The rename page renames the media and re-points `file_list`, `file_list_mediainfo`, `series_episode_map` and `comparison_pair` at the new paths. A plugin holding its own data keyed by an input path has to re-key it when that happens, or keep what it needs directly rather than looking it up again later.
+  - `token_replacer` plugins are now called from the template preview as well as during processing. Previously the preview called them without a `context`, which every plugin needing one rejected, and the resulting error was discarded - so plugin tokens were always left raw in the preview with no indication why.
+    - The preview now passes `context` and `dummy_screen_shots=True`. A plugin that fills image tokens should render a placeholder while that flag is set, as nothing has been uploaded at that point in the workflow.
+    - The preview only calls the plugin when the selected template belongs to exactly one tracker, which matches how processing calls it. A template shared by several trackers (or assigned to none) has its plugin tokens left as they are.
+    - A plugin error during preview is now reported instead of discarded. **This affects existing plugins**: one that has always failed in the preview will begin surfacing that failure, where before it failed silently.
 - Improved the visuals of tracker format override widget.
 - File rename no longer happens during processing stage.
 - Updated dependencies:

--- a/src/frontend/custom_widgets/template_selector.py
+++ b/src/frontend/custom_widgets/template_selector.py
@@ -629,33 +629,40 @@ class TemplateSelector(QWidget):
                 self.text_edit.setReadOnly(False)
                 raise
 
-            try:
-                if self.config.settings.general.enable_plugins:
-                    token_replacer_plugin = self.config.settings.plugins.token_replacer
-                    if token_replacer_plugin:
-                        plugin = self.config.plugin_registry.plugins[
-                            token_replacer_plugin
-                        ].token_replacer
-                        if plugin and callable(plugin):
-                            selected_template = self.template_combo.currentText()
-                            tracker_s = [
-                                tracker
-                                for tracker, tracker_settings in self.config.settings.trackers.by_selection().items()
-                                if tracker_settings.nfo_template == selected_template
-                            ]
-                            replace_tokens = plugin(
-                                config=self.config, input_str=nfo, tracker_s=tracker_s
-                            )
-                            nfo = replace_tokens if replace_tokens else nfo
-            except Exception:
-                # we attempt to execute the plugin, but since some data is filled in process step
-                # it might not be available.
-                pass
-
-            self.text_edit.setPlainText(nfo)
+            self.text_edit.setPlainText(self._apply_token_replacer_plugin(nfo))
         else:
             self.text_edit.setReadOnly(False)
             self.text_edit.setPlainText(self.old_text if self.old_text else "")
+
+    def _apply_token_replacer_plugin(self, nfo: str) -> str:
+        """Fill the token replacer plugin's tokens for the preview.
+
+        Returns the NFO unchanged when no plugin applies, or when the plugin
+        cannot render.
+        """
+        try:
+            if self.config.settings.general.enable_plugins:
+                token_replacer_plugin = self.config.settings.plugins.token_replacer
+                if token_replacer_plugin:
+                    plugin = self.config.plugin_registry.plugins[
+                        token_replacer_plugin
+                    ].token_replacer
+                    if plugin and callable(plugin):
+                        selected_template = self.template_combo.currentText()
+                        tracker_s = [
+                            tracker
+                            for tracker, tracker_settings in self.config.settings.trackers.by_selection().items()
+                            if tracker_settings.nfo_template == selected_template
+                        ]
+                        replace_tokens = plugin(
+                            config=self.config, input_str=nfo, tracker_s=tracker_s
+                        )
+                        nfo = replace_tokens if replace_tokens else nfo
+        except Exception:
+            # we attempt to execute the plugin, but since some data is filled in process step
+            # it might not be available.
+            pass
+        return nfo
 
     @Slot()
     def maximize_template(self) -> None:

--- a/src/frontend/custom_widgets/template_selector.py
+++ b/src/frontend/custom_widgets/template_selector.py
@@ -42,6 +42,7 @@ from src.frontend.custom_widgets.token_table import TokenTable
 from src.frontend.global_signals import GSigs
 from src.frontend.utils.qtawesome_theme_swapper import QTAThemeSwap
 from src.frontend.wizards.sandbox_wizard import SandboxMainWindow
+from src.logger.nfo_forge_logger import LOG
 
 if TYPE_CHECKING:
     from src.frontend.windows.main_window import MainWindow
@@ -637,32 +638,60 @@ class TemplateSelector(QWidget):
     def _apply_token_replacer_plugin(self, nfo: str) -> str:
         """Fill the token replacer plugin's tokens for the preview.
 
-        Returns the NFO unchanged when no plugin applies, or when the plugin
-        cannot render.
+        Returns the NFO unchanged when no plugin applies, when the template does
+        not belong to exactly one tracker, or when the plugin fails. A preview is
+        not a run: a plugin that cannot render here must not stop the user
+        editing, so a failure is reported and the host's own output kept.
         """
+        if not self.config.settings.general.enable_plugins:
+            return nfo
+        token_replacer_plugin = self.config.settings.plugins.token_replacer
+        if not token_replacer_plugin:
+            return nfo
+        plugin = self.config.plugin_registry.plugins[
+            token_replacer_plugin
+        ].token_replacer
+        if not plugin or not callable(plugin):
+            return nfo
+
+        selected_template = self.template_combo.currentText()
+        tracker_s = [
+            tracker
+            for tracker, tracker_settings in self.config.settings.trackers.by_selection().items()
+            if tracker_settings.nfo_template == selected_template
+        ]
+        # processing always calls the plugin for exactly one tracker, so a template
+        # shared by several (or wired to none) has no format to render as: leave
+        # its tokens alone rather than guess one
+        if len(tracker_s) != 1:
+            return nfo
+
         try:
-            if self.config.settings.general.enable_plugins:
-                token_replacer_plugin = self.config.settings.plugins.token_replacer
-                if token_replacer_plugin:
-                    plugin = self.config.plugin_registry.plugins[
-                        token_replacer_plugin
-                    ].token_replacer
-                    if plugin and callable(plugin):
-                        selected_template = self.template_combo.currentText()
-                        tracker_s = [
-                            tracker
-                            for tracker, tracker_settings in self.config.settings.trackers.by_selection().items()
-                            if tracker_settings.nfo_template == selected_template
-                        ]
-                        replace_tokens = plugin(
-                            config=self.config, input_str=nfo, tracker_s=tracker_s
-                        )
-                        nfo = replace_tokens if replace_tokens else nfo
-        except Exception:
-            # we attempt to execute the plugin, but since some data is filled in process step
-            # it might not be available.
-            pass
-        return nfo
+            replace_tokens = plugin(
+                config=self.config,
+                context=self.context,
+                input_str=nfo,
+                tracker_s=tracker_s,
+                tracker_images=None,
+                # nothing is uploaded until the process page, so a plugin's image
+                # tokens stand in for now
+                dummy_screen_shots=True,
+            )
+        except Exception as plugin_error:
+            # reported rather than swallowed: leaving the tokens raw without a word
+            # is what makes a working template look broken
+            LOG.warning(
+                LOG.LOG_SOURCE.FE,
+                f"Token replacer plugin failed during preview: {plugin_error}",
+            )
+            QMessageBox.warning(
+                self,
+                "Plugin Preview",
+                "The token replacer plugin could not fill its tokens in this "
+                f"preview, so they are left as they are.\n\n{plugin_error}",
+            )
+            return nfo
+        return replace_tokens if replace_tokens else nfo
 
     @Slot()
     def maximize_template(self) -> None:

--- a/tests/test_frontend/test_template_selector_widget.py
+++ b/tests/test_frontend/test_template_selector_widget.py
@@ -11,6 +11,7 @@ from src.frontend.custom_widgets.template_selector import (
     TemplateSelector,
     saved_status_message,
 )
+from src.plugins.plugin_payload import PluginPayload
 
 
 def _paths(tmp_path: Path) -> ConfigPaths:
@@ -203,3 +204,89 @@ def test_status_message_is_singular_for_one_unknown_token() -> None:
 
 def test_status_message_is_plural_for_several_unknown_tokens() -> None:
     assert saved_status_message(3) == "Saved template - 3 unrecognized tokens"
+
+
+def _selector_with_plugin(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    plugin: object,
+    template_name: str = "shared_template",
+    assign_to: int = 1,
+) -> TemplateSelector:
+    """A selector wired to a fake token replacer plugin.
+
+    ``assign_to`` is how many trackers point their NFO template at
+    ``template_name``, which is what decides whether the plugin is called at all.
+    """
+    selector = _make_selector(tmp_path, monkeypatch)
+    selector.config.settings.general.enable_plugins = True
+    selector.config.settings.plugins.token_replacer = "fake_plugin"
+    selector.config.plugin_registry.plugins["fake_plugin"] = PluginPayload(
+        name="fake_plugin", token_replacer=plugin
+    )
+    for tracker in list(selector.config.settings.trackers.by_selection())[:assign_to]:
+        selector.config.settings.trackers.by_selection()[
+            tracker
+        ].nfo_template = template_name
+    selector.template_combo.addItem(template_name)
+    selector.template_combo.setCurrentText(template_name)
+    return selector
+
+
+def test_preview_passes_the_context_and_the_dummy_flag_to_the_plugin(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # the preview used to omit context entirely, which every plugin needing one
+    # rejected, leaving its tokens raw
+    seen: dict = {}
+
+    def fake_plugin(**kwargs):
+        seen.update(kwargs)
+        return "filled"
+
+    selector = _selector_with_plugin(tmp_path, monkeypatch, fake_plugin)
+
+    assert selector._apply_token_replacer_plugin("{plugin_token}") == "filled"
+    assert seen["context"] is selector.context
+    assert seen["dummy_screen_shots"] is True
+    assert seen["tracker_images"] is None
+    assert len(seen["tracker_s"]) == 1
+
+
+def test_preview_skips_the_plugin_when_the_template_is_not_unique_to_one_tracker(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # processing always calls the plugin for exactly one tracker; with two there
+    # is no format to render as, so the tokens are left rather than guessed at
+    calls = []
+
+    def fake_plugin(**kwargs):
+        calls.append(kwargs)
+        return "filled"
+
+    selector = _selector_with_plugin(tmp_path, monkeypatch, fake_plugin, assign_to=2)
+
+    assert selector._apply_token_replacer_plugin("{plugin_token}") == "{plugin_token}"
+    assert calls == []
+
+
+def test_preview_reports_a_plugin_failure_instead_of_discarding_it(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # the failure used to be swallowed, so a plugin that could not render looked
+    # identical to a broken template
+    warnings = []
+
+    def fake_plugin(**kwargs):
+        raise ValueError("no images for Aither")
+
+    monkeypatch.setattr(
+        "src.frontend.custom_widgets.template_selector.QMessageBox.warning",
+        lambda *args, **kwargs: warnings.append(args),
+    )
+    selector = _selector_with_plugin(tmp_path, monkeypatch, fake_plugin)
+
+    # the host's own output survives a plugin failure
+    assert selector._apply_token_replacer_plugin("{plugin_token}") == "{plugin_token}"
+    assert len(warnings) == 1
+    assert "no images for Aither" in warnings[0][2]


### PR DESCRIPTION
## Problem

The template preview called the token replacer plugin without a `context`, which any plugin needing one rejects, and then discarded the resulting error:

```python
except Exception:
    # we attempt to execute the plugin, but since some data is filled in process step
    # it might not be available.
    pass
```

So plugin tokens were always left raw in the preview with nothing to say why. A plugin's own unfilled-token checks never ran either, meaning a malformed template went unreported until processing.

## Changes

Three commits, split so the refactor can be reviewed as a no-op:

- **`docs:`** records plugin-facing breaking changes already on dev that were never written down: run state moving from `ConfigManager` to `ProcessingContext`, and `MediaInputPayload` replacing its single encode/MediaInfo pair with path-keyed collections. It also notes that input paths are not stable for the length of a run, since the rename page re-points every path-keyed field at the renamed media.
- **`refactor:`** extracts the preview's plugin call into `_apply_token_replacer_plugin`. No behaviour change, the body is identical including the swallowed exception. `preview_template` runs the template read, the prompt token dialog and the host's own `TokenReplacer` before it reaches the plugin, so the call could not be exercised without standing all of that up first.
- **`fix:`** the change itself.

The fix:

- Passes `context` and `dummy_screen_shots=True`, so a plugin can stand in for the image tokens it cannot fill before anything has been uploaded.
- Only calls the plugin when the selected template belongs to exactly one tracker, matching how `process.py` calls it. A template shared by several trackers, or assigned to none, has no format to render as, so its tokens are left alone rather than guessed at.
- Reports a plugin failure instead of discarding it, keeping the host's own output so a preview failure never blocks editing.

## Impact on existing plugins

A plugin that has always failed during preview will now surface that failure rather than failing silently. This is called out in the changelog. Nothing on the processing path changes.

## Testing

`505 passed`, `ruff` clean, `mypy --strict` clean on the changed module. Three new tests cover the arguments handed to the plugin, the single-tracker gate, and that a plugin failure is reported while the host's own output survives.