### PR TITLE
feat: add media type, anime, and Atmos template tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,12 +24,16 @@
     - `{episode_title}`- Title parsed from media databases with minimal formatting.
     - `{episode_title_clean}`- Clean title parsed from media databases.
     - `{episode_title_exact}`- Title parsed from media databases with no modifications.
+    - `{audio_codec_no_atmos}`- Audio codec with Atmos removed (TrueHD).
+    - `{atmos}`- Returns 'Atmos' if Atmos was detected.
   - **NfoTokens**:
     - `{total_seasons}`- Total seasons in series.
     - `{total_episodes}`- Total episodes in season/series.
     - `{episode_mediainfo}` - Synopsis of all episodes mediainfo.
     - `{episode_metadata}` - Synopsis of all episodes metadata.
     - `{episode_metadata_mediainfo}` - Synopsis of all episodes metadata + mediainfo.
+    - `{media_type}`- Media type (Movie/Series).
+    - `{is_anime}`- Returns 'Anime' if the release is anime.
 - Built **Series Mapper** _(for series)_:
   - New widget that will allow the user to match their episode(s) with aired, dvd, or absolute data parsed from **TVDB**. This data will allow NfoForge to accurately rename/manage files throughout the rest of the work flow.
   - New wizard page for the user to access this during the workflow.

--- a/docs/snippets/generated_templates/file_tokens.md
+++ b/docs/snippets/generated_templates/file_tokens.md
@@ -1,12 +1,14 @@
 | Token | Description |
 |-------|-------------|
 | `{air_date}` | Air date (series first aired - UTC) |
+| `{atmos}` | Returns 'Atmos' if Atmos was detected |
 | `{audio_bitrate}` | Audio bitrate (640000) |
 | `{audio_bitrate_formatted}` | Audio bitrate formatted (640 kb/s) |
 | `{audio_channel_s}` | Audio channels (5.1) |
 | `{audio_channel_s_i}` | Audio channels (6) |
 | `{audio_channel_s_layout}` | Audio channel layout (L R C LFE Ls Rs Lb Rb) |
 | `{audio_codec}` | Audio codec |
+| `{audio_codec_no_atmos}` | Audio codec with Atmos removed (TrueHD) |
 | `{audio_commercial_name}` | Audio commercial name (Dolby Digital Plus) |
 | `{audio_compression}` | Audio compression (Lossy) |
 | `{audio_format_info}` | Audio format info (Enhanced AC-3) |

--- a/docs/snippets/generated_templates/nfo_tokens.md
+++ b/docs/snippets/generated_templates/nfo_tokens.md
@@ -12,10 +12,12 @@
 | `{{ file_size }}` | File size (7.89 GiB) |
 | `{{ file_size_bytes }}` | File size in bytes (8469985859) |
 | `{{ format_profile }}` | Format Profile (Main@L4) |
+| `{{ is_anime }}` | Returns 'Anime' if the release is anime |
 | `{{ media_file }}` | Media filename with extension |
 | `{{ media_file_no_ext }}` | Media filename without extension |
 | `{{ media_info }}` | Mediainfo output with filepath cleansed |
 | `{{ media_info_short }}` | Shortened Mediainfo output with filepath cleansed |
+| `{{ media_type }}` | Media type (Movie/Series) |
 | `{{ program_info }}` | NfoForge vx.x.x |
 | `{{ proper }}` | Returns 'PROPER' if proper was detected |
 | `{{ proper_n }}` | Proper and proper number if exists (PROPER2) |

--- a/docs/view/token-replacer/multi-line.md
+++ b/docs/view/token-replacer/multi-line.md
@@ -167,7 +167,7 @@ Absolute episode        : {{ episode_number_absolute }}
 
 **Audio codec and Atmos:**
 
-`{{ audio_codec_no_atmos }}` is the codec with the Atmos tag removed, and `{{ atmos }}` is the tag on its own. Together they rebuild `{{ audio_codec }}`.
+`{{ audio_codec_no_atmos }}` is the codec with the Atmos tag removed, and `{{ atmos }}` is the tag on its own. Together they rebuild `{{ audio_codec }}`, with the tag always rendered as `Atmos`.
 
 ```jinja
 Audio                   : {{ audio_codec_no_atmos }} {{ audio_channel_s }}{% if atmos %} + {{ atmos }}{% endif %}

--- a/docs/view/token-replacer/multi-line.md
+++ b/docs/view/token-replacer/multi-line.md
@@ -143,6 +143,42 @@ Title                   : Big Buck Bunny (2008)
 Edition                 : Extended Cut
 ```
 
+**Media type and anime conditionals:**
+
+`{{ media_type }}` renders `Movie` or `Series`, and `{{ is_anime }}` renders `Anime` or nothing at all. Both let one template serve every release.
+
+```jinja
+Info
+Title                   : {{ title_exact }} {{ release_year_parentheses }}
+{% if media_type == "Series" %}
+Season                  : {{ season_number }}
+Episodes                : {{ total_episodes }}
+{% else %}
+Runtime                 : {{ duration_short }}
+{% endif %}
+{% if is_anime %}
+Absolute episode        : {{ episode_number_absolute }}
+{% endif %}
+```
+
+<!-- prettier-ignore -->
+!!! info
+    The comparison is case sensitive: `media_type == "series"` never matches. `{{ is_anime }}` renders an empty string when the release is not anime, which Jinja treats as false, so `{% if is_anime %}` works on its own.
+
+**Audio codec and Atmos:**
+
+`{{ audio_codec_no_atmos }}` is the codec with the Atmos tag removed, and `{{ atmos }}` is the tag on its own. Together they rebuild `{{ audio_codec }}`.
+
+```jinja
+Audio                   : {{ audio_codec_no_atmos }} {{ audio_channel_s }}{% if atmos %} + {{ atmos }}{% endif %}
+```
+
+**Output:**
+
+```text
+Audio                   : TrueHD 7.1 + Atmos
+```
+
 ### Jinja Filters
 
 While I can't go over all of what jinja [supports](https://jinja.palletsprojects.com/en/stable/templates/#list-of-builtin-filters) _(it would take forever and they have very clean documentation)_, I figured I could go over a quick useful example called the **replace** filter. This works identically to Pythons built in string function replace.

--- a/src/backend/process.py
+++ b/src/backend/process.py
@@ -64,6 +64,7 @@ from src.backend.trackers.morethantv import MTVUploader
 from src.backend.trackers.torrentleech import TLUploader
 from src.backend.trackers.unit3d_base import Unit3dBaseSearch, Unit3dBaseUploader
 from src.backend.trackers.utils import format_image_tag
+from src.backend.utils.anime import is_anime_release
 from src.backend.utils.image_optimizer import MultiProcessImageOptimizer
 from src.backend.utils.images import (
     format_image_data_to_comparison,
@@ -78,7 +79,6 @@ from src.context.processing_context import ProcessingContext
 from src.enums.image_host import ImageHost, ImageSource
 from src.enums.media_type import MediaType
 from src.enums.multi_episode_style import MultiEpisodeStyle
-from src.enums.series import EpisodeFormat
 from src.enums.token_replacer import UnfilledTokenRemoval
 from src.enums.torrent_client import TorrentClientSelection
 from src.enums.tracker_selection import TrackerSelection
@@ -91,17 +91,6 @@ from src.payloads.series import SeriesReleaseInfo, build_series_release_info
 from src.payloads.tracker_search_result import TrackerSearchResult
 from src.payloads.trackers import TrackerInfo
 from src.payloads.watch_folder import WatchFolder
-
-
-def _is_anime_release(
-    media_input: MediaInputPayload, media_search: MediaSearchPayload
-) -> bool:
-    """Return whether confirmed metadata or user-selected mapping marks anime."""
-    return bool(
-        media_search.anilist_id
-        or media_search.anilist_data
-        or media_input.series_episode_format is EpisodeFormat.ANIME_ABSOLUTE
-    )
 
 
 class ProcessBackEnd:
@@ -1308,7 +1297,7 @@ class ProcessBackEnd:
                 mediainfo_obj=mediainfo_obj,
                 media_type=media_type,
                 is_pack=release_info.is_pack,
-                is_anime=_is_anime_release(context.media_input, media_search_obj),
+                is_anime=is_anime_release(context.media_input, media_search_obj),
                 timeout=self.config.settings.general.timeout,
             )
         elif tracker is TrackerSelection.BEYOND_HD:

--- a/src/backend/token_replacer.py
+++ b/src/backend/token_replacer.py
@@ -108,6 +108,8 @@ class TokenReplacer:
         # series caches
         "_series_counts",
         "_series_episode_cache",
+        # audio codec cache
+        "_audio_codec_cache",
     )
 
     def __init__(
@@ -251,6 +253,10 @@ class TokenReplacer:
         # series counts and episode lookups have different key/value shapes
         self._series_counts: dict[str, int] = {}
         self._series_episode_cache: dict[int, dict[int, dict[str, Any]]] = {}
+
+        # the conventions file is read from disk per lookup, and three tokens
+        # share the result, so resolve it once per instance
+        self._audio_codec_cache: str | None = None
 
         if not self.flatten and not self.jinja_engine:
             raise AttributeError(
@@ -1137,20 +1143,27 @@ class TokenReplacer:
 
         return self._optional_user_input(layout, token_data)
 
-    def _audio_codec(self, token_data: TokenData) -> str:
-        audio_codec = self.guess_name.get("audio_codec", "")
-        if self.media_info_obj and self.media_info_obj.audio_tracks:
-            audio_codecs = AudioCodecs()
-            # TODO: remove hard coded json path later?
-            audio_convention_path = Path(
-                RUNTIME_DIR / "config" / "audio_conventions" / "default.json"
-            )
-            audio_codec = audio_codecs.get_codec(
-                self.media_info_obj.audio_tracks[0],
-                audio_convention_path,
-            )
+    def _resolved_audio_codec(self) -> str:
+        """Codec name from the conventions file, computed once per instance."""
+        if self._audio_codec_cache is None:
+            # guessit can hand back a list here; it already reached output via
+            # f-string interpolation downstream, so coercing early is a no-op
+            codec = str(self.guess_name.get("audio_codec", "") or "")
+            if self.media_info_obj and self.media_info_obj.audio_tracks:
+                audio_codecs = AudioCodecs()
+                # TODO: remove hard coded json path later?
+                audio_convention_path = Path(
+                    RUNTIME_DIR / "config" / "audio_conventions" / "default.json"
+                )
+                codec = audio_codecs.get_codec(
+                    self.media_info_obj.audio_tracks[0],
+                    audio_convention_path,
+                )
+            self._audio_codec_cache = codec
+        return self._audio_codec_cache
 
-        return self._optional_user_input(audio_codec, token_data)
+    def _audio_codec(self, token_data: TokenData) -> str:
+        return self._optional_user_input(self._resolved_audio_codec(), token_data)
 
     def _audio_commercial_name(self, token_data: TokenData) -> str:
         commercial_name = ""

--- a/src/backend/token_replacer.py
+++ b/src/backend/token_replacer.py
@@ -789,7 +789,10 @@ class TokenReplacer:
         return ""
 
     def _nfo_tokens(self, token_data: TokenData) -> str | Sequence[Any] | None:
-        if token_data.bracket_token == Tokens.CHAPTER_TYPE.token:
+        if token_data.bracket_token == Tokens.MEDIA_TYPE.token:
+            return self._media_type(token_data)
+
+        elif token_data.bracket_token == Tokens.CHAPTER_TYPE.token:
             return self._chapter_type(token_data)
 
         elif token_data.bracket_token == Tokens.FORMAT_PROFILE.token:
@@ -2745,6 +2748,16 @@ class TokenReplacer:
             tvdb_counter=self._count_tvdb_episodes,
             token_data=token_data,
         )
+
+    def _media_type(self, token_data: TokenData) -> str:
+        # `media_input_obj` rather than `media_search_obj`: both receive the
+        # value in the same statement when the user confirms a match, but this
+        # one is a required constructor argument while `media_search_obj` falls
+        # back to an empty payload. It is also what `is_series_mode` reads.
+        media_type = self.media_input_obj.media_type
+        if not media_type:
+            return ""
+        return self._optional_user_input(str(media_type), token_data)
 
     def _program_info(self, token_data: TokenData) -> str:
         return self._optional_user_input(f"{program_name} v{__version__}", token_data)

--- a/src/backend/token_replacer.py
+++ b/src/backend/token_replacer.py
@@ -15,6 +15,7 @@ from jinja2 import meta
 from pymediainfo import MediaInfo, Track
 
 from src.backend.tokens import FileToken, NfoToken, TokenData, Tokens, TokenType
+from src.backend.utils.anime import is_anime_release
 from src.backend.utils.audio_channels import ParseAudioChannels
 from src.backend.utils.audio_codecs import AudioCodecs
 from src.backend.utils.guessit_helpers import get_guessit_title
@@ -791,6 +792,9 @@ class TokenReplacer:
     def _nfo_tokens(self, token_data: TokenData) -> str | Sequence[Any] | None:
         if token_data.bracket_token == Tokens.MEDIA_TYPE.token:
             return self._media_type(token_data)
+
+        elif token_data.bracket_token == Tokens.IS_ANIME.token:
+            return self._is_anime(token_data)
 
         elif token_data.bracket_token == Tokens.CHAPTER_TYPE.token:
             return self._chapter_type(token_data)
@@ -2758,6 +2762,13 @@ class TokenReplacer:
         if not media_type:
             return ""
         return self._optional_user_input(str(media_type), token_data)
+
+    def _is_anime(self, token_data: TokenData) -> str:
+        # A word rather than a bool: Jinja treats any non-empty string as true,
+        # so returning "False" here would make {% if is_anime %} always fire.
+        if not is_anime_release(self.media_input_obj, self.media_search_obj):
+            return ""
+        return self._optional_user_input("Anime", token_data)
 
     def _program_info(self, token_data: TokenData) -> str:
         return self._optional_user_input(f"{program_name} v{__version__}", token_data)

--- a/src/backend/token_replacer.py
+++ b/src/backend/token_replacer.py
@@ -1155,7 +1155,9 @@ class TokenReplacer:
         return self._optional_user_input(layout, token_data)
 
     def _resolved_audio_codec(self) -> str:
-        """Codec name from the conventions file, computed once per instance."""
+        """Audio codec for the primary file, computed once per instance (conventions
+        file when MediaInfo is available, guessit otherwise).
+        """
         if self._audio_codec_cache is None:
             # guessit can hand back a list here; it already reached output via
             # f-string interpolation downstream, so coercing early is a no-op
@@ -1183,10 +1185,11 @@ class TokenReplacer:
 
     def _atmos(self, token_data: TokenData) -> str:
         # reads the same resolved codec the other two audio tokens use, so the
-        # three can never disagree
-        if not self._ATMOS_RE.search(self._resolved_audio_codec()):
-            return ""
-        return self._optional_user_input("Atmos", token_data)
+        # three can never disagree. The empty case still routes through
+        # _optional_user_input because that call also normalises token_string
+        # (stripping any :opt= wrapper or |filter suffix) for _format_token_string.
+        atmos = "Atmos" if self._ATMOS_RE.search(self._resolved_audio_codec()) else ""
+        return self._optional_user_input(atmos, token_data)
 
     def _audio_commercial_name(self, token_data: TokenData) -> str:
         commercial_name = ""

--- a/src/backend/token_replacer.py
+++ b/src/backend/token_replacer.py
@@ -59,6 +59,11 @@ class TokenReplacer:
         r"^(?:tba|episode\s*\d+)$", re.IGNORECASE
     )
 
+    # matches the Atmos suffix the audio conventions file produces ("DDP Atmos",
+    # "TrueHD Atmos"). Leading whitespace is part of the pattern so stripping
+    # leaves "DDP" rather than "DDP ".
+    _ATMOS_RE = re.compile(r"\s*\bAtmos\b", re.IGNORECASE)
+
     __slots__ = (
         # __init__
         "media_input_obj",
@@ -607,6 +612,12 @@ class TokenReplacer:
 
         elif token_data.bracket_token == Tokens.AUDIO_CODEC.token:
             return self._audio_codec(token_data)
+
+        elif token_data.bracket_token == Tokens.AUDIO_CODEC_NO_ATMOS.token:
+            return self._audio_codec_no_atmos(token_data)
+
+        elif token_data.bracket_token == Tokens.ATMOS.token:
+            return self._atmos(token_data)
 
         elif token_data.bracket_token == Tokens.AUDIO_COMMERCIAL_NAME.token:
             return self._audio_commercial_name(token_data)
@@ -1164,6 +1175,18 @@ class TokenReplacer:
 
     def _audio_codec(self, token_data: TokenData) -> str:
         return self._optional_user_input(self._resolved_audio_codec(), token_data)
+
+    def _audio_codec_no_atmos(self, token_data: TokenData) -> str:
+        # trailing strip covers a conventions file that puts the word first
+        codec = self._ATMOS_RE.sub("", self._resolved_audio_codec()).strip()
+        return self._optional_user_input(codec, token_data)
+
+    def _atmos(self, token_data: TokenData) -> str:
+        # reads the same resolved codec the other two audio tokens use, so the
+        # three can never disagree
+        if not self._ATMOS_RE.search(self._resolved_audio_codec()):
+            return ""
+        return self._optional_user_input("Atmos", token_data)
 
     def _audio_commercial_name(self, token_data: TokenData) -> str:
         commercial_name = ""

--- a/src/backend/tokens.py
+++ b/src/backend/tokens.py
@@ -211,6 +211,7 @@ class Tokens:
     )
 
     # NFO Tokens
+    MEDIA_TYPE = NfoToken("{media_type}", "Media type (Movie/Series)")
     CHAPTER_TYPE = NfoToken(
         "{chapter_type}", "Chapter type (Named / Numbered (1 - 10) / Tagged)"
     )

--- a/src/backend/tokens.py
+++ b/src/backend/tokens.py
@@ -68,6 +68,10 @@ class Tokens:
         "{audio_channel_s_layout}", "Audio channel layout (L R C LFE Ls Rs Lb Rb)"
     )
     AUDIO_CODEC = FileToken("{audio_codec}", "Audio codec")
+    AUDIO_CODEC_NO_ATMOS = FileToken(
+        "{audio_codec_no_atmos}", "Audio codec with Atmos removed (TrueHD)"
+    )
+    ATMOS = FileToken("{atmos}", "Returns 'Atmos' if Atmos was detected")
     AUDIO_COMMERCIAL_NAME = FileToken(
         "{audio_commercial_name}", "Audio commercial name (Dolby Digital Plus)"
     )

--- a/src/backend/tokens.py
+++ b/src/backend/tokens.py
@@ -212,6 +212,7 @@ class Tokens:
 
     # NFO Tokens
     MEDIA_TYPE = NfoToken("{media_type}", "Media type (Movie/Series)")
+    IS_ANIME = NfoToken("{is_anime}", "Returns 'Anime' if the release is anime")
     CHAPTER_TYPE = NfoToken(
         "{chapter_type}", "Chapter type (Named / Numbered (1 - 10) / Tagged)"
     )

--- a/src/backend/utils/anime.py
+++ b/src/backend/utils/anime.py
@@ -1,0 +1,21 @@
+"""Shared anime detection for the release being processed.
+
+Lives here rather than in `process.py` because `token_replacer.py` needs it
+too, and `process.py` imports `TokenReplacer` -- importing back the other way
+would be circular.
+"""
+
+from src.enums.series import EpisodeFormat
+from src.payloads.media_inputs import MediaInputPayload
+from src.payloads.media_search import MediaSearchPayload
+
+
+def is_anime_release(
+    media_input: MediaInputPayload, media_search: MediaSearchPayload
+) -> bool:
+    """Return whether confirmed metadata or user-selected mapping marks anime."""
+    return bool(
+        media_search.anilist_id
+        or media_search.anilist_data
+        or media_input.series_episode_format is EpisodeFormat.ANIME_ABSOLUTE
+    )

--- a/tests/test_backend/test_token_replacer_movies.py
+++ b/tests/test_backend/test_token_replacer_movies.py
@@ -6,6 +6,7 @@ from src.backend.utils.example_parsed_movie_data import (
 )
 from src.enums.media_type import MediaType
 from src.enums.token_replacer import UnfilledTokenRemoval
+from src.nf_jinja2 import Jinja2TemplateEngine
 from src.payloads.media_search import MediaSearchPayload
 
 
@@ -72,3 +73,28 @@ def test_title_tokens_use_first_guessit_title_when_list_shaped(
     )
 
     assert replacer._title_exact(_td()) == "Primary Title"
+
+
+def test_media_type_token_renders_movie() -> None:
+    output = TokenReplacer(
+        media_input_obj=EXAMPLE_MEDIA_INPUT_PAYLOAD,
+        token_string="{{ media_type }}",
+        media_search_obj=EXAMPLE_SEARCH_PAYLOAD,
+        jinja_engine=Jinja2TemplateEngine(),
+    ).get_output()
+
+    assert output == "Movie"
+
+
+def test_media_type_token_drives_the_movie_branch_of_a_conditional() -> None:
+    # The shape the docs tell users to write. Asserting on the rendered branch
+    # rather than on the bare value means a change to what {media_type}
+    # returns breaks a test that looks like a real template.
+    output = TokenReplacer(
+        media_input_obj=EXAMPLE_MEDIA_INPUT_PAYLOAD,
+        token_string='{% if media_type == "Series" %}series{% else %}movie{% endif %}',
+        media_search_obj=EXAMPLE_SEARCH_PAYLOAD,
+        jinja_engine=Jinja2TemplateEngine(),
+    ).get_output()
+
+    assert output == "movie"

--- a/tests/test_backend/test_token_replacer_movies.py
+++ b/tests/test_backend/test_token_replacer_movies.py
@@ -1,5 +1,6 @@
 from src.backend.token_replacer import TokenReplacer
 from src.backend.tokens import FileToken, TokenData
+from src.backend.utils.audio_codecs import AudioCodecs
 from src.backend.utils.example_parsed_movie_data import (
     EXAMPLE_MEDIA_INPUT_PAYLOAD,
     EXAMPLE_SEARCH_PAYLOAD,
@@ -113,3 +114,24 @@ def test_is_anime_token_renders_for_an_anime_film() -> None:
     ).get_output()
 
     assert output == "Anime"
+
+
+def test_audio_codec_reads_the_conventions_file_once_per_instance(monkeypatch) -> None:
+    # Three tokens now share this value. Without the cache each one re-reads
+    # and re-parses the conventions JSON on every occurrence in a template.
+    calls: list[object] = []
+    original = AudioCodecs.get_codec
+
+    def counting_get_codec(self, mi_obj, json_path):
+        calls.append(json_path)
+        return original(self, mi_obj, json_path)
+
+    monkeypatch.setattr(AudioCodecs, "get_codec", counting_get_codec)
+
+    replacer = _movie_replacer()
+    first = replacer._audio_codec(_td())
+    second = replacer._audio_codec(_td())
+
+    assert first == "TrueHD Atmos"
+    assert second == "TrueHD Atmos"
+    assert len(calls) == 1

--- a/tests/test_backend/test_token_replacer_movies.py
+++ b/tests/test_backend/test_token_replacer_movies.py
@@ -153,3 +153,20 @@ def test_audio_codec_no_atmos_plus_atmos_reconstructs_audio_codec() -> None:
     rebuilt = f"{replacer._audio_codec_no_atmos(_td())} {replacer._atmos(_td())}"
 
     assert rebuilt.strip() == replacer._audio_codec(_td())
+
+
+def test_audio_codec_tokens_resolve_through_the_token_string() -> None:
+    # The direct-resolver tests above would still pass if the registry entry
+    # or the dispatch branch were deleted; this one goes through get_output()
+    # so it fails if the tokens stop being reachable.
+    output = TokenReplacer(
+        media_input_obj=EXAMPLE_MEDIA_INPUT_PAYLOAD,
+        token_string="{audio_codec_no_atmos}.{atmos}",
+        media_search_obj=EXAMPLE_SEARCH_PAYLOAD,
+        flatten=True,
+        file_name_mode=True,
+        token_type=FileToken,
+        unfilled_token_mode=UnfilledTokenRemoval.TOKEN_ONLY,
+    ).get_output()
+
+    assert output == "TrueHD.Atmos.mkv"

--- a/tests/test_backend/test_token_replacer_movies.py
+++ b/tests/test_backend/test_token_replacer_movies.py
@@ -98,3 +98,18 @@ def test_media_type_token_drives_the_movie_branch_of_a_conditional() -> None:
     ).get_output()
 
     assert output == "movie"
+
+
+def test_is_anime_token_renders_for_an_anime_film() -> None:
+    # AniList is queried on Animation genre plus Japanese original language,
+    # with no media type condition, so anime films resolve too.
+    output = TokenReplacer(
+        media_input_obj=EXAMPLE_MEDIA_INPUT_PAYLOAD,
+        token_string="{{ is_anime }}",
+        media_search_obj=MediaSearchPayload(
+            media_type=MediaType.MOVIE, anilist_id="123"
+        ),
+        jinja_engine=Jinja2TemplateEngine(),
+    ).get_output()
+
+    assert output == "Anime"

--- a/tests/test_backend/test_token_replacer_movies.py
+++ b/tests/test_backend/test_token_replacer_movies.py
@@ -135,3 +135,21 @@ def test_audio_codec_reads_the_conventions_file_once_per_instance(monkeypatch) -
     assert first == "TrueHD Atmos"
     assert second == "TrueHD Atmos"
     assert len(calls) == 1
+
+
+def test_audio_codec_tokens_split_atmos_out() -> None:
+    replacer = _movie_replacer()
+
+    assert replacer._audio_codec(_td()) == "TrueHD Atmos"
+    assert replacer._audio_codec_no_atmos(_td()) == "TrueHD"
+    assert replacer._atmos(_td()) == "Atmos"
+
+
+def test_audio_codec_no_atmos_plus_atmos_reconstructs_audio_codec() -> None:
+    # The property the whole design rests on: both new tokens read the same
+    # resolved codec string, so they can never contradict {audio_codec}.
+    replacer = _movie_replacer()
+
+    rebuilt = f"{replacer._audio_codec_no_atmos(_td())} {replacer._atmos(_td())}"
+
+    assert rebuilt.strip() == replacer._audio_codec(_td())

--- a/tests/test_backend/test_token_replacer_series.py
+++ b/tests/test_backend/test_token_replacer_series.py
@@ -944,3 +944,27 @@ def test_is_anime_token_is_falsy_in_a_conditional_when_not_anime() -> None:
     ).get_output()
 
     assert output == "not anime"
+
+
+def _series_audio_replacer() -> TokenReplacer:
+    # `_series_replacer` builds a payload with no MediaInfo, so audio tokens
+    # would fall through to guessit. The example payload carries a real
+    # MediaInfo object whose first audio track is MLP FBA without the 16-ch
+    # variant, which is the non-Atmos case.
+    return TokenReplacer(
+        media_input_obj=EXAMPLE_MEDIA_INPUT_PAYLOAD,
+        token_string="{audio_codec}",
+        media_search_obj=EXAMPLE_SEARCH_PAYLOAD,
+        flatten=True,
+        file_name_mode=True,
+        token_type=FileToken,
+        unfilled_token_mode=UnfilledTokenRemoval.TOKEN_ONLY,
+    )
+
+
+def test_audio_codec_tokens_when_there_is_no_atmos() -> None:
+    replacer = _series_audio_replacer()
+
+    assert replacer._audio_codec(_td()) == "TrueHD"
+    assert replacer._audio_codec_no_atmos(_td()) == "TrueHD"
+    assert replacer._atmos(_td()) == ""

--- a/tests/test_backend/test_token_replacer_series.py
+++ b/tests/test_backend/test_token_replacer_series.py
@@ -13,6 +13,7 @@ from src.backend.utils.example_parsed_series_data import (
 )
 from src.enums.media_type import MediaType
 from src.enums.multi_episode_style import MultiEpisodeStyle
+from src.enums.series import EpisodeFormat
 from src.enums.token_replacer import ColonReplace, UnfilledTokenRemoval
 from src.nf_jinja2 import Jinja2TemplateEngine
 from src.payloads.media_inputs import MediaInputPayload
@@ -889,3 +890,57 @@ def test_media_type_token_drives_the_series_branch_of_a_conditional() -> None:
     ).get_output()
 
     assert output == "series"
+
+
+@pytest.mark.parametrize(
+    ("anilist_id", "anilist_data", "episode_format", "expected"),
+    [
+        ("123", None, EpisodeFormat.STANDARD, "Anime"),
+        (None, {"id": 123}, EpisodeFormat.STANDARD, "Anime"),
+        (None, None, EpisodeFormat.ANIME_ABSOLUTE, "Anime"),
+        (None, None, EpisodeFormat.STANDARD, ""),
+    ],
+)
+def test_is_anime_token_covers_each_signal(
+    anilist_id: str | None,
+    anilist_data: dict[str, int] | None,
+    episode_format: EpisodeFormat,
+    expected: str,
+) -> None:
+    # Each of the three positive signals gets its own case: a change that drops
+    # one of them from the shared helper would otherwise still pass.
+    media_file = Path("Show.S01E01.mkv")
+    media_input = MediaInputPayload(
+        input_path=media_file,
+        media_type=MediaType.SERIES,
+        file_list=[media_file],
+        file_list_mediainfo={media_file: EXAMPLE_MEDIAINFO_OBJ},
+        series_episode_format=episode_format,
+    )
+
+    output = TokenReplacer(
+        media_input_obj=media_input,
+        token_string="{{ is_anime }}",
+        media_search_obj=MediaSearchPayload(
+            media_type=MediaType.SERIES,
+            anilist_id=anilist_id,
+            anilist_data=anilist_data,
+        ),
+        jinja_engine=Jinja2TemplateEngine(),
+    ).get_output()
+
+    assert output == expected
+
+
+def test_is_anime_token_is_falsy_in_a_conditional_when_not_anime() -> None:
+    # Guards the reason the token renders "Anime"/"" instead of "True"/"False":
+    # a non-empty string is truthy in Jinja, so "False" would break every
+    # {% if is_anime %} block.
+    output = TokenReplacer(
+        media_input_obj=EXAMPLE_MEDIA_INPUT_PAYLOAD,
+        token_string="{% if is_anime %}anime{% else %}not anime{% endif %}",
+        media_search_obj=EXAMPLE_SEARCH_PAYLOAD,
+        jinja_engine=Jinja2TemplateEngine(),
+    ).get_output()
+
+    assert output == "not anime"

--- a/tests/test_backend/test_token_replacer_series.py
+++ b/tests/test_backend/test_token_replacer_series.py
@@ -867,3 +867,25 @@ def test_get_mi_synopsis_handles_no_video_track() -> None:
     out = replacer.get_mi_synopsis(fake_mi_no_video)
 
     assert isinstance(out, str)
+
+
+def test_media_type_token_renders_series() -> None:
+    output = TokenReplacer(
+        media_input_obj=EXAMPLE_MEDIA_INPUT_PAYLOAD,
+        token_string="{{ media_type }}",
+        media_search_obj=EXAMPLE_SEARCH_PAYLOAD,
+        jinja_engine=Jinja2TemplateEngine(),
+    ).get_output()
+
+    assert output == "Series"
+
+
+def test_media_type_token_drives_the_series_branch_of_a_conditional() -> None:
+    output = TokenReplacer(
+        media_input_obj=EXAMPLE_MEDIA_INPUT_PAYLOAD,
+        token_string='{% if media_type == "Series" %}series{% else %}movie{% endif %}',
+        media_search_obj=EXAMPLE_SEARCH_PAYLOAD,
+        jinja_engine=Jinja2TemplateEngine(),
+    ).get_output()
+
+    assert output == "series"

--- a/tests/test_backend/test_tracker_series_support.py
+++ b/tests/test_backend/test_tracker_series_support.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from pymediainfo import MediaInfo
 
-from src.backend.process import ProcessBackEnd, _is_anime_release
+from src.backend.process import ProcessBackEnd
 from src.backend.trackers.aither import AitherUploader
 from src.backend.trackers.beyondhd import BHDUploader
 from src.backend.trackers.darkpeers import DarkPeersUploader
@@ -26,6 +26,7 @@ from src.backend.trackers.shareisland import ShareIslandUploader
 from src.backend.trackers.torrentleech import TLUploader
 from src.backend.trackers.unit3d_base import Unit3dBaseUploader
 from src.backend.trackers.uploadcx import UploadCXUploader
+from src.backend.utils.anime import is_anime_release
 from src.enums.media_type import MediaType
 from src.enums.series import EpisodeFormat
 from src.enums.tracker_selection import TrackerSelection
@@ -172,7 +173,7 @@ def test_torrentleech_anime_signal_uses_metadata_or_series_format(
         anilist_data=anilist_data,
     )
 
-    assert _is_anime_release(media_input, media_search) is expected
+    assert is_anime_release(media_input, media_search) is expected
 
 
 @patch("src.backend.process.tl_upload", return_value=True)


### PR DESCRIPTION
Adds four template tokens so a single NFO template can serve movies and series, and so a release name can carry the audio codec and the Atmos tag separately.

## Tokens

| Token | Type | Renders |
|---|---|---|
| `{media_type}` | NfoToken | `Movie` or `Series` |
| `{is_anime}` | NfoToken | `Anime` or empty |
| `{audio_codec_no_atmos}` | FileToken | `{audio_codec}` with the Atmos tag removed |
| `{atmos}` | FileToken | `Atmos` or empty |

```jinja
{% if media_type == "Series" %}
Season                  : {{ season_number }}
Episodes                : {{ total_episodes }}
{% else %}
Runtime                 : {{ duration_short }}
{% endif %}

Audio                   : {{ audio_codec_no_atmos }} {{ audio_channel_s }}{% if atmos %} + {{ atmos }}{% endif %}
```

The two conditional tokens render a word or an empty string rather than a bool, because Jinja treats the non-empty string `"False"` as true.

`{audio_codec_no_atmos}` and `{atmos}` are FileTokens, matching the existing `{audio_codec}`, so one registration covers both rename templates and NFO templates.

## Supporting refactors

**Anime detection moved to `src/backend/utils/anime.py`.** `token_replacer.py` needs the check, but `process.py` imports `TokenReplacer`, so importing back the other way would be circular. Pure move: the function body is unchanged and its existing test moved with it.

**Audio codec resolution memoised per `TokenReplacer` instance.** `_audio_codec` re-read and re-parsed the audio conventions JSON on every call; three tokens now need that value. `_resolved_audio_codec()` computes it once per instance. Output is unchanged on both the MediaInfo and guessit paths.

Memoising also makes the split structural rather than coincidental: all three audio tokens read the same resolved string, so `{audio_codec_no_atmos}` plus `{atmos}` always reconstructs `{audio_codec}` (with the tag normalised to `Atmos`).

## Notes for review

- `{media_type}` reads `media_input_obj.media_type`, not `media_search_obj.media_type`. Both receive the value in the same statement at match time, but the former is a required constructor argument while the latter falls back to an empty payload.
- The cache sentinel is `None` rather than falsy, because an empty-string codec is a legitimate resolved value.
- No sandbox UI change was needed: the template sandbox already matches through the real search wizard, so all four tokens resolve from live data. "Clear Sandbox Input" resets the match for testing the other branch.
- `docs/snippets/generated_templates/*.md` are regenerated output from `docs_scripts/generate_token_tables.py`, not hand edits.

## Testing

540 tests passing; `ruff check` and `ruff format --check` clean. New coverage includes each of the three anime signals independently, both Atmos states from the existing fixtures, and a dispatch-level test that renders the new FileTokens through `get_output()` so the tokens cannot become unreachable while the suite stays green.
