### PR TITLE
fix: never auto-retry an upload the tracker may have received

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@
 - Series support during flow to handle mapping/renaming
 - Now checks tracker health before attempting to upload
 - Template editor now highlights tokens that will not resolve when the template renders. The highlight color is configurable in Settings > Templates, and the save status tip reports how many were found.
-- Implemented torrent upload retries with user control
+- Implemented torrent upload retries with user control.
 
 ### Changed
 

--- a/src/backend/process.py
+++ b/src/backend/process.py
@@ -482,7 +482,11 @@ class ProcessBackEnd:
 
         status_code = getattr(error, "status_code", None)
         if isinstance(status_code, int):
-            return status_code == 408 or status_code == 429 or status_code >= 500
+            # 408/429 mean the request was rejected before it could be
+            # processed. A 5xx means the tracker received and answered the
+            # request -- it may have recorded the upload before failing, so
+            # it must not be retried automatically.
+            return status_code == 408 or status_code == 429
 
         return False
 
@@ -590,7 +594,25 @@ class ProcessBackEnd:
                 if action is UploadRetryAction.CANCEL:
                     queued_status_update(str(tracker), "⏹ Cancelled")
                     raise ProcessCancelled from error
-                queued_status_update(str(tracker), "⏭ Skipped")
+                if failure.phase is UploadFailurePhase.DOWNLOAD:
+                    # The upload POST already succeeded; only fetching the
+                    # tracker's copy of the torrent failed, and the user
+                    # chose to keep the release as-is. Report this
+                    # distinctly from a genuine skip so nobody reads this as
+                    # "never uploaded" and re-uploads by hand.
+                    queued_status_update(
+                        str(tracker), "⚠️ Uploaded - tracker torrent not downloaded"
+                    )
+                    queued_text_update(
+                        f"<br /><span>Upload succeeded for <b>{tracker}</b>; kept "
+                        "after the tracker's torrent copy could not be "
+                        "downloaded</span>"
+                    )
+                else:
+                    queued_status_update(str(tracker), "⏭ Skipped")
+                    queued_text_update(
+                        "<br /><span>Skipped upload after user decision</span>"
+                    )
                 return None, True
 
     def _inject_with_user_retry(
@@ -623,16 +645,22 @@ class ProcessBackEnd:
                 return True
             except Exception as error:
                 caught_error.emit(f"Injection Error: {traceback.format_exc()}")
+                # rTorrent embeds credentials as userinfo in its host URI, and
+                # `RTorrentClient.inject_torrent` has no exception handling of
+                # its own, so an `xmlrpc.client.ProtocolError` carrying the
+                # full netloc can reach here; scrub once and reuse everywhere
+                # below instead of interpolating the raw error.
+                safe_message = scrub_secrets(str(error))
                 if upload_retry_cb is None:
                     queued_status_update(
-                        tracker_name, f"❌ Failed to inject torrent ({error})"
+                        tracker_name, f"❌ Failed to inject torrent ({safe_message})"
                     )
                     return False
 
                 failure = UploadFailure(
                     tracker=tracker,
                     phase=UploadFailurePhase.INJECTION,
-                    message=scrub_secrets(str(error)),
+                    message=safe_message,
                     attempt=attempt,
                     automatic_attempts=0,
                     retryable=True,
@@ -650,7 +678,7 @@ class ProcessBackEnd:
                     queued_status_update(tracker_name, "⏹ Cancelled")
                     raise ProcessCancelled from error
                 queued_status_update(
-                    tracker_name, f"❌ Failed to inject torrent ({error})"
+                    tracker_name, f"❌ Failed to inject torrent ({safe_message})"
                 )
                 return False
 
@@ -1019,11 +1047,10 @@ class ProcessBackEnd:
                         ):
                             queued_status_update(tracker_name, "✅ Complete")
                     else:
-                        if skipped_upload:
-                            queued_text_update(
-                                "<br /><span>Skipped upload after user decision</span>"
-                            )
-                        else:
+                        # `_upload_tracker_with_retry` already reported the
+                        # skip (with phase-appropriate status/text) when it
+                        # returned; nothing further to say here.
+                        if not skipped_upload:
                             queued_text_update(
                                 '<br /><span style="font-weight: bold; color: red;">Failed to upload release, '
                                 "check logs for information</span>"

--- a/src/backend/process.py
+++ b/src/backend/process.py
@@ -5,7 +5,6 @@ from collections.abc import Callable, Sequence
 from pathlib import Path
 from typing import Any, cast
 
-import niquests
 from PySide6.QtCore import SignalInstance
 from tenacity import Retrying, retry_if_exception, stop_after_attempt
 from tenacity.wait import wait_exponential
@@ -465,7 +464,11 @@ class ProcessBackEnd:
 
     @staticmethod
     def _is_automatic_upload_retryable(error: BaseException) -> bool:
-        """Return whether retrying the upload request is safe enough to automate."""
+        """Return whether retrying the upload request is safe enough to automate.
+
+        Trackers annotate their own failures; an un-annotated error is treated
+        as unsafe rather than guessed at from its message text.
+        """
         if getattr(error, "server_accepted", False):
             # The POST may already have succeeded. Retrying the whole upload can
             # create a duplicate; only an explicit user decision may continue.
@@ -479,37 +482,7 @@ class ProcessBackEnd:
         if isinstance(status_code, int):
             return status_code == 408 or status_code == 429 or status_code >= 500
 
-        if isinstance(error, niquests.exceptions.RequestException):
-            return True
-        if isinstance(error.__cause__, niquests.exceptions.RequestException):
-            return True
-        if isinstance(error.__context__, niquests.exceptions.RequestException):
-            return True
-
-        message = str(error).lower()
-        return any(
-            marker in message
-            for marker in (
-                "timed out",
-                "timeout",
-                "connection reset",
-                "connection aborted",
-                "temporarily unavailable",
-                "service unavailable",
-                "http 408",
-                "http 429",
-                "http 500",
-                "http 502",
-                "http 503",
-                "http 504",
-                "status code: 408",
-                "status code: 429",
-                "status code: 500",
-                "status code: 502",
-                "status code: 503",
-                "status code: 504",
-            )
-        )
+        return False
 
     def _upload_tracker_with_retry(
         self,

--- a/src/backend/process.py
+++ b/src/backend/process.py
@@ -70,6 +70,7 @@ from src.backend.upload_retry import (
     UploadFailure,
     UploadFailurePhase,
     UploadRetryAction,
+    scrub_secrets,
 )
 from src.backend.utils.anime import is_anime_release
 from src.backend.utils.image_optimizer import MultiProcessImageOptimizer
@@ -553,10 +554,11 @@ class ProcessBackEnd:
                 raise
             except Exception as error:
                 retryable = self._is_automatic_upload_retryable(error)
+                safe_message = scrub_secrets(str(error))
                 failure = UploadFailure(
                     tracker=tracker,
                     phase=self._upload_error_phase(error),
-                    message=str(error),
+                    message=safe_message,
                     attempt=total_attempts,
                     automatic_attempts=self.AUTOMATIC_UPLOAD_ATTEMPTS,
                     retryable=retryable,
@@ -566,7 +568,7 @@ class ProcessBackEnd:
                 queued_status_update(str(tracker), "⚠️ Failed - awaiting action")
                 queued_text_update(
                     f'<br /><span style="font-weight: bold; color: red;">'
-                    f"Upload failed for {tracker}: {error}</span>"
+                    f"Upload failed for {tracker}: {safe_message}</span>"
                 )
                 caught_error.emit(f"Upload Error: {traceback.format_exc()}")
 
@@ -626,7 +628,7 @@ class ProcessBackEnd:
                 failure = UploadFailure(
                     tracker=tracker,
                     phase=UploadFailurePhase.INJECTION,
-                    message=str(error),
+                    message=scrub_secrets(str(error)),
                     attempt=attempt,
                     automatic_attempts=0,
                     retryable=True,

--- a/src/backend/process.py
+++ b/src/backend/process.py
@@ -67,6 +67,7 @@ from src.backend.trackers.torrentleech import TLUploader
 from src.backend.trackers.unit3d_base import Unit3dBaseSearch, Unit3dBaseUploader
 from src.backend.trackers.utils import format_image_tag
 from src.backend.upload_retry import (
+    RETRY_ATTEMPTS,
     UploadFailure,
     UploadFailurePhase,
     UploadRetryAction,
@@ -102,7 +103,7 @@ from src.payloads.watch_folder import WatchFolder
 
 
 class ProcessBackEnd:
-    AUTOMATIC_UPLOAD_ATTEMPTS = 3
+    AUTOMATIC_UPLOAD_ATTEMPTS = RETRY_ATTEMPTS
 
     def __init__(self, config: ConfigManager) -> None:
         self.config = config
@@ -530,15 +531,18 @@ class ProcessBackEnd:
             def before_sleep(retry_state: object) -> None:
                 # Retrying's concrete state exposes the attempt number, but the
                 # callback is intentionally kept duck-typed for static checks.
-                attempt_number = getattr(retry_state, "attempt_number", total_attempts)
+                # It reports the attempt that just failed, so the attempt about
+                # to start is one higher.
+                failed_attempt = getattr(retry_state, "attempt_number", total_attempts)
+                next_attempt = failed_attempt + 1
                 tracker_health_cache.pop(tracker, None)
                 queued_status_update(
                     str(tracker),
-                    f"↻ Retrying upload ({attempt_number}/{self.AUTOMATIC_UPLOAD_ATTEMPTS})",
+                    f"↻ Retrying upload ({next_attempt}/{self.AUTOMATIC_UPLOAD_ATTEMPTS})",
                 )
                 queued_text_update(
                     f"<br /><span>Temporary upload failure for <b>{tracker}</b>; "
-                    f"retrying ({attempt_number}/{self.AUTOMATIC_UPLOAD_ATTEMPTS})</span>"
+                    f"retrying ({next_attempt}/{self.AUTOMATIC_UPLOAD_ATTEMPTS})</span>"
                 )
 
             try:

--- a/src/backend/process.py
+++ b/src/backend/process.py
@@ -995,6 +995,34 @@ class ProcessBackEnd:
                         caught_error=caught_error,
                         upload_retry_cb=upload_retry_cb,
                     )
+
+                    if execute_upload:
+                        queued_text_update(
+                            "<br /><span>Successfully uploaded release</span>"
+                        )
+                        # handle injection
+                        if self._inject_with_user_retry(
+                            tracker=cur_tracker,
+                            tracker_name=tracker_name,
+                            torrent_path=torrent_path,
+                            file_input=media_input,
+                            queued_text_update=queued_text_update,
+                            queued_status_update=queued_status_update,
+                            caught_error=caught_error,
+                            upload_retry_cb=upload_retry_cb,
+                        ):
+                            queued_status_update(tracker_name, "✅ Complete")
+                    else:
+                        if skipped_upload:
+                            queued_text_update(
+                                "<br /><span>Skipped upload after user decision</span>"
+                            )
+                        else:
+                            queued_text_update(
+                                '<br /><span style="font-weight: bold; color: red;">Failed to upload release, '
+                                "check logs for information</span>"
+                            )
+                            queued_status_update(tracker_name, "❌ Failed")
                 except ProcessCancelled:
                     for remaining_tracker in list(process_dict)[idx:]:
                         queued_status_update(remaining_tracker, "⏹ Cancelled")
@@ -1007,34 +1035,6 @@ class ProcessBackEnd:
                     )
                     caught_error.emit(f"Upload Error: {traceback.format_exc()}")
                     queued_status_update(tracker_name, "❌ Failed")
-
-                if execute_upload:
-                    queued_text_update(
-                        "<br /><span>Successfully uploaded release</span>"
-                    )
-                    # handle injection
-                    if self._inject_with_user_retry(
-                        tracker=cur_tracker,
-                        tracker_name=tracker_name,
-                        torrent_path=torrent_path,
-                        file_input=media_input,
-                        queued_text_update=queued_text_update,
-                        queued_status_update=queued_status_update,
-                        caught_error=caught_error,
-                        upload_retry_cb=upload_retry_cb,
-                    ):
-                        queued_status_update(tracker_name, "✅ Complete")
-                else:
-                    if skipped_upload:
-                        queued_text_update(
-                            "<br /><span>Skipped upload after user decision</span>"
-                        )
-                    else:
-                        queued_text_update(
-                            '<br /><span style="font-weight: bold; color: red;">Failed to upload release, '
-                            "check logs for information</span>"
-                        )
-                        queued_status_update(tracker_name, "❌ Failed")
             elif not tracker_info.upload_enabled and pre_upload_processing is None:
                 queued_text_update(
                     "<br /><span>Skipping upload & injection, upload is disabled</span>"

--- a/src/backend/process.py
+++ b/src/backend/process.py
@@ -513,6 +513,10 @@ class ProcessBackEnd:
                     tracker=tracker,
                     timeout=self.config.settings.general.timeout,
                     cache=tracker_health_cache,
+                    # `_upload_tracker_with_retry` already retries this call, so
+                    # a nested budget here would multiply the wait before the
+                    # user can intervene.
+                    attempts=1,
                 )
                 result = upload_request()
                 if not result:
@@ -906,11 +910,13 @@ class ProcessBackEnd:
 
             # upload
             if tracker_info.upload_enabled and pre_upload_processing is not False:
-                queued_text_update("<br /><span>Checking tracker availability</span>")
                 execute_upload = None
                 skipped_upload = False
                 try:
-                    queued_text_update("<br /><span>Uploading release</span>")
+                    queued_text_update(
+                        "<br /><span>Checking tracker availability and uploading "
+                        "release</span>"
+                    )
                     execute_upload, skipped_upload = self._upload_tracker_with_retry(
                         tracker=cur_tracker,
                         torrent_path=torrent_path,

--- a/src/backend/process.py
+++ b/src/backend/process.py
@@ -587,6 +587,67 @@ class ProcessBackEnd:
                 queued_status_update(str(tracker), "⏭ Skipped")
                 return None, True
 
+    def _inject_with_user_retry(
+        self,
+        *,
+        tracker: TrackerSelection,
+        tracker_name: str,
+        torrent_path: Path,
+        file_input: Path,
+        queued_text_update: Callable[[str], None],
+        queued_status_update: Callable[[str, str], None],
+        caught_error: SignalInstance,
+        upload_retry_cb: Callable[[UploadFailure], UploadRetryAction] | None,
+    ) -> bool:
+        """Inject a torrent, letting the user retry on failure.
+
+        The torrent is already on the tracker at this point, so retrying an
+        injection cannot create a duplicate upload.
+        """
+        attempt = 0
+        while True:
+            attempt += 1
+            try:
+                self._handle_injection(
+                    queued_text_update=queued_text_update,
+                    tracker_name=tracker_name,
+                    torrent_path=torrent_path,
+                    file_input=file_input,
+                )
+                return True
+            except Exception as error:
+                caught_error.emit(f"Injection Error: {traceback.format_exc()}")
+                if upload_retry_cb is None:
+                    queued_status_update(
+                        tracker_name, f"❌ Failed to inject torrent ({error})"
+                    )
+                    return False
+
+                failure = UploadFailure(
+                    tracker=tracker,
+                    phase=UploadFailurePhase.INJECTION,
+                    message=str(error),
+                    attempt=attempt,
+                    automatic_attempts=0,
+                    retryable=True,
+                    server_accepted=False,
+                    torrent_path=torrent_path,
+                )
+                queued_status_update(tracker_name, "⚠️ Injection failed - awaiting action")
+                action = upload_retry_cb(failure)
+                if action is UploadRetryAction.RETRY:
+                    queued_status_update(
+                        tracker_name, f"↻ Retrying injection (attempt {attempt + 1})"
+                    )
+                    continue
+                if action is UploadRetryAction.CANCEL:
+                    queued_status_update(tracker_name, "⏹ Cancelled")
+                    raise ProcessCancelled from error
+                queued_status_update(
+                    tracker_name, f"❌ Failed to inject torrent ({error})"
+                )
+                return False
+
     def process_trackers(
         self,
         process_dict: dict[str, Any],
@@ -952,19 +1013,17 @@ class ProcessBackEnd:
                         "<br /><span>Successfully uploaded release</span>"
                     )
                     # handle injection
-                    try:
-                        self._handle_injection(
-                            queued_text_update=queued_text_update,
-                            tracker_name=tracker_name,
-                            torrent_path=torrent_path,
-                            file_input=media_input,
-                        )
+                    if self._inject_with_user_retry(
+                        tracker=cur_tracker,
+                        tracker_name=tracker_name,
+                        torrent_path=torrent_path,
+                        file_input=media_input,
+                        queued_text_update=queued_text_update,
+                        queued_status_update=queued_status_update,
+                        caught_error=caught_error,
+                        upload_retry_cb=upload_retry_cb,
+                    ):
                         queued_status_update(tracker_name, "✅ Complete")
-                    except Exception as e:
-                        queued_status_update(
-                            tracker_name, f"❌ Failed to inject torrent ({e})"
-                        )
-                        caught_error.emit(f"Injection Error: {traceback.format_exc()}")
                 else:
                     if skipped_upload:
                         queued_text_update(

--- a/src/backend/trackers/beyondhd.py
+++ b/src/backend/trackers/beyondhd.py
@@ -211,16 +211,19 @@ class BHDUploader:
                 response_error_msg = f"Failed to upload torrent. Reason: {response.reason}, Status Code: {response.status_code}"
                 LOG.error(LOG.LOG_SOURCE.BE, response_error_msg)
                 status_code = response.status_code
+                # 408/429 mean the request was rejected before it could be
+                # processed. A 5xx means BeyondHD received and answered the
+                # upload -- it may have recorded the torrent before failing,
+                # so that must route to the user instead of an automatic
+                # retry.
+                retryable = isinstance(status_code, int) and (
+                    status_code == 408 or status_code == 429 or status_code >= 500
+                )
+                server_accepted = isinstance(status_code, int) and status_code >= 500
                 raise TrackerError(
                     response_error_msg,
-                    retryable=(
-                        isinstance(status_code, int)
-                        and (
-                            status_code == 408
-                            or status_code == 429
-                            or status_code >= 500
-                        )
-                    ),
+                    retryable=retryable,
+                    server_accepted=server_accepted,
                     status_code=status_code if isinstance(status_code, int) else None,
                 )
 

--- a/src/backend/trackers/beyondhd.py
+++ b/src/backend/trackers/beyondhd.py
@@ -8,6 +8,7 @@ import regex
 from niquests.typing import MultiPartFilesAltType
 
 from src.backend.trackers.utils import TRACKER_HEADERS
+from src.backend.upload_retry import classify_upload_post_error
 from src.backend.utils.media_info_utils import MinimalMediaInfo
 from src.enums.media_type import MediaType
 from src.enums.tracker_selection import TrackerSelection
@@ -209,7 +210,15 @@ class BHDUploader:
             if not response.ok or response.status_code != 200:
                 response_error_msg = f"Failed to upload torrent. Reason: {response.reason}, Status Code: {response.status_code}"
                 LOG.error(LOG.LOG_SOURCE.BE, response_error_msg)
-                raise TrackerError(response_error_msg)
+                status_code = response.status_code
+                raise TrackerError(
+                    response_error_msg,
+                    retryable=(
+                        isinstance(status_code, int)
+                        and (status_code == 429 or status_code >= 500)
+                    ),
+                    status_code=status_code if isinstance(status_code, int) else None,
+                )
 
             response_json = response.json()
             if response_json.get("success"):
@@ -236,7 +245,12 @@ class BHDUploader:
         except niquests.exceptions.RequestException as error:
             requests_exc_error_msg = f"Failed to upload to BeyondHD: {error}"
             LOG.error(LOG.LOG_SOURCE.BE, requests_exc_error_msg)
-            raise TrackerError(requests_exc_error_msg)
+            retryable, server_accepted = classify_upload_post_error(error)
+            raise TrackerError(
+                requests_exc_error_msg,
+                retryable=retryable,
+                server_accepted=server_accepted,
+            ) from error
 
         return None
 

--- a/src/backend/trackers/beyondhd.py
+++ b/src/backend/trackers/beyondhd.py
@@ -215,7 +215,11 @@ class BHDUploader:
                     response_error_msg,
                     retryable=(
                         isinstance(status_code, int)
-                        and (status_code == 429 or status_code >= 500)
+                        and (
+                            status_code == 408
+                            or status_code == 429
+                            or status_code >= 500
+                        )
                     ),
                     status_code=status_code if isinstance(status_code, int) else None,
                 )

--- a/src/backend/trackers/health.py
+++ b/src/backend/trackers/health.py
@@ -10,6 +10,7 @@ from tenacity import (
 )
 
 from src.backend.trackers.utils import TRACKER_HEADERS
+from src.backend.upload_retry import RETRY_ATTEMPTS
 from src.enums.tracker_selection import TrackerSelection
 from src.exceptions import TrackerError
 
@@ -43,7 +44,7 @@ def ensure_tracker_health(
     timeout: int,
     cache: MutableMapping[TrackerSelection, bool],
     *,
-    attempts: int = 3,
+    attempts: int = RETRY_ATTEMPTS,
 ) -> None:
     """Verify a tracker root is reachable once per processing run."""
     cached = cache.get(tracker)

--- a/src/backend/trackers/health.py
+++ b/src/backend/trackers/health.py
@@ -3,7 +3,7 @@ from collections.abc import MutableMapping
 import niquests
 from niquests import RequestException
 from tenacity import (
-    retry,
+    Retrying,
     retry_if_exception_type,
     stop_after_attempt,
     wait_exponential,
@@ -16,13 +16,7 @@ from src.exceptions import TrackerError
 HEALTH_CHECK_TIMEOUT_SECONDS = 5
 
 
-@retry(
-    retry=retry_if_exception_type(RequestException),
-    stop=stop_after_attempt(3),
-    wait=wait_exponential(multiplier=0.5, min=0.5, max=2),
-    reraise=True,
-)
-def _probe_tracker(url: str, timeout: int) -> tuple[int, str | None]:
+def _probe_tracker_once(url: str, timeout: int) -> tuple[int, str | None]:
     with niquests.get(
         url,
         headers=TRACKER_HEADERS,
@@ -34,16 +28,32 @@ def _probe_tracker(url: str, timeout: int) -> tuple[int, str | None]:
         return response.status_code, response.reason
 
 
+def _probe_tracker(url: str, timeout: int, attempts: int) -> tuple[int, str | None]:
+    """Probe the tracker root, retrying up to ``attempts`` times."""
+    return Retrying(
+        retry=retry_if_exception_type(RequestException),
+        stop=stop_after_attempt(attempts),
+        wait=wait_exponential(multiplier=0.5, min=0.5, max=2),
+        reraise=True,
+    )(_probe_tracker_once, url, timeout)
+
+
 def ensure_tracker_health(
     tracker: TrackerSelection,
     timeout: int,
     cache: MutableMapping[TrackerSelection, bool],
+    *,
+    attempts: int = 3,
 ) -> None:
     """Verify a tracker root is reachable once per processing run."""
     cached = cache.get(tracker)
     if cached is not None:
         if not cached:
-            raise TrackerError(f"{tracker} is unavailable")
+            raise TrackerError(
+                f"{tracker} is unavailable",
+                retryable=True,
+                phase="health_check",
+            )
         return
 
     probe_timeout = max(1, min(timeout, HEALTH_CHECK_TIMEOUT_SECONDS))
@@ -52,6 +62,7 @@ def ensure_tracker_health(
         status_code, reason = _probe_tracker(
             tracker.get_root_url(),
             probe_timeout,
+            attempts,
         )
     except RequestException as error:
         cache[tracker] = False

--- a/src/backend/trackers/morethantv.py
+++ b/src/backend/trackers/morethantv.py
@@ -17,6 +17,7 @@ from pymediainfo import MediaInfo
 from unidecode import unidecode
 
 from src.backend.trackers.utils import TRACKER_HEADERS
+from src.backend.upload_retry import classify_upload_post_error
 from src.backend.utils.resolution import VideoResolutionAnalyzer
 from src.enums.audio_formats import AudioFormats
 from src.enums.media_type import MediaType
@@ -341,13 +342,23 @@ class MTVUploader:
             f"\n#### UPLOAD PAYLOAD ####\n{data}\n#### UPLOAD PAYLOAD ####\n",
         )
 
-        upload_page = self._session.post(
-            self.UPLOAD_URL,
-            data=data,
-            files=files,
-            headers=TRACKER_HEADERS,
-            timeout=self.timeout,
-        )
+        try:
+            upload_page = self._session.post(
+                self.UPLOAD_URL,
+                data=data,
+                files=files,
+                headers=TRACKER_HEADERS,
+                timeout=self.timeout,
+            )
+        except niquests.exceptions.RequestException as error:
+            upload_error_msg = f"There was an error uploading to MoreThanTV: {error}"
+            LOG.error(LOG.LOG_SOURCE.BE, upload_error_msg)
+            retryable, server_accepted = classify_upload_post_error(error)
+            raise TrackerError(
+                upload_error_msg,
+                retryable=retryable,
+                server_accepted=server_accepted,
+            ) from error
 
         LOG.debug(
             LOG.LOG_SOURCE.BE,

--- a/src/backend/trackers/passthepopcorn.py
+++ b/src/backend/trackers/passthepopcorn.py
@@ -16,6 +16,7 @@ from pymediainfo import MediaInfo
 from src.backend.image_host_uploading.base_image_host import ImageUploadRequest
 from src.backend.image_host_uploading.img_box import ImageBoxUploader
 from src.backend.trackers.utils import TRACKER_HEADERS
+from src.backend.upload_retry import classify_upload_post_error
 from src.backend.utils.resolution import VideoResolutionAnalyzer
 from src.enums.tracker_selection import TrackerSelection
 from src.enums.trackers.passthepopcorn import (
@@ -347,9 +348,19 @@ class PTPUploader:
                         )
                     }
                 )
-            upload = response.post(
-                url=url, headers=TRACKER_HEADERS, data=data, files=files
-            )
+            try:
+                upload = response.post(
+                    url=url, headers=TRACKER_HEADERS, data=data, files=files
+                )
+            except niquests.exceptions.RequestException as error:
+                upload_error_msg = f"Upload to PTP failed: {error}"
+                LOG.error(LOG.LOG_SOURCE.BE, upload_error_msg)
+                retryable, server_accepted = classify_upload_post_error(error)
+                raise TrackerError(
+                    upload_error_msg,
+                    retryable=retryable,
+                    server_accepted=server_accepted,
+                ) from error
 
             # if the response contains our announce URL, then we are on the upload page and the upload wasn't successful.
             if upload.text and upload.text.find(self.announce_url) != -1:

--- a/src/backend/trackers/passthepopcorn.py
+++ b/src/backend/trackers/passthepopcorn.py
@@ -350,7 +350,11 @@ class PTPUploader:
                 )
             try:
                 upload = response.post(
-                    url=url, headers=TRACKER_HEADERS, data=data, files=files
+                    url=url,
+                    headers=TRACKER_HEADERS,
+                    data=data,
+                    files=files,
+                    timeout=self.timeout,
                 )
             except niquests.exceptions.RequestException as error:
                 upload_error_msg = f"Upload to PTP failed: {error}"

--- a/src/backend/trackers/torrentleech.py
+++ b/src/backend/trackers/torrentleech.py
@@ -9,6 +9,7 @@ from niquests.typing import MultiPartFilesAltType
 from pymediainfo import MediaInfo
 
 from src.backend.trackers.utils import TRACKER_HEADERS
+from src.backend.upload_retry import classify_upload_post_error
 from src.backend.utils.resolution import VideoResolutionAnalyzer
 from src.enums.media_type import MediaType
 from src.enums.tracker_selection import TrackerSelection
@@ -97,11 +98,24 @@ class TLUploader:
                     f"{request.status_code} ({request.reason} - {request.text})"
                 )
                 LOG.error(LOG.LOG_SOURCE.BE, upload_error_msg)
-                raise TrackerError(upload_error_msg)
+                status_code = request.status_code
+                raise TrackerError(
+                    upload_error_msg,
+                    retryable=(
+                        isinstance(status_code, int)
+                        and (status_code == 429 or status_code >= 500)
+                    ),
+                    status_code=status_code if isinstance(status_code, int) else None,
+                )
         except niquests.exceptions.RequestException as e:
             request_error_msg = f"There was an error uploading (niquests): {e}"
             LOG.error(LOG.LOG_SOURCE.BE, request_error_msg)
-            raise TrackerError(request_error_msg)
+            retryable, server_accepted = classify_upload_post_error(e)
+            raise TrackerError(
+                request_error_msg,
+                retryable=retryable,
+                server_accepted=server_accepted,
+            ) from e
 
     def _get_files(self, nfo: str, torrent_file: Path) -> MultiPartFilesAltType:
         with open(torrent_file, "rb") as t_file:

--- a/src/backend/trackers/torrentleech.py
+++ b/src/backend/trackers/torrentleech.py
@@ -99,16 +99,19 @@ class TLUploader:
                 )
                 LOG.error(LOG.LOG_SOURCE.BE, upload_error_msg)
                 status_code = request.status_code
+                # 408/429 mean the request was rejected before it could be
+                # processed. A 5xx means TorrentLeech received and answered
+                # the upload -- it may have recorded the torrent before
+                # failing, so that must route to the user instead of an
+                # automatic retry.
+                retryable = isinstance(status_code, int) and (
+                    status_code == 408 or status_code == 429 or status_code >= 500
+                )
+                server_accepted = isinstance(status_code, int) and status_code >= 500
                 raise TrackerError(
                     upload_error_msg,
-                    retryable=(
-                        isinstance(status_code, int)
-                        and (
-                            status_code == 408
-                            or status_code == 429
-                            or status_code >= 500
-                        )
-                    ),
+                    retryable=retryable,
+                    server_accepted=server_accepted,
                     status_code=status_code if isinstance(status_code, int) else None,
                 )
         except niquests.exceptions.RequestException as e:

--- a/src/backend/trackers/torrentleech.py
+++ b/src/backend/trackers/torrentleech.py
@@ -103,7 +103,11 @@ class TLUploader:
                     upload_error_msg,
                     retryable=(
                         isinstance(status_code, int)
-                        and (status_code == 429 or status_code >= 500)
+                        and (
+                            status_code == 408
+                            or status_code == 429
+                            or status_code >= 500
+                        )
                     ),
                     status_code=status_code if isinstance(status_code, int) else None,
                 )

--- a/src/backend/trackers/unit3d_base.py
+++ b/src/backend/trackers/unit3d_base.py
@@ -213,7 +213,11 @@ class Unit3dBaseUploader:
                             error_msg,
                             retryable=(
                                 isinstance(status_code, int)
-                                and (status_code == 429 or status_code >= 500)
+                                and (
+                                    status_code == 408
+                                    or status_code == 429
+                                    or status_code >= 500
+                                )
                             ),
                             status_code=(
                                 status_code if isinstance(status_code, int) else None

--- a/src/backend/trackers/unit3d_base.py
+++ b/src/backend/trackers/unit3d_base.py
@@ -209,16 +209,23 @@ class Unit3dBaseUploader:
                     else:
                         error_msg = f"Message='{message}' Context='{context}'"
                         status_code = getattr(response, "status_code", None)
+                        # 408/429 mean the request was rejected before it
+                        # could be processed. A 5xx means the tracker
+                        # received and answered the upload -- it may have
+                        # recorded the torrent before failing, so that must
+                        # route to the user instead of an automatic retry.
+                        retryable = isinstance(status_code, int) and (
+                            status_code == 408
+                            or status_code == 429
+                            or status_code >= 500
+                        )
+                        server_accepted = (
+                            isinstance(status_code, int) and status_code >= 500
+                        )
                         raise TrackerError(
                             error_msg,
-                            retryable=(
-                                isinstance(status_code, int)
-                                and (
-                                    status_code == 408
-                                    or status_code == 429
-                                    or status_code >= 500
-                                )
-                            ),
+                            retryable=retryable,
+                            server_accepted=server_accepted,
                             status_code=(
                                 status_code if isinstance(status_code, int) else None
                             ),

--- a/src/backend/trackers/unit3d_base.py
+++ b/src/backend/trackers/unit3d_base.py
@@ -17,6 +17,7 @@ from src.backend.trackers.utils import (
     looks_like_torrent,
     tracker_string_replace_map,
 )
+from src.backend.upload_retry import classify_upload_post_error
 from src.backend.utils.media_info_utils import MinimalMediaInfo
 from src.backend.utils.resolution import VideoResolutionAnalyzer
 from src.enums.media_type import MediaType
@@ -235,7 +236,12 @@ class Unit3dBaseUploader:
         except niquests.exceptions.RequestException as error:
             requests_exc_error_msg = f"Failed to upload to {self.tracker_name}: {error}"
             LOG.error(LOG.LOG_SOURCE.BE, requests_exc_error_msg)
-            raise TrackerError(requests_exc_error_msg, retryable=True) from error
+            retryable, server_accepted = classify_upload_post_error(error)
+            raise TrackerError(
+                requests_exc_error_msg,
+                retryable=retryable,
+                server_accepted=server_accepted,
+            ) from error
 
     def _download_uploaded_torrent(self, download_url: str) -> Path:
         """Stream the tracker-generated torrent to its final path atomically."""

--- a/src/backend/trackers/unit3d_base.py
+++ b/src/backend/trackers/unit3d_base.py
@@ -17,7 +17,7 @@ from src.backend.trackers.utils import (
     looks_like_torrent,
     tracker_string_replace_map,
 )
-from src.backend.upload_retry import classify_upload_post_error
+from src.backend.upload_retry import RETRY_ATTEMPTS, classify_upload_post_error
 from src.backend.utils.media_info_utils import MinimalMediaInfo
 from src.backend.utils.resolution import VideoResolutionAnalyzer
 from src.enums.media_type import MediaType
@@ -297,7 +297,7 @@ class Unit3dBaseUploader:
                 and bool(getattr(error, "server_accepted", False))
                 and bool(getattr(error, "retryable", False))
             ),
-            stop=stop_after_attempt(3),
+            stop=stop_after_attempt(RETRY_ATTEMPTS),
             wait=wait_exponential(multiplier=0.5, min=0.5, max=4),
             reraise=True,
         )(lambda: self._download_uploaded_torrent(download_url))

--- a/src/backend/upload_retry.py
+++ b/src/backend/upload_retry.py
@@ -2,6 +2,8 @@ from dataclasses import dataclass
 from enum import Enum, auto
 from pathlib import Path
 
+import niquests
+
 from src.enums.tracker_selection import TrackerSelection
 
 
@@ -34,3 +36,30 @@ class UploadFailure:
     retryable: bool
     server_accepted: bool = False
     torrent_path: Path | None = None
+
+
+def classify_upload_post_error(error: BaseException) -> tuple[bool | None, bool]:
+    """Return ``(retryable, server_accepted)`` for an error raised by an upload POST.
+
+    An upload POST cannot be re-sent blindly: if the request body already
+    reached the tracker, retrying creates a duplicate torrent. Classify by
+    whether the failure provably happened before the body was transmitted.
+
+    A ``retryable`` of ``None`` means "unknown"; callers treat that as not
+    safe to retry automatically.
+    """
+    # ConnectTimeout subclasses ConnectionError, so it must be tested first.
+    if isinstance(error, niquests.exceptions.ConnectTimeout):
+        return True, False
+    if isinstance(error, niquests.exceptions.ReadTimeout):
+        # The body was fully sent and the tracker was still processing it.
+        return True, True
+    if isinstance(error, niquests.exceptions.InvalidJSONError):
+        # A response arrived but was not JSON (proxy or CDN error page). The
+        # tracker may still have recorded the upload. Covers JSONDecodeError.
+        return True, True
+    if isinstance(error, niquests.exceptions.ConnectionError):
+        # Refused, DNS failure, or a reset mid-send: the tracker never received
+        # a complete multipart body, so it cannot have processed the upload.
+        return True, False
+    return None, True

--- a/src/backend/upload_retry.py
+++ b/src/backend/upload_retry.py
@@ -63,9 +63,16 @@ def classify_upload_post_error(error: BaseException) -> tuple[bool | None, bool]
         # tracker may still have recorded the upload. Covers JSONDecodeError.
         return True, True
     if isinstance(error, niquests.exceptions.ConnectionError):
-        # Refused, DNS failure, or a reset mid-send: the tracker never received
-        # a complete multipart body, so it cannot have processed the upload.
-        return True, False
+        # niquests' HTTPAdapter wraps the *entire* conn.urlopen() call --
+        # which spans sending the request body and reading the response
+        # headers -- in a single `except (ProtocolError, OSError) as err:
+        # raise ConnectionError(err, request=request)`. Refused, DNS
+        # failure, and a reset mid-send all surface as this same bare
+        # ConnectionError, but so does a tracker that accepted a large
+        # multipart upload and then reset while processing it. That is
+        # physically the same failure as ReadTimeout (marked
+        # server_accepted=True above), so this is not provably pre-body.
+        return None, True
     return None, True
 
 
@@ -73,7 +80,15 @@ _SECRET_QUERY_PARAM = re.compile(
     r"(?i)\b(api_token|api_key|apikey|passkey|rsskey|torrent_pass)=[^&\s\"']+"
 )
 
+# Matches the userinfo portion of a URI, e.g. the credentials rTorrent embeds
+# in its host URI (`https://user:password@host/...`). An `xmlrpc.client.
+# ProtocolError` copies that full netloc into its message, so this shape can
+# reach on-screen status text the same way a query-string secret can.
+_URI_USERINFO_PASSWORD = re.compile(r"(?i)(://[^/\s:@]+:)[^@\s]+(@)")
+
 
 def scrub_secrets(text: str) -> str:
     """Redact credentials that transport errors copy out of a request URL."""
-    return _SECRET_QUERY_PARAM.sub(r"\1=[redacted]", text)
+    text = _SECRET_QUERY_PARAM.sub(r"\1=[redacted]", text)
+    text = _URI_USERINFO_PASSWORD.sub(r"\1[redacted]\2", text)
+    return text

--- a/src/backend/upload_retry.py
+++ b/src/backend/upload_retry.py
@@ -7,6 +7,9 @@ import niquests
 
 from src.enums.tracker_selection import TrackerSelection
 
+RETRY_ATTEMPTS = 3
+"""Default number of attempts for automatic retries of a tracker operation."""
+
 
 class UploadRetryAction(Enum):
     """The action selected after an upload attempt needs user attention."""

--- a/src/backend/upload_retry.py
+++ b/src/backend/upload_retry.py
@@ -1,3 +1,4 @@
+import re
 from dataclasses import dataclass
 from enum import Enum, auto
 from pathlib import Path
@@ -63,3 +64,13 @@ def classify_upload_post_error(error: BaseException) -> tuple[bool | None, bool]
         # a complete multipart body, so it cannot have processed the upload.
         return True, False
     return None, True
+
+
+_SECRET_QUERY_PARAM = re.compile(
+    r"(?i)\b(api_token|api_key|apikey|passkey|rsskey|torrent_pass)=[^&\s\"']+"
+)
+
+
+def scrub_secrets(text: str) -> str:
+    """Redact credentials that transport errors copy out of a request URL."""
+    return _SECRET_QUERY_PARAM.sub(r"\1=[redacted]", text)

--- a/src/frontend/global_signals.py
+++ b/src/frontend/global_signals.py
@@ -52,6 +52,7 @@ class GlobalSignals(QObject):
     # dict[TrackerSelection, dict[str | None, str]]
     overview_prompt_response = Signal(object)
     upload_retry_response = Signal(object)
+    upload_retry_ack = Signal()  # GUI has received a retry prompt request
     ########### SIGNALS ###########
 
     def __new__(cls) -> Self:

--- a/src/frontend/wizards/process.py
+++ b/src/frontend/wizards/process.py
@@ -464,6 +464,11 @@ class ProcessPage(BaseWizardPage):
                     "copy of the torrent failed, so the local torrent file was "
                     "kept. Re-uploading would create a duplicate."
                 )
+            elif failure.phase is UploadFailurePhase.INJECTION:
+                details += (
+                    "\n\nThe upload succeeded. Only adding the torrent to your "
+                    "client failed, so retrying is safe."
+                )
             elif failure.server_accepted:
                 details += (
                     "\n\nThe tracker may already have accepted this upload. "

--- a/src/frontend/wizards/process.py
+++ b/src/frontend/wizards/process.py
@@ -232,8 +232,10 @@ class ProcessWorker(BaseWorker):
 
         # wait for response
         GSigs().prompt_tokens_response.connect(waiter.on_response)
-        loop.exec_()
-        GSigs().prompt_tokens_response.disconnect(waiter.on_response)
+        try:
+            loop.exec_()
+        finally:
+            GSigs().prompt_tokens_response.disconnect(waiter.on_response)
 
         # return response
         return self._prompt_tokens_response
@@ -253,8 +255,10 @@ class ProcessWorker(BaseWorker):
 
         # wait for response
         GSigs().overview_prompt_response.connect(waiter.on_response)
-        loop.exec_()
-        GSigs().overview_prompt_response.disconnect(waiter.on_response)
+        try:
+            loop.exec_()
+        finally:
+            GSigs().overview_prompt_response.disconnect(waiter.on_response)
 
         # return response
         return self._overview_prompt
@@ -551,7 +555,7 @@ class ProcessPage(BaseWizardPage):
                 # of the torrent failed. Re-uploading would duplicate it.
                 retry_button = None
                 skip_button = dialog.addButton(
-                    "Keep upload, use local torrent", QMessageBox.ButtonRole.AcceptRole
+                    "Keep upload, continue", QMessageBox.ButtonRole.AcceptRole
                 )
                 dialog.addButton("Cancel remaining", QMessageBox.ButtonRole.RejectRole)
                 dialog.setDefaultButton(skip_button)

--- a/src/frontend/wizards/process.py
+++ b/src/frontend/wizards/process.py
@@ -6,7 +6,7 @@ from dataclasses import fields
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
-from PySide6.QtCore import QEventLoop, QObject, QThread, Signal, Slot
+from PySide6.QtCore import QEventLoop, QObject, QThread, QTimer, Signal, Slot
 from PySide6.QtGui import Qt, QTextCursor
 from PySide6.QtWidgets import (
     QApplication,
@@ -109,6 +109,8 @@ class ProcessWorker(BaseWorker):
     overview_signal = Signal(object)
     upload_retry_signal = Signal(object)
     job_cancelled = Signal()
+
+    RETRY_PROMPT_ACK_TIMEOUT_MS = 5000
 
     def __init__(
         self,
@@ -219,15 +221,30 @@ class ProcessWorker(BaseWorker):
             response = action
             loop.quit()
 
+        # The GUI may be gone: if the slot is never invoked nothing would ever
+        # reply and this loop would block forever. Bound the wait until the GUI
+        # acknowledges receipt, then let the user take as long as they need.
+        watchdog = QTimer()
+        watchdog.setSingleShot(True)
+        watchdog.timeout.connect(loop.quit)
+
+        @Slot()
+        def on_ack() -> None:
+            watchdog.stop()
+
         # Connect before emitting so the response can never arrive first, and
         # always disconnect so a raise inside the loop cannot leak a connection
         # onto the global signal singleton.
+        GSigs().upload_retry_ack.connect(on_ack)
         GSigs().upload_retry_response.connect(on_response)
         try:
+            watchdog.start(ProcessWorker.RETRY_PROMPT_ACK_TIMEOUT_MS)
             self.upload_retry_signal.emit(failure)
             loop.exec_()
         finally:
+            watchdog.stop()
             GSigs().upload_retry_response.disconnect(on_response)
+            GSigs().upload_retry_ack.disconnect(on_ack)
 
         return response or UploadRetryAction.CANCEL
 
@@ -449,6 +466,9 @@ class ProcessPage(BaseWizardPage):
     def _on_upload_retry_signal(self, failure: UploadFailure) -> None:
         """Present a retry/skip/cancel choice while the worker waits."""
         action = UploadRetryAction.CANCEL
+        # Tell the worker its request was received, so it stops the ack
+        # watchdog and waits indefinitely for the user's actual answer.
+        GSigs().upload_retry_ack.emit()
         try:
             dialog = QMessageBox(self)
             dialog.setIcon(QMessageBox.Icon.Warning)

--- a/src/frontend/wizards/process.py
+++ b/src/frontend/wizards/process.py
@@ -24,6 +24,7 @@ from PySide6.QtWidgets import (
 from src.backend.process import ProcessBackEnd
 from src.backend.upload_retry import (
     UploadFailure,
+    UploadFailurePhase,
     UploadRetryAction,
 )
 from src.backend.utils.file_utilities import open_explorer
@@ -457,7 +458,13 @@ class ProcessPage(BaseWizardPage):
             )
             if failure.torrent_path:
                 details += f"\n\nOutput: {failure.torrent_path.parent}"
-            if failure.server_accepted:
+            if failure.phase is UploadFailurePhase.DOWNLOAD:
+                details += (
+                    "\n\nThe upload succeeded. Only downloading the tracker's "
+                    "copy of the torrent failed, so the local torrent file was "
+                    "kept. Re-uploading would create a duplicate."
+                )
+            elif failure.server_accepted:
                 details += (
                     "\n\nThe tracker may already have accepted this upload. "
                     "Retrying could create a duplicate."
@@ -469,16 +476,34 @@ class ProcessPage(BaseWizardPage):
                 )
             dialog.setInformativeText(details)
 
-            retry_button = dialog.addButton("Retry", QMessageBox.ButtonRole.AcceptRole)
-            skip_button = dialog.addButton(
-                "Skip tracker", QMessageBox.ButtonRole.DestructiveRole
-            )
-            dialog.addButton("Cancel remaining", QMessageBox.ButtonRole.RejectRole)
-            dialog.setDefaultButton(retry_button)
+            if failure.phase is UploadFailurePhase.DOWNLOAD:
+                # The upload itself succeeded; only fetching the tracker's copy
+                # of the torrent failed. Re-uploading would duplicate it.
+                retry_button = None
+                skip_button = dialog.addButton(
+                    "Keep upload, use local torrent", QMessageBox.ButtonRole.AcceptRole
+                )
+                dialog.addButton("Cancel remaining", QMessageBox.ButtonRole.RejectRole)
+                dialog.setDefaultButton(skip_button)
+            else:
+                retry_label = (
+                    "Re-upload (may duplicate)" if failure.server_accepted else "Retry"
+                )
+                retry_button = dialog.addButton(
+                    retry_label, QMessageBox.ButtonRole.AcceptRole
+                )
+                skip_button = dialog.addButton(
+                    "Skip tracker", QMessageBox.ButtonRole.DestructiveRole
+                )
+                dialog.addButton("Cancel remaining", QMessageBox.ButtonRole.RejectRole)
+                # Never default to the action that can create a duplicate.
+                dialog.setDefaultButton(
+                    skip_button if failure.server_accepted else retry_button
+                )
             dialog.exec()
 
             clicked = dialog.clickedButton()
-            if clicked is retry_button:
+            if retry_button is not None and clicked is retry_button:
                 action = UploadRetryAction.RETRY
             elif clicked is skip_button:
                 action = UploadRetryAction.SKIP

--- a/src/frontend/wizards/process.py
+++ b/src/frontend/wizards/process.py
@@ -210,7 +210,6 @@ class ProcessWorker(BaseWorker):
     def upload_retry_and_wait_cb(self, failure: UploadFailure) -> UploadRetryAction:
         """Ask the frontend what to do with a failed tracker upload."""
         response: UploadRetryAction | None = None
-        self.upload_retry_signal.emit(failure)
         loop = QEventLoop()
 
         @Slot(object)
@@ -219,9 +218,15 @@ class ProcessWorker(BaseWorker):
             response = action
             loop.quit()
 
+        # Connect before emitting so the response can never arrive first, and
+        # always disconnect so a raise inside the loop cannot leak a connection
+        # onto the global signal singleton.
         GSigs().upload_retry_response.connect(on_response)
-        loop.exec_()
-        GSigs().upload_retry_response.disconnect(on_response)
+        try:
+            self.upload_retry_signal.emit(failure)
+            loop.exec_()
+        finally:
+            GSigs().upload_retry_response.disconnect(on_response)
 
         return response or UploadRetryAction.CANCEL
 
@@ -437,47 +442,58 @@ class ProcessPage(BaseWizardPage):
     @Slot(object)
     def _on_upload_retry_signal(self, failure: UploadFailure) -> None:
         """Present a retry/skip/cancel choice while the worker waits."""
-        dialog = QMessageBox(self)
-        dialog.setIcon(QMessageBox.Icon.Warning)
-        dialog.setWindowTitle(f"Upload failed: {failure.tracker}")
-        dialog.setText(
-            f"{failure.tracker} failed during {failure.phase.name.lower().replace('_', ' ')}."
-        )
-        details = (
-            f"Attempts: {failure.attempt} "
-            f"({failure.automatic_attempts} automatic attempts)\n\n"
-            f"{failure.message}"
-        )
-        if failure.torrent_path:
-            details += f"\n\nOutput: {failure.torrent_path.parent}"
-        if failure.server_accepted:
-            details += (
-                "\n\nThe tracker may already have accepted this upload. "
-                "Retrying could create a duplicate."
+        action = UploadRetryAction.CANCEL
+        try:
+            dialog = QMessageBox(self)
+            dialog.setIcon(QMessageBox.Icon.Warning)
+            dialog.setWindowTitle(f"Upload failed: {failure.tracker}")
+            dialog.setText(
+                f"{failure.tracker} failed during {failure.phase.name.lower().replace('_', ' ')}."
             )
-        elif not failure.retryable:
-            details += (
-                "\n\nThis does not look like a temporary failure; verify the "
-                "tracker settings before retrying."
+            details = (
+                f"Attempts: {failure.attempt} "
+                f"({failure.automatic_attempts} automatic attempts)\n\n"
+                f"{failure.message}"
             )
-        dialog.setInformativeText(details)
+            if failure.torrent_path:
+                details += f"\n\nOutput: {failure.torrent_path.parent}"
+            if failure.server_accepted:
+                details += (
+                    "\n\nThe tracker may already have accepted this upload. "
+                    "Retrying could create a duplicate."
+                )
+            elif not failure.retryable:
+                details += (
+                    "\n\nThis does not look like a temporary failure; verify the "
+                    "tracker settings before retrying."
+                )
+            dialog.setInformativeText(details)
 
-        retry_button = dialog.addButton("Retry", QMessageBox.ButtonRole.AcceptRole)
-        skip_button = dialog.addButton(
-            "Skip tracker", QMessageBox.ButtonRole.DestructiveRole
-        )
-        dialog.addButton("Cancel remaining", QMessageBox.ButtonRole.RejectRole)
-        dialog.setDefaultButton(retry_button)
-        dialog.exec()
+            retry_button = dialog.addButton("Retry", QMessageBox.ButtonRole.AcceptRole)
+            skip_button = dialog.addButton(
+                "Skip tracker", QMessageBox.ButtonRole.DestructiveRole
+            )
+            dialog.addButton("Cancel remaining", QMessageBox.ButtonRole.RejectRole)
+            dialog.setDefaultButton(retry_button)
+            dialog.exec()
 
-        clicked = dialog.clickedButton()
-        if clicked is retry_button:
-            action = UploadRetryAction.RETRY
-        elif clicked is skip_button:
-            action = UploadRetryAction.SKIP
-        else:
-            action = UploadRetryAction.CANCEL
-        GSigs().upload_retry_response.emit(action)
+            clicked = dialog.clickedButton()
+            if clicked is retry_button:
+                action = UploadRetryAction.RETRY
+            elif clicked is skip_button:
+                action = UploadRetryAction.SKIP
+        except Exception as e:
+            # Presenting the dialog failed (e.g. the page was torn down while
+            # the prompt was up). Fall back to CANCEL below instead of leaving
+            # the exception unhandled.
+            LOG.error(
+                LOG.LOG_SOURCE.FE,
+                f"Failed to present upload retry prompt: {e}\n{traceback.format_exc()}",
+            )
+        finally:
+            # The worker thread is blocked on this response. Releasing it from a
+            # finally keeps a dialog failure from hanging the whole run.
+            GSigs().upload_retry_response.emit(action)
 
     def _job_ended(self) -> None:
         self.dupe_worker = None

--- a/src/frontend/wizards/process.py
+++ b/src/frontend/wizards/process.py
@@ -431,8 +431,13 @@ class ProcessPage(BaseWizardPage):
     def _on_cancelled(self) -> None:
         self._job_ended()
         self._on_text_update(
-            "<br /><span style='font-weight: bold;'>Remaining processing cancelled.</span>"
+            "<br /><span style='font-weight: bold;'>Remaining processing cancelled. "
+            "Trackers that already completed were not rolled back; restart the "
+            "wizard to upload the remaining ones.</span>"
         )
+        # Without this the process button restarts from the first tracker and
+        # re-uploads the ones that already succeeded.
+        GSigs().wizard_process_btn_set_hidden.emit()
 
     @Slot(str, str)
     def _on_failed(self, e: str, trace_back: str) -> None:

--- a/src/frontend/wizards/process.py
+++ b/src/frontend/wizards/process.py
@@ -102,6 +102,65 @@ class DupeWorker(BaseWorker):
             async_loop.close()
 
 
+class _TokenPromptWaiter(QObject):
+    """Bound-method receiver for ``prompt_tokens_response``.
+
+    PySide routes a queued connection to a plain Python closure through an
+    internal receiver whose thread affinity is pinned by the *first*
+    connection made in the process. On a second (or later) worker QThread
+    that pins the delivery to the wrong thread and the signal is silently
+    dropped. A fresh QObject instance per call carries its own thread
+    affinity, so real bound ``@Slot`` methods on it keep being delivered.
+    """
+
+    def __init__(self, worker: "ProcessWorker", loop: QEventLoop) -> None:
+        super().__init__()
+        self._worker = worker
+        self._loop = loop
+
+    @Slot(object)
+    def on_response(self, response: dict[str, str] | None) -> None:
+        self._worker._prompt_tokens_response = response
+        self._loop.quit()
+
+
+class _OverviewPromptWaiter(QObject):
+    """Bound-method receiver for ``overview_prompt_response``. See
+    ``_TokenPromptWaiter`` for why a closure slot is not used here."""
+
+    def __init__(self, worker: "ProcessWorker", loop: QEventLoop) -> None:
+        super().__init__()
+        self._worker = worker
+        self._loop = loop
+
+    @Slot(object)
+    def on_response(
+        self, response: dict[TrackerSelection, dict[str, str | None]] | None
+    ) -> None:
+        self._worker._overview_prompt = response
+        self._loop.quit()
+
+
+class _UploadRetryWaiter(QObject):
+    """Bound-method receiver for ``upload_retry_ack`` / ``upload_retry_response``.
+    See ``_TokenPromptWaiter`` for why a closure slot is not used here."""
+
+    def __init__(self, watchdog: QTimer, loop: QEventLoop) -> None:
+        super().__init__()
+        self._watchdog = watchdog
+        self._loop = loop
+        self.response: UploadRetryAction | None = None
+
+    @Slot()
+    def on_ack(self) -> None:
+        self._watchdog.stop()
+
+    @Slot(object)
+    def on_response(self, action: UploadRetryAction) -> None:
+        self.response = action
+        self._loop.quit()
+
+
 class ProcessWorker(BaseWorker):
     queued_status_update = Signal(str, str)
     progress_signal = Signal(int)
@@ -169,16 +228,12 @@ class ProcessWorker(BaseWorker):
         self.prompt_tokens_signal.emit(tokens)
         # start event loop
         loop = QEventLoop()
-
-        @Slot(object)
-        def on_response(response: dict[str, str] | None) -> None:
-            self._prompt_tokens_response = response
-            loop.quit()
+        waiter = _TokenPromptWaiter(self, loop)
 
         # wait for response
-        GSigs().prompt_tokens_response.connect(on_response)
+        GSigs().prompt_tokens_response.connect(waiter.on_response)
         loop.exec_()
-        GSigs().prompt_tokens_response.disconnect(on_response)
+        GSigs().prompt_tokens_response.disconnect(waiter.on_response)
 
         # return response
         return self._prompt_tokens_response
@@ -194,32 +249,19 @@ class ProcessWorker(BaseWorker):
 
         # start loop
         loop = QEventLoop()
-
-        @Slot(object)
-        def on_response(
-            response: dict[TrackerSelection, dict[str, str | None]] | None,
-        ) -> None:
-            self._overview_prompt = response
-            loop.quit()
+        waiter = _OverviewPromptWaiter(self, loop)
 
         # wait for response
-        GSigs().overview_prompt_response.connect(on_response)
+        GSigs().overview_prompt_response.connect(waiter.on_response)
         loop.exec_()
-        GSigs().overview_prompt_response.disconnect(on_response)
+        GSigs().overview_prompt_response.disconnect(waiter.on_response)
 
         # return response
         return self._overview_prompt
 
     def upload_retry_and_wait_cb(self, failure: UploadFailure) -> UploadRetryAction:
         """Ask the frontend what to do with a failed tracker upload."""
-        response: UploadRetryAction | None = None
         loop = QEventLoop()
-
-        @Slot(object)
-        def on_response(action: UploadRetryAction) -> None:
-            nonlocal response
-            response = action
-            loop.quit()
 
         # The GUI may be gone: if the slot is never invoked nothing would ever
         # reply and this loop would block forever. Bound the wait until the GUI
@@ -228,25 +270,23 @@ class ProcessWorker(BaseWorker):
         watchdog.setSingleShot(True)
         watchdog.timeout.connect(loop.quit)
 
-        @Slot()
-        def on_ack() -> None:
-            watchdog.stop()
+        waiter = _UploadRetryWaiter(watchdog, loop)
 
         # Connect before emitting so the response can never arrive first, and
         # always disconnect so a raise inside the loop cannot leak a connection
         # onto the global signal singleton.
-        GSigs().upload_retry_ack.connect(on_ack)
-        GSigs().upload_retry_response.connect(on_response)
+        GSigs().upload_retry_ack.connect(waiter.on_ack)
+        GSigs().upload_retry_response.connect(waiter.on_response)
         try:
-            watchdog.start(ProcessWorker.RETRY_PROMPT_ACK_TIMEOUT_MS)
+            watchdog.start(self.RETRY_PROMPT_ACK_TIMEOUT_MS)
             self.upload_retry_signal.emit(failure)
             loop.exec_()
         finally:
             watchdog.stop()
-            GSigs().upload_retry_response.disconnect(on_response)
-            GSigs().upload_retry_ack.disconnect(on_ack)
+            GSigs().upload_retry_response.disconnect(waiter.on_response)
+            GSigs().upload_retry_ack.disconnect(waiter.on_ack)
 
-        return response or UploadRetryAction.CANCEL
+        return waiter.response or UploadRetryAction.CANCEL
 
 
 class ProcessPage(BaseWizardPage):

--- a/tests/test_backend/test_passthepopcorn.py
+++ b/tests/test_backend/test_passthepopcorn.py
@@ -60,3 +60,40 @@ def test_ptp_new_group_poster_requires_imgbox_url(
         _uploader(tmp_path)._upload_poster_to_imgbox(
             "https://image.tmdb.org/t/p/original/poster.jpg"
         )
+
+
+@patch("src.backend.trackers.passthepopcorn.VideoResolutionAnalyzer")
+def test_ptp_upload_post_has_a_timeout(
+    _resolution_analyzer: MagicMock, tmp_path: Path
+) -> None:
+    """Every other request in this module passes ``self.timeout`` and the
+    session sets no default; a hung upload POST must not be able to block
+    the worker thread forever."""
+    uploader = _uploader(tmp_path)
+    torrent_file = tmp_path / "release.torrent"
+    torrent_file.write_bytes(b"torrent contents")
+
+    fake_response = MagicMock(text="", url=None, status_code=None)
+    fake_session = MagicMock()
+    fake_session.__enter__.return_value = fake_session
+    fake_session.__exit__.return_value = False
+    fake_session.post.return_value = fake_response
+    uploader._session = fake_session
+
+    media_search_payload = MagicMock()
+    # Skip the type-detection duration lookup, which needs a real MediaInfo
+    # object; only the timeout on the POST is under test here.
+    media_search_payload.imdb_data.kind = None
+
+    with pytest.raises(TrackerError, match="is not the expected one"):
+        uploader.upload(
+            auth_token="token",
+            media_search_payload=media_search_payload,
+            torrent_file=torrent_file,
+            input_path=tmp_path / "Example.2026.1080p.WEB-DL-GRP",
+            nfo="nfo contents",
+            group_id="12345",
+        )
+
+    fake_session.post.assert_called_once()
+    assert fake_session.post.call_args.kwargs["timeout"] == uploader.timeout

--- a/tests/test_backend/test_tracker_health.py
+++ b/tests/test_backend/test_tracker_health.py
@@ -2,7 +2,9 @@ from unittest.mock import ANY, MagicMock, patch
 
 import niquests
 import pytest
+from tenacity.wait import wait_none
 
+import src.backend.trackers.health as health_module
 from src.backend.trackers.health import (
     HEALTH_CHECK_TIMEOUT_SECONDS,
     ensure_tracker_health,
@@ -72,3 +74,41 @@ def test_health_check_blocks_request_failures(
 
 def test_health_check_has_a_root_url_for_every_tracker() -> None:
     assert set(TRACKER_ROOT_URLS) == set(TrackerSelection)
+
+
+def test_attempts_is_honoured(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The caller owns the retry budget so nested loops cannot multiply it."""
+    calls = 0
+
+    def _fail(url: str, timeout: int) -> tuple[int, str | None]:
+        nonlocal calls
+        calls += 1
+        raise niquests.RequestException("unreachable")
+
+    monkeypatch.setattr(health_module, "_probe_tracker_once", _fail)
+    cache: dict[TrackerSelection, bool] = {}
+
+    with pytest.raises(TrackerError):
+        ensure_tracker_health(TrackerSelection.AITHER, 5, cache, attempts=1)
+
+    assert calls == 1
+    assert cache[TrackerSelection.AITHER] is False
+
+
+def test_default_attempts_still_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = 0
+
+    def _fail(url: str, timeout: int) -> tuple[int, str | None]:
+        nonlocal calls
+        calls += 1
+        raise niquests.RequestException("unreachable")
+
+    # Matches the existing pattern in tests/test_backend/test_upload_retry.py:46
+    # so the retry runs without real backoff sleeps.
+    monkeypatch.setattr(health_module, "_probe_tracker_once", _fail)
+    monkeypatch.setattr(health_module, "wait_exponential", lambda **_kwargs: wait_none())
+
+    with pytest.raises(TrackerError):
+        ensure_tracker_health(TrackerSelection.AITHER, 5, {})
+
+    assert calls == 3

--- a/tests/test_backend/test_upload_retry.py
+++ b/tests/test_backend/test_upload_retry.py
@@ -100,3 +100,77 @@ def test_cancel_decision_stops_processing(
         )
 
     assert upload.call_count == 1
+
+
+def test_user_retry_runs_the_upload_again(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A RETRY decision restarts the whole attempt budget and can succeed."""
+    monkeypatch.setattr(process_module, "ensure_tracker_health", lambda **_kwargs: None)
+    upload = MagicMock(
+        side_effect=[TrackerError("invalid API key", retryable=False), True]
+    )
+    callback = MagicMock(return_value=UploadRetryAction.RETRY)
+    kwargs = _kwargs(tmp_path)
+
+    result, skipped = _backend()._upload_tracker_with_retry(
+        upload_request=upload,
+        upload_retry_cb=callback,
+        **kwargs,
+    )
+
+    assert result is True
+    assert skipped is False
+    assert upload.call_count == 2
+    callback.assert_called_once()
+
+
+def test_automatic_attempts_are_exhausted_before_prompting(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Retryable failures use the full automatic budget, then reach the user."""
+    monkeypatch.setattr(process_module, "ensure_tracker_health", lambda **_kwargs: None)
+    monkeypatch.setattr(
+        process_module, "wait_exponential", lambda **_kwargs: wait_none()
+    )
+    upload = MagicMock(side_effect=TrackerError("temporary timeout", retryable=True))
+    callback = MagicMock(return_value=UploadRetryAction.SKIP)
+    kwargs = _kwargs(tmp_path)
+
+    result, skipped = _backend()._upload_tracker_with_retry(
+        upload_request=upload,
+        upload_retry_cb=callback,
+        **kwargs,
+    )
+
+    assert result is None
+    assert skipped is True
+    assert upload.call_count == ProcessBackEnd.AUTOMATIC_UPLOAD_ATTEMPTS
+    failure = callback.call_args.args[0]
+    assert failure.attempt == ProcessBackEnd.AUTOMATIC_UPLOAD_ATTEMPTS
+
+
+def test_server_accepted_failure_prompts_on_the_first_attempt(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A possibly-accepted upload must reach the user without a silent re-POST."""
+    monkeypatch.setattr(process_module, "ensure_tracker_health", lambda **_kwargs: None)
+    upload = MagicMock(
+        side_effect=TrackerError(
+            "read timed out", retryable=True, server_accepted=True
+        )
+    )
+    callback = MagicMock(return_value=UploadRetryAction.SKIP)
+    kwargs = _kwargs(tmp_path)
+
+    result, skipped = _backend()._upload_tracker_with_retry(
+        upload_request=upload,
+        upload_retry_cb=callback,
+        **kwargs,
+    )
+
+    assert result is None
+    assert skipped is True
+    assert upload.call_count == 1
+    failure = callback.call_args.args[0]
+    assert failure.server_accepted is True

--- a/tests/test_backend/test_upload_retry.py
+++ b/tests/test_backend/test_upload_retry.py
@@ -14,6 +14,7 @@ from src.backend.upload_retry import (
     UploadRetryAction,
 )
 from src.config.config import ConfigManager
+from src.context.processing_context import ProcessingContext
 from src.enums.tracker_selection import TrackerSelection
 from src.exceptions import ProcessCancelled, TrackerClientError, TrackerError
 
@@ -220,3 +221,99 @@ def test_injection_failure_without_callback_is_reported_once(tmp_path: Path) -> 
     )
 
     assert injected is False
+
+
+def test_injection_cancel_marks_remaining_trackers_and_disconnects(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A CANCEL decision at an injection prompt must run the same cleanup as
+    a CANCEL decision at an upload prompt: mark the remaining trackers
+    cancelled and disconnect the torrent clients.
+
+    This exercises the real `process_trackers` loop (not
+    `_inject_with_user_retry` in isolation) because the defect this guards
+    against was in how the two call sites did, or did not, share the
+    surrounding `try`/`except ProcessCancelled` handler: a `ProcessCancelled`
+    raised from injection used to escape `process_trackers` entirely,
+    skipping both the per-tracker cancellation status updates and
+    `disconnect_from_clients()`.
+    """
+    monkeypatch.setattr(process_module, "ensure_tracker_health", lambda **_kwargs: None)
+    monkeypatch.setattr(process_module, "generate_torrent", lambda **_kwargs: MagicMock())
+    monkeypatch.setattr(
+        process_module,
+        "write_torrent",
+        lambda *_a, **_kwargs: tmp_path / "written.torrent",
+    )
+    monkeypatch.setattr(
+        process_module,
+        "build_series_release_info",
+        lambda *_a, **_kwargs: MagicMock(),
+    )
+
+    tracker_info = SimpleNamespace(upload_enabled=True, nfo_template=None)
+    backend = object.__new__(ProcessBackEnd)
+    backend.config = cast(
+        ConfigManager,
+        SimpleNamespace(
+            settings=SimpleNamespace(
+                general=SimpleNamespace(
+                    timeout=60,
+                    enable_mkbrr=False,
+                    enable_plugins=False,
+                    enable_prompt_overview=False,
+                ),
+                trackers=SimpleNamespace(
+                    by_selection=lambda: {
+                        TrackerSelection.AITHER: tracker_info,
+                        TrackerSelection.BEYOND_HD: tracker_info,
+                    }
+                ),
+                user_tokens=SimpleNamespace(tokens={}),
+                dependencies=SimpleNamespace(mkbrr=None),
+            )
+        ),
+    )
+    backend.template_selector_be = SimpleNamespace(
+        load_templates=lambda: None, read_template=lambda name=None: None
+    )
+    backend.handle_images_for_trackers = MagicMock(return_value={})  # type: ignore[method-assign]
+    backend.determine_max_piece_size = MagicMock(return_value=None)  # type: ignore[method-assign]
+    backend.generate_tracker_title = MagicMock(return_value=None)  # type: ignore[method-assign]
+    backend.upload = MagicMock(return_value=True)  # type: ignore[method-assign]
+    backend._handle_injection = MagicMock(  # type: ignore[method-assign]
+        side_effect=TrackerClientError("client offline")
+    )
+    backend.disconnect_from_clients = MagicMock()  # type: ignore[method-assign]
+
+    context = cast(
+        ProcessingContext,
+        SimpleNamespace(
+            media_input=SimpleNamespace(
+                require_input_path=lambda: tmp_path / "media.mkv"
+            )
+        ),
+    )
+    process_dict = {
+        "Aither": {"path": tmp_path / "aither.torrent"},
+        "BeyondHD": {"path": tmp_path / "beyondhd.torrent"},
+    }
+    status_updates: list[tuple[str, str]] = []
+
+    with pytest.raises(ProcessCancelled):
+        backend.process_trackers(
+            process_dict=process_dict,
+            queued_status_update=lambda tracker, status: status_updates.append(
+                (tracker, status)
+            ),
+            queued_text_update=MagicMock(),
+            queued_text_update_replace_last_line=MagicMock(),
+            progress_bar_cb=MagicMock(),
+            caught_error=cast(SignalInstance, MagicMock()),
+            context=context,
+            upload_retry_cb=lambda _failure: UploadRetryAction.CANCEL,
+        )
+
+    backend.disconnect_from_clients.assert_called_once()
+    assert ("Aither", "⏹ Cancelled") in status_updates
+    assert ("BeyondHD", "⏹ Cancelled") in status_updates

--- a/tests/test_backend/test_upload_retry.py
+++ b/tests/test_backend/test_upload_retry.py
@@ -86,6 +86,80 @@ def test_permanent_failure_can_be_skipped(
     assert upload.call_count == 1
 
 
+def test_upload_failure_message_has_credentials_scrubbed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Deleting the ``scrub_secrets()`` call must be caught by a test, not
+    just by review: drive the real failure path with a message containing a
+    tracker API token and assert it never reaches the callback."""
+    monkeypatch.setattr(process_module, "ensure_tracker_health", lambda **_kwargs: None)
+    upload = MagicMock(
+        side_effect=TrackerError(
+            "Failed to upload: /api/torrents/upload?api_token=SECRETKEY123",
+            retryable=False,
+        )
+    )
+    callback = MagicMock(return_value=UploadRetryAction.SKIP)
+    kwargs = _kwargs(tmp_path)
+
+    _backend()._upload_tracker_with_retry(
+        upload_request=upload,
+        upload_retry_cb=callback,
+        **kwargs,
+    )
+
+    callback.assert_called_once()
+    failure = callback.call_args.args[0]
+    assert "SECRETKEY123" not in failure.message
+    assert "api_token=[redacted]" in failure.message
+
+
+def test_download_phase_skip_is_reported_as_kept_not_skipped(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A DOWNLOAD-phase failure means the upload already succeeded; only
+    fetching the tracker's copy of the torrent failed. Choosing SKIP there
+    must not be reported the same way as a genuine skip, or a user reading
+    the status afterwards could mistakenly re-upload by hand."""
+    monkeypatch.setattr(process_module, "ensure_tracker_health", lambda **_kwargs: None)
+    upload = MagicMock(
+        side_effect=TrackerError(
+            "Failed to download torrent from Aither: connection reset",
+            retryable=True,
+            server_accepted=True,
+            phase="download",
+        )
+    )
+    callback = MagicMock(return_value=UploadRetryAction.SKIP)
+    status_update = MagicMock()
+    text_update = MagicMock()
+    kwargs = _kwargs(tmp_path)
+    kwargs["queued_status_update"] = status_update
+    kwargs["queued_text_update"] = text_update
+
+    result, skipped = _backend()._upload_tracker_with_retry(
+        upload_request=upload,
+        upload_retry_cb=callback,
+        **kwargs,
+    )
+
+    assert result is None
+    assert skipped is True
+    failure = callback.call_args.args[0]
+    assert failure.phase is UploadFailurePhase.DOWNLOAD
+
+    final_status_calls = [call.args for call in status_update.call_args_list]
+    assert (str(TrackerSelection.AITHER), "⏭ Skipped") not in final_status_calls
+    assert (
+        str(TrackerSelection.AITHER),
+        "⚠️ Uploaded - tracker torrent not downloaded",
+    ) in final_status_calls
+
+    final_text_calls = "".join(call.args[0] for call in text_update.call_args_list)
+    assert "skipped upload" not in final_text_calls.lower()
+    assert "upload succeeded" in final_text_calls.lower()
+
+
 def test_cancel_decision_stops_processing(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -221,6 +295,69 @@ def test_injection_failure_without_callback_is_reported_once(tmp_path: Path) -> 
     )
 
     assert injected is False
+
+
+def test_injection_status_text_scrubs_credentials_without_callback(
+    tmp_path: Path,
+) -> None:
+    """rTorrent embeds credentials as userinfo in its host URI, and
+    RTorrentClient.inject_torrent has no exception handling of its own, so
+    an xmlrpc.client.ProtocolError carrying the full netloc can reach this
+    status line."""
+    backend = _backend()
+    backend._handle_injection = MagicMock(  # type: ignore[method-assign]
+        side_effect=TrackerClientError(
+            "<ProtocolError for https://user:hunter2@host.example/rpc: "
+            "500 Internal Server Error>"
+        )
+    )
+    status_update = MagicMock()
+
+    injected = backend._inject_with_user_retry(
+        tracker=TrackerSelection.AITHER,
+        tracker_name="Aither",
+        torrent_path=tmp_path / "release.torrent",
+        file_input=tmp_path / "release.mkv",
+        queued_text_update=MagicMock(),
+        queued_status_update=status_update,
+        caught_error=cast(SignalInstance, MagicMock()),
+        upload_retry_cb=None,
+    )
+
+    assert injected is False
+    status_text = status_update.call_args.args[1]
+    assert "hunter2" not in status_text
+
+
+def test_injection_status_and_message_scrub_credentials_after_skip(
+    tmp_path: Path,
+) -> None:
+    backend = _backend()
+    backend._handle_injection = MagicMock(  # type: ignore[method-assign]
+        side_effect=TrackerClientError(
+            "<ProtocolError for https://user:hunter2@host.example/rpc: "
+            "500 Internal Server Error>"
+        )
+    )
+    callback = MagicMock(return_value=UploadRetryAction.SKIP)
+    status_update = MagicMock()
+
+    injected = backend._inject_with_user_retry(
+        tracker=TrackerSelection.AITHER,
+        tracker_name="Aither",
+        torrent_path=tmp_path / "release.torrent",
+        file_input=tmp_path / "release.mkv",
+        queued_text_update=MagicMock(),
+        queued_status_update=status_update,
+        caught_error=cast(SignalInstance, MagicMock()),
+        upload_retry_cb=callback,
+    )
+
+    assert injected is False
+    failure = callback.call_args.args[0]
+    assert "hunter2" not in failure.message
+    final_status_text = status_update.call_args.args[1]
+    assert "hunter2" not in final_status_text
 
 
 def test_injection_cancel_marks_remaining_trackers_and_disconnects(

--- a/tests/test_backend/test_upload_retry.py
+++ b/tests/test_backend/test_upload_retry.py
@@ -15,7 +15,7 @@ from src.backend.upload_retry import (
 )
 from src.config.config import ConfigManager
 from src.enums.tracker_selection import TrackerSelection
-from src.exceptions import ProcessCancelled, TrackerError
+from src.exceptions import ProcessCancelled, TrackerClientError, TrackerError
 
 
 def _backend() -> ProcessBackEnd:
@@ -174,3 +174,49 @@ def test_server_accepted_failure_prompts_on_the_first_attempt(
     assert upload.call_count == 1
     failure = callback.call_args.args[0]
     assert failure.server_accepted is True
+
+
+def test_injection_retry_prompts_and_succeeds(tmp_path: Path) -> None:
+    """Injection failures are transient and carry no duplicate risk."""
+    backend = _backend()
+    inject = MagicMock(side_effect=[TrackerClientError("client offline"), None])
+    backend._handle_injection = inject  # type: ignore[method-assign]
+    callback = MagicMock(return_value=UploadRetryAction.RETRY)
+
+    injected = backend._inject_with_user_retry(
+        tracker=TrackerSelection.AITHER,
+        tracker_name="Aither",
+        torrent_path=tmp_path / "release.torrent",
+        file_input=tmp_path / "release.mkv",
+        queued_text_update=MagicMock(),
+        queued_status_update=MagicMock(),
+        caught_error=cast(SignalInstance, MagicMock()),
+        upload_retry_cb=callback,
+    )
+
+    assert injected is True
+    assert inject.call_count == 2
+    failure = callback.call_args.args[0]
+    assert failure.phase is UploadFailurePhase.INJECTION
+    assert failure.server_accepted is False
+
+
+def test_injection_failure_without_callback_is_reported_once(tmp_path: Path) -> None:
+    backend = _backend()
+    backend._handle_injection = MagicMock(  # type: ignore[method-assign]
+        side_effect=TrackerClientError("client offline")
+    )
+    status_update = MagicMock()
+
+    injected = backend._inject_with_user_retry(
+        tracker=TrackerSelection.AITHER,
+        tracker_name="Aither",
+        torrent_path=tmp_path / "release.torrent",
+        file_input=tmp_path / "release.mkv",
+        queued_text_update=MagicMock(),
+        queued_status_update=status_update,
+        caught_error=cast(SignalInstance, MagicMock()),
+        upload_retry_cb=None,
+    )
+
+    assert injected is False

--- a/tests/test_backend/test_upload_retry_classification.py
+++ b/tests/test_backend/test_upload_retry_classification.py
@@ -279,3 +279,18 @@ def test_scrub_secrets_leaves_ordinary_text_alone() -> None:
     text = "Failed to upload to Aither: 503 Service Unavailable"
 
     assert scrub_secrets(text) == text
+
+
+def test_scrub_secrets_preserves_everything_after_the_token() -> None:
+    """An over-matching pattern would hide the actual error, not just the secret."""
+    text = (
+        "Max retries exceeded with url: "
+        "/api/torrents/upload?api_token=SECRETKEY123&foo=bar "
+        "(Caused by ReadTimeoutError)"
+    )
+
+    assert scrub_secrets(text) == (
+        "Max retries exceeded with url: "
+        "/api/torrents/upload?api_token=[redacted]&foo=bar "
+        "(Caused by ReadTimeoutError)"
+    )

--- a/tests/test_backend/test_upload_retry_classification.py
+++ b/tests/test_backend/test_upload_retry_classification.py
@@ -249,3 +249,33 @@ def test_server_accepted_overrides_retryable() -> None:
     error = TrackerError("timed out", retryable=True, server_accepted=True)
 
     assert ProcessBackEnd._is_automatic_upload_retryable(error) is False
+
+
+from src.backend.upload_retry import scrub_secrets
+
+
+def test_scrub_secrets_redacts_query_string_credentials() -> None:
+    text = (
+        "Max retries exceeded with url: /api/torrents/upload?api_token=SECRETKEY123 "
+        "(Caused by ReadTimeoutError)"
+    )
+
+    scrubbed = scrub_secrets(text)
+
+    assert "SECRETKEY123" not in scrubbed
+    assert "api_token=[redacted]" in scrubbed
+
+
+def test_scrub_secrets_handles_several_parameter_names() -> None:
+    text = "?apikey=AAA&passkey=BBB&api_key=CCC&api_token=DDD"
+
+    scrubbed = scrub_secrets(text)
+
+    for secret in ("AAA", "BBB", "CCC", "DDD"):
+        assert secret not in scrubbed
+
+
+def test_scrub_secrets_leaves_ordinary_text_alone() -> None:
+    text = "Failed to upload to Aither: 503 Service Unavailable"
+
+    assert scrub_secrets(text) == text

--- a/tests/test_backend/test_upload_retry_classification.py
+++ b/tests/test_backend/test_upload_retry_classification.py
@@ -102,3 +102,40 @@ def test_connect_timeout_on_upload_is_still_retried_automatically(
 
     assert error.server_accepted is False
     assert ProcessBackEnd._is_automatic_upload_retryable(error) is True
+
+
+def test_unannotated_error_is_not_retried_automatically() -> None:
+    """With every tracker annotated, an unknown error must not be guessed at."""
+    assert ProcessBackEnd._is_automatic_upload_retryable(TrackerError("boom")) is False
+
+
+def test_error_text_no_longer_drives_retry_decisions() -> None:
+    """Tracker HTML containing 'timeout' must not flip a permanent failure."""
+    error = TrackerError(
+        "There was an error uploading to TorrentLeech: 403 "
+        "(Forbidden - <html><body>gateway timeout advice</body></html>)",
+        retryable=False,
+    )
+
+    assert ProcessBackEnd._is_automatic_upload_retryable(error) is False
+
+
+def test_status_code_still_drives_retry_when_retryable_is_unset() -> None:
+    assert (
+        ProcessBackEnd._is_automatic_upload_retryable(
+            TrackerError("server error", status_code=503)
+        )
+        is True
+    )
+    assert (
+        ProcessBackEnd._is_automatic_upload_retryable(
+            TrackerError("forbidden", status_code=403)
+        )
+        is False
+    )
+
+
+def test_server_accepted_overrides_retryable() -> None:
+    error = TrackerError("timed out", retryable=True, server_accepted=True)
+
+    assert ProcessBackEnd._is_automatic_upload_retryable(error) is False

--- a/tests/test_backend/test_upload_retry_classification.py
+++ b/tests/test_backend/test_upload_retry_classification.py
@@ -5,7 +5,9 @@ import niquests
 import pytest
 
 from src.backend.process import ProcessBackEnd
+from src.backend.trackers.beyondhd import BHDUploader
 from src.backend.trackers.huno import HunoUploader
+from src.backend.trackers.torrentleech import TLUploader
 from src.backend.upload_retry import classify_upload_post_error
 from src.enums.media_type import MediaType
 from src.exceptions import TrackerError
@@ -104,17 +106,115 @@ def test_connect_timeout_on_upload_is_still_retried_automatically(
     assert ProcessBackEnd._is_automatic_upload_retryable(error) is True
 
 
+def _upload_raising_from_response(
+    response_json: dict[str, object], status_code: int, tmp_path: Path
+) -> TrackerError:
+    """Run a real UNIT3D upload where the tracker responds with a structured failure."""
+    torrent_file = tmp_path / "release.torrent"
+    torrent_file.write_bytes(b"original torrent")
+    mock_response = MagicMock()
+    mock_response.__enter__.return_value = mock_response
+    mock_response.__exit__.return_value = False
+    mock_response.json.return_value = response_json
+    mock_response.status_code = status_code
+    with (
+        patch.object(HunoUploader, "_build_upload_payload", return_value={}),
+        patch(
+            "src.backend.trackers.unit3d_base.niquests.post",
+            return_value=mock_response,
+        ),
+    ):
+        with pytest.raises(TrackerError) as excinfo:
+            _uploader(torrent_file).upload(
+                tracker_title="Example.2026.1080p.WEB-DL-GRP"
+            )
+    return excinfo.value
+
+
+def test_unit3d_408_response_is_retryable(tmp_path: Path) -> None:
+    """A structured 408 from a UNIT3D tracker must agree with the generic rule."""
+    error = _upload_raising_from_response(
+        {"success": False, "message": "Rate limited", "data": None}, 408, tmp_path
+    )
+
+    assert error.status_code == 408
+    assert error.retryable is True
+    assert ProcessBackEnd._is_automatic_upload_retryable(error) is True
+
+
+def test_beyondhd_408_response_is_retryable(tmp_path: Path) -> None:
+    """A structured 408 from BeyondHD must agree with the generic status-code rule."""
+    uploader = BHDUploader(
+        api_key="api-key",
+        torrent_file=tmp_path / "release.torrent",
+        input_path=tmp_path / "Example.2026.1080p.WEB-DL-GRP",
+        media_type=MediaType.MOVIE,
+    )
+    mock_response = MagicMock(ok=False, status_code=408, reason="Request Timeout")
+    with (
+        patch.object(BHDUploader, "_build_upload_payload", return_value={}),
+        patch.object(BHDUploader, "_files", return_value={}),
+        patch(
+            "src.backend.trackers.beyondhd.niquests.post", return_value=mock_response
+        ),
+    ):
+        with pytest.raises(TrackerError) as excinfo:
+            uploader.upload(tracker_title="Example.2026.1080p.WEB-DL-GRP")
+
+    error = excinfo.value
+    assert error.status_code == 408
+    assert error.retryable is True
+    assert ProcessBackEnd._is_automatic_upload_retryable(error) is True
+
+
+def test_torrentleech_408_response_is_retryable(tmp_path: Path) -> None:
+    """A structured 408 from TorrentLeech must agree with the generic status-code rule."""
+    torrent_file = tmp_path / "release.torrent"
+    torrent_file.write_bytes(b"original torrent")
+    uploader = TLUploader(announce_key="key")
+    mock_response = MagicMock(
+        ok=False, status_code=408, reason="Request Timeout", text="body"
+    )
+    with (
+        patch.object(TLUploader, "_get_data", return_value={}),
+        patch("src.backend.trackers.torrentleech.VideoResolutionAnalyzer"),
+        patch(
+            "src.backend.trackers.torrentleech.niquests.post",
+            return_value=mock_response,
+        ),
+    ):
+        with pytest.raises(TrackerError) as excinfo:
+            uploader.upload(
+                nfo="nfo contents",
+                tracker_title=None,
+                torrent_file=torrent_file,
+                mediainfo_obj=MagicMock(),
+                media_type=MediaType.MOVIE,
+                is_pack=False,
+            )
+
+    error = excinfo.value
+    assert error.status_code == 408
+    assert error.retryable is True
+    assert ProcessBackEnd._is_automatic_upload_retryable(error) is True
+
+
 def test_unannotated_error_is_not_retried_automatically() -> None:
     """With every tracker annotated, an unknown error must not be guessed at."""
     assert ProcessBackEnd._is_automatic_upload_retryable(TrackerError("boom")) is False
 
 
 def test_error_text_no_longer_drives_retry_decisions() -> None:
-    """Tracker HTML containing 'timeout' must not flip a permanent failure."""
+    """An un-annotated error containing 'timeout' must not be guessed retryable.
+
+    ``retryable`` and ``status_code`` are both left unset, so this is the only
+    construction that actually reaches the code path the marker list used to
+    occupy; a substring match on "gateway timeout advice" would have flipped
+    the old heuristic to retryable.
+    """
     error = TrackerError(
         "There was an error uploading to TorrentLeech: 403 "
         "(Forbidden - <html><body>gateway timeout advice</body></html>)",
-        retryable=False,
     )
 
     assert ProcessBackEnd._is_automatic_upload_retryable(error) is False
@@ -132,6 +232,16 @@ def test_status_code_still_drives_retry_when_retryable_is_unset() -> None:
             TrackerError("forbidden", status_code=403)
         )
         is False
+    )
+
+
+def test_http_408_is_retryable_via_status_code() -> None:
+    """A 408 means the request body never fully arrived, so retrying is safe."""
+    assert (
+        ProcessBackEnd._is_automatic_upload_retryable(
+            TrackerError("request timeout", status_code=408)
+        )
+        is True
     )
 
 

--- a/tests/test_backend/test_upload_retry_classification.py
+++ b/tests/test_backend/test_upload_retry_classification.py
@@ -1,7 +1,14 @@
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
 import niquests
 import pytest
 
+from src.backend.process import ProcessBackEnd
+from src.backend.trackers.huno import HunoUploader
 from src.backend.upload_retry import classify_upload_post_error
+from src.enums.media_type import MediaType
+from src.exceptions import TrackerError
 
 
 @pytest.mark.parametrize(
@@ -39,3 +46,59 @@ def test_json_decode_error_is_a_request_exception() -> None:
     assert issubclass(
         niquests.exceptions.JSONDecodeError, niquests.exceptions.RequestException
     )
+
+
+def _uploader(torrent_file: Path) -> HunoUploader:
+    return HunoUploader(
+        media_type=MediaType.MOVIE,
+        api_key="api-key",
+        torrent_file=torrent_file,
+        input_path=torrent_file.parent / "Example.2026.1080p.WEB-DL-GRP",
+        mediainfo_obj=MagicMock(),
+    )
+
+
+def _upload_raising(post_error: BaseException, tmp_path: Path) -> TrackerError:
+    """Run a real upload with the POST failing, and return the TrackerError."""
+    torrent_file = tmp_path / "release.torrent"
+    torrent_file.write_bytes(b"original torrent")
+    # The uploader classes use __slots__, so stub on the class, not the instance.
+    with (
+        patch.object(HunoUploader, "_build_upload_payload", return_value={}),
+        patch("src.backend.trackers.unit3d_base.niquests.post") as post,
+    ):
+        post.side_effect = post_error
+        with pytest.raises(TrackerError) as excinfo:
+            _uploader(torrent_file).upload(
+                tracker_title="Example.2026.1080p.WEB-DL-GRP"
+            )
+    return excinfo.value
+
+
+def test_read_timeout_on_upload_is_not_retried_automatically(tmp_path: Path) -> None:
+    """A timed-out POST may already have been accepted; it must reach the user."""
+    error = _upload_raising(niquests.exceptions.ReadTimeout("read timed out"), tmp_path)
+
+    assert error.server_accepted is True
+    assert ProcessBackEnd._is_automatic_upload_retryable(error) is False
+
+
+def test_html_error_page_on_upload_is_not_retried_automatically(tmp_path: Path) -> None:
+    error = _upload_raising(
+        niquests.exceptions.JSONDecodeError("Expecting value", "<html>", 0), tmp_path
+    )
+
+    assert error.server_accepted is True
+    assert ProcessBackEnd._is_automatic_upload_retryable(error) is False
+
+
+def test_connect_timeout_on_upload_is_still_retried_automatically(
+    tmp_path: Path,
+) -> None:
+    """Nothing left the socket, so the automatic retry budget still applies."""
+    error = _upload_raising(
+        niquests.exceptions.ConnectTimeout("connect timed out"), tmp_path
+    )
+
+    assert error.server_accepted is False
+    assert ProcessBackEnd._is_automatic_upload_retryable(error) is True

--- a/tests/test_backend/test_upload_retry_classification.py
+++ b/tests/test_backend/test_upload_retry_classification.py
@@ -1,0 +1,41 @@
+import niquests
+import pytest
+
+from src.backend.upload_retry import classify_upload_post_error
+
+
+@pytest.mark.parametrize(
+    ("error", "expected"),
+    (
+        # Nothing was transmitted: safe to re-POST automatically.
+        (niquests.exceptions.ConnectTimeout("connect timed out"), (True, False)),
+        (niquests.exceptions.ConnectionError("connection refused"), (True, False)),
+        # The body was fully sent; the tracker may have recorded the upload.
+        (niquests.exceptions.ReadTimeout("read timed out"), (True, True)),
+        (
+            niquests.exceptions.JSONDecodeError("Expecting value", "<html>", 0),
+            (True, True),
+        ),
+        (niquests.exceptions.InvalidJSONError("bad json"), (True, True)),
+        # Unknown transport failures are assumed to have reached the tracker.
+        (niquests.exceptions.RequestException("something else"), (None, True)),
+        (niquests.exceptions.TooManyRedirects("too many redirects"), (None, True)),
+    ),
+)
+def test_classify_upload_post_error(
+    error: BaseException, expected: tuple[bool | None, bool]
+) -> None:
+    assert classify_upload_post_error(error) == expected
+
+
+def test_connect_timeout_is_checked_before_connection_error() -> None:
+    """ConnectTimeout subclasses ConnectionError; ordering must not misclassify it."""
+    assert issubclass(niquests.exceptions.ConnectTimeout, niquests.exceptions.ConnectionError)
+    assert classify_upload_post_error(niquests.exceptions.ConnectTimeout("x")) == (True, False)
+
+
+def test_json_decode_error_is_a_request_exception() -> None:
+    """The bug this classifier fixes: a non-JSON response body looks like a transport error."""
+    assert issubclass(
+        niquests.exceptions.JSONDecodeError, niquests.exceptions.RequestException
+    )

--- a/tests/test_backend/test_upload_retry_classification.py
+++ b/tests/test_backend/test_upload_retry_classification.py
@@ -8,7 +8,7 @@ from src.backend.process import ProcessBackEnd
 from src.backend.trackers.beyondhd import BHDUploader
 from src.backend.trackers.huno import HunoUploader
 from src.backend.trackers.torrentleech import TLUploader
-from src.backend.upload_retry import classify_upload_post_error
+from src.backend.upload_retry import classify_upload_post_error, scrub_secrets
 from src.enums.media_type import MediaType
 from src.exceptions import TrackerError
 
@@ -18,7 +18,11 @@ from src.exceptions import TrackerError
     (
         # Nothing was transmitted: safe to re-POST automatically.
         (niquests.exceptions.ConnectTimeout("connect timed out"), (True, False)),
-        (niquests.exceptions.ConnectionError("connection refused"), (True, False)),
+        # A bare ConnectionError is NOT provably pre-body: niquests wraps the
+        # whole send-body-and-read-headers span in one except clause, so a
+        # reset while the tracker was processing an already-received upload
+        # looks identical to a refused connection. Must route to the user.
+        (niquests.exceptions.ConnectionError("connection refused"), (None, True)),
         # The body was fully sent; the tracker may have recorded the upload.
         (niquests.exceptions.ReadTimeout("read timed out"), (True, True)),
         (
@@ -41,6 +45,28 @@ def test_connect_timeout_is_checked_before_connection_error() -> None:
     """ConnectTimeout subclasses ConnectionError; ordering must not misclassify it."""
     assert issubclass(niquests.exceptions.ConnectTimeout, niquests.exceptions.ConnectionError)
     assert classify_upload_post_error(niquests.exceptions.ConnectTimeout("x")) == (True, False)
+
+
+def test_bare_connection_error_is_not_retried_automatically() -> None:
+    """Regression test for treating a bare ConnectionError as pre-body.
+
+    Verified against niquests' HTTPAdapter.send (adapters.py): the whole
+    ``conn.urlopen(..., preload_content=False)`` call -- which spans sending
+    the multipart body and reading the response headers -- is wrapped in a
+    single ``except (ProtocolError, OSError) as err: raise
+    ConnectionError(err, request=request)``. A tracker that accepted a large
+    upload and then reset while processing it is indistinguishable, from
+    this exception alone, from a connection that was refused outright.
+    """
+    retryable, server_accepted = classify_upload_post_error(
+        niquests.exceptions.ConnectionError("connection reset by peer")
+    )
+    assert retryable is None
+    assert server_accepted is True
+    error = TrackerError(
+        "connection reset", retryable=retryable, server_accepted=server_accepted
+    )
+    assert ProcessBackEnd._is_automatic_upload_retryable(error) is False
 
 
 def test_json_decode_error_is_a_request_exception() -> None:
@@ -142,6 +168,30 @@ def test_unit3d_408_response_is_retryable(tmp_path: Path) -> None:
     assert ProcessBackEnd._is_automatic_upload_retryable(error) is True
 
 
+def test_unit3d_429_response_is_retryable(tmp_path: Path) -> None:
+    """A structured 429 from a UNIT3D tracker must remain automatically retryable."""
+    error = _upload_raising_from_response(
+        {"success": False, "message": "Rate limited", "data": None}, 429, tmp_path
+    )
+
+    assert error.status_code == 429
+    assert error.retryable is True
+    assert error.server_accepted is False
+    assert ProcessBackEnd._is_automatic_upload_retryable(error) is True
+
+
+def test_unit3d_5xx_response_is_not_retried_automatically(tmp_path: Path) -> None:
+    """A 5xx means UNIT3D received and answered the upload; it must not
+    auto-retry and must route to the user instead."""
+    error = _upload_raising_from_response(
+        {"success": False, "message": "Internal error", "data": None}, 500, tmp_path
+    )
+
+    assert error.status_code == 500
+    assert error.server_accepted is True
+    assert ProcessBackEnd._is_automatic_upload_retryable(error) is False
+
+
 def test_beyondhd_408_response_is_retryable(tmp_path: Path) -> None:
     """A structured 408 from BeyondHD must agree with the generic status-code rule."""
     uploader = BHDUploader(
@@ -165,6 +215,46 @@ def test_beyondhd_408_response_is_retryable(tmp_path: Path) -> None:
     assert error.status_code == 408
     assert error.retryable is True
     assert ProcessBackEnd._is_automatic_upload_retryable(error) is True
+
+
+def _bhd_upload_raising(status_code: int, tmp_path: Path) -> TrackerError:
+    uploader = BHDUploader(
+        api_key="api-key",
+        torrent_file=tmp_path / "release.torrent",
+        input_path=tmp_path / "Example.2026.1080p.WEB-DL-GRP",
+        media_type=MediaType.MOVIE,
+    )
+    mock_response = MagicMock(ok=False, status_code=status_code, reason="error")
+    with (
+        patch.object(BHDUploader, "_build_upload_payload", return_value={}),
+        patch.object(BHDUploader, "_files", return_value={}),
+        patch(
+            "src.backend.trackers.beyondhd.niquests.post", return_value=mock_response
+        ),
+    ):
+        with pytest.raises(TrackerError) as excinfo:
+            uploader.upload(tracker_title="Example.2026.1080p.WEB-DL-GRP")
+    return excinfo.value
+
+
+def test_beyondhd_429_response_is_retryable(tmp_path: Path) -> None:
+    """A structured 429 from BeyondHD must remain automatically retryable."""
+    error = _bhd_upload_raising(429, tmp_path)
+
+    assert error.status_code == 429
+    assert error.retryable is True
+    assert error.server_accepted is False
+    assert ProcessBackEnd._is_automatic_upload_retryable(error) is True
+
+
+def test_beyondhd_5xx_response_is_not_retried_automatically(tmp_path: Path) -> None:
+    """A 5xx means BeyondHD received and answered the upload; it must not
+    auto-retry and must route to the user instead."""
+    error = _bhd_upload_raising(502, tmp_path)
+
+    assert error.status_code == 502
+    assert error.server_accepted is True
+    assert ProcessBackEnd._is_automatic_upload_retryable(error) is False
 
 
 def test_torrentleech_408_response_is_retryable(tmp_path: Path) -> None:
@@ -199,6 +289,59 @@ def test_torrentleech_408_response_is_retryable(tmp_path: Path) -> None:
     assert ProcessBackEnd._is_automatic_upload_retryable(error) is True
 
 
+def _tl_upload_raising(status_code: int, tmp_path: Path) -> TrackerError:
+    torrent_file = tmp_path / "release.torrent"
+    torrent_file.write_bytes(b"original torrent")
+    uploader = TLUploader(announce_key="key")
+    mock_response = MagicMock(
+        ok=False, status_code=status_code, reason="error", text="body"
+    )
+    with (
+        patch.object(TLUploader, "_get_data", return_value={}),
+        patch("src.backend.trackers.torrentleech.VideoResolutionAnalyzer"),
+        patch(
+            "src.backend.trackers.torrentleech.niquests.post",
+            return_value=mock_response,
+        ),
+    ):
+        with pytest.raises(TrackerError) as excinfo:
+            uploader.upload(
+                nfo="nfo contents",
+                tracker_title=None,
+                torrent_file=torrent_file,
+                mediainfo_obj=MagicMock(),
+                media_type=MediaType.MOVIE,
+                is_pack=False,
+            )
+    return excinfo.value
+
+
+def test_torrentleech_429_response_is_retryable(tmp_path: Path) -> None:
+    """A structured 429 from TorrentLeech must remain automatically retryable."""
+    error = _tl_upload_raising(429, tmp_path)
+
+    assert error.status_code == 429
+    assert error.retryable is True
+    assert error.server_accepted is False
+    assert ProcessBackEnd._is_automatic_upload_retryable(error) is True
+
+
+def test_torrentleech_5xx_response_is_not_retried_automatically(tmp_path: Path) -> None:
+    """A 5xx means TorrentLeech received and answered the upload; it must not
+    auto-retry and must route to the user instead.
+
+    Pre-branch, TorrentLeech's message text only matched an old "service
+    unavailable" marker, so 500/502/504 did not auto-retry. This branch's
+    status-code annotation widened that to retry every 5xx automatically;
+    this test locks the safe behaviour back in.
+    """
+    error = _tl_upload_raising(500, tmp_path)
+
+    assert error.status_code == 500
+    assert error.server_accepted is True
+    assert ProcessBackEnd._is_automatic_upload_retryable(error) is False
+
+
 def test_unannotated_error_is_not_retried_automatically() -> None:
     """With every tracker annotated, an unknown error must not be guessed at."""
     assert ProcessBackEnd._is_automatic_upload_retryable(TrackerError("boom")) is False
@@ -221,11 +364,14 @@ def test_error_text_no_longer_drives_retry_decisions() -> None:
 
 
 def test_status_code_still_drives_retry_when_retryable_is_unset() -> None:
+    """A 5xx means the tracker answered the request; it may have recorded
+    the upload before failing, so the status-code fallback must not treat
+    it as automatically retryable."""
     assert (
         ProcessBackEnd._is_automatic_upload_retryable(
             TrackerError("server error", status_code=503)
         )
-        is True
+        is False
     )
     assert (
         ProcessBackEnd._is_automatic_upload_retryable(
@@ -245,13 +391,31 @@ def test_http_408_is_retryable_via_status_code() -> None:
     )
 
 
+def test_http_429_is_retryable_via_status_code() -> None:
+    """A 429 means the request was rejected before processing, so retrying is safe."""
+    assert (
+        ProcessBackEnd._is_automatic_upload_retryable(
+            TrackerError("rate limited", status_code=429)
+        )
+        is True
+    )
+
+
+def test_http_5xx_is_not_retryable_via_status_code() -> None:
+    """A 5xx means the request was received and answered; it must not be
+    guessed as automatically retryable via the status-code fallback."""
+    assert (
+        ProcessBackEnd._is_automatic_upload_retryable(
+            TrackerError("bad gateway", status_code=502)
+        )
+        is False
+    )
+
+
 def test_server_accepted_overrides_retryable() -> None:
     error = TrackerError("timed out", retryable=True, server_accepted=True)
 
     assert ProcessBackEnd._is_automatic_upload_retryable(error) is False
-
-
-from src.backend.upload_retry import scrub_secrets
 
 
 def test_scrub_secrets_redacts_query_string_credentials() -> None:
@@ -294,3 +458,26 @@ def test_scrub_secrets_preserves_everything_after_the_token() -> None:
         "/api/torrents/upload?api_token=[redacted]&foo=bar "
         "(Caused by ReadTimeoutError)"
     )
+
+
+def test_scrub_secrets_redacts_uri_userinfo_password() -> None:
+    """rTorrent embeds credentials as userinfo in its host URI, and an
+    xmlrpc.client.ProtocolError copies the full netloc into its message
+    (verified: ``str(ProtocolError(url, ...))`` includes ``self.url``
+    verbatim). The password must be redacted; the username may stay."""
+    text = (
+        "<ProtocolError for https://myuser:hunter2@tracker.example/rpc: "
+        "500 Internal Server Error>"
+    )
+
+    scrubbed = scrub_secrets(text)
+
+    assert "hunter2" not in scrubbed
+    assert "myuser" in scrubbed
+    assert "https://myuser:[redacted]@tracker.example/rpc" in scrubbed
+
+
+def test_scrub_secrets_leaves_plain_uri_without_credentials_alone() -> None:
+    text = "Failed to reach https://tracker.example/rpc: connection refused"
+
+    assert scrub_secrets(text) == text

--- a/tests/test_frontend/test_process_page_retry.py
+++ b/tests/test_frontend/test_process_page_retry.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -142,3 +143,18 @@ def test_retry_is_relabelled_when_the_tracker_may_have_the_torrent(responses) ->
         ProcessPage._on_upload_retry_signal(QWidget(), _failure(server_accepted=True))
 
     assert responses == [UploadRetryAction.RETRY]
+
+
+def test_cancel_hides_the_process_button() -> None:
+    """Otherwise pressing Process again re-uploads the trackers that finished."""
+    fired: list[bool] = []
+    handler = lambda: fired.append(True)  # noqa: E731
+    GSigs().wizard_process_btn_set_hidden.connect(handler)
+    stub = SimpleNamespace(_job_ended=MagicMock(), _on_text_update=MagicMock())
+    try:
+        ProcessPage._on_cancelled(stub)
+    finally:
+        GSigs().wizard_process_btn_set_hidden.disconnect(handler)
+
+    assert fired == [True]
+    stub._job_ended.assert_called_once_with()

--- a/tests/test_frontend/test_process_page_retry.py
+++ b/tests/test_frontend/test_process_page_retry.py
@@ -124,7 +124,7 @@ def test_default_button_is_not_retry_when_server_accepted(responses) -> None:
 
 def test_download_phase_offers_no_reupload(responses) -> None:
     """The upload already succeeded, so re-POSTing is a guaranteed duplicate."""
-    _FakeMessageBox.click_label = "Keep upload, use local torrent"
+    _FakeMessageBox.click_label = "Keep upload, continue"
     with patch.object(page_module, "QMessageBox", _FakeMessageBox):
         ProcessPage._on_upload_retry_signal(
             QWidget(), _failure(phase=UploadFailurePhase.DOWNLOAD, server_accepted=True)

--- a/tests/test_frontend/test_process_page_retry.py
+++ b/tests/test_frontend/test_process_page_retry.py
@@ -1,0 +1,103 @@
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from PySide6.QtWidgets import QMessageBox, QWidget
+
+import src.frontend.wizards.process as page_module
+from src.backend.upload_retry import (
+    UploadFailure,
+    UploadFailurePhase,
+    UploadRetryAction,
+)
+from src.enums.tracker_selection import TrackerSelection
+from src.frontend.global_signals import GSigs
+from src.frontend.wizards.process import ProcessPage
+
+
+class _FakeButton:
+    def __init__(self, label: str, role: object) -> None:
+        self.label = label
+        self.role = role
+
+
+class _FakeMessageBox:
+    """Stands in for QMessageBox so the slot's decisions are observable."""
+
+    Icon = QMessageBox.Icon
+    ButtonRole = QMessageBox.ButtonRole
+    last: "_FakeMessageBox | None" = None
+    click_label: str | None = None
+
+    def __init__(self, parent: object = None) -> None:
+        self.buttons: list[_FakeButton] = []
+        self.default_button: _FakeButton | None = None
+        self.informative_text = ""
+        _FakeMessageBox.last = self
+
+    def setIcon(self, *_a: object) -> None: ...
+    def setWindowTitle(self, *_a: object) -> None: ...
+    def setText(self, *_a: object) -> None: ...
+
+    def setInformativeText(self, text: str) -> None:
+        self.informative_text = text
+
+    def addButton(self, label: str, role: object) -> _FakeButton:
+        button = _FakeButton(label, role)
+        self.buttons.append(button)
+        return button
+
+    def setDefaultButton(self, button: _FakeButton) -> None:
+        self.default_button = button
+
+    def exec(self) -> None: ...
+
+    def clickedButton(self) -> _FakeButton | None:
+        for button in self.buttons:
+            if button.label == _FakeMessageBox.click_label:
+                return button
+        return None
+
+
+def _failure(**overrides: object) -> UploadFailure:
+    kwargs: dict = {
+        "tracker": TrackerSelection.AITHER,
+        "phase": UploadFailurePhase.UPLOAD,
+        "message": "read timed out",
+        "attempt": 1,
+        "automatic_attempts": 3,
+        "retryable": True,
+        "server_accepted": False,
+        "torrent_path": Path("release.torrent"),
+    }
+    kwargs.update(overrides)
+    return UploadFailure(**kwargs)
+
+
+@pytest.fixture
+def responses():
+    """Record UploadRetryAction values emitted on the global response signal."""
+    seen: list[UploadRetryAction] = []
+    GSigs().upload_retry_response.connect(seen.append)
+    yield seen
+    GSigs().upload_retry_response.disconnect(seen.append)
+
+
+def test_retry_prompt_returns_the_clicked_action(responses) -> None:
+    _FakeMessageBox.click_label = "Skip tracker"
+    with patch.object(page_module, "QMessageBox", _FakeMessageBox):
+        ProcessPage._on_upload_retry_signal(QWidget(), _failure())
+
+    assert responses == [UploadRetryAction.SKIP]
+
+
+def test_worker_released_when_dialog_raises(responses) -> None:
+    """A dialog failure must not leave the worker blocked in loop.exec_()."""
+    boom = MagicMock(side_effect=RuntimeError("Internal C++ object already deleted"))
+    boom.Icon = QMessageBox.Icon
+    boom.ButtonRole = QMessageBox.ButtonRole
+
+    with patch.object(page_module, "QMessageBox", boom):
+        ProcessPage._on_upload_retry_signal(QWidget(), _failure())
+
+    assert responses == [UploadRetryAction.CANCEL]

--- a/tests/test_frontend/test_process_page_retry.py
+++ b/tests/test_frontend/test_process_page_retry.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
+from PySide6.QtCore import QTimer
 from PySide6.QtWidgets import QMessageBox, QWidget
 
 import src.frontend.wizards.process as page_module
@@ -13,7 +14,7 @@ from src.backend.upload_retry import (
 )
 from src.enums.tracker_selection import TrackerSelection
 from src.frontend.global_signals import GSigs
-from src.frontend.wizards.process import ProcessPage
+from src.frontend.wizards.process import ProcessPage, ProcessWorker
 
 
 class _FakeButton:
@@ -158,3 +159,33 @@ def test_cancel_hides_the_process_button() -> None:
 
     assert fired == [True]
     stub._job_ended.assert_called_once_with()
+
+
+def test_worker_is_released_when_the_prompt_never_runs(monkeypatch) -> None:
+    """If the receiver is gone the slot never runs, so nothing would ever reply."""
+    monkeypatch.setattr(ProcessWorker, "RETRY_PROMPT_ACK_TIMEOUT_MS", 50)
+    # Nothing is connected to upload_retry_signal: this is what a destroyed
+    # ProcessPage looks like from the worker's side.
+    stub = SimpleNamespace(upload_retry_signal=MagicMock())
+
+    action = ProcessWorker.upload_retry_and_wait_cb(stub, _failure())
+
+    assert action is UploadRetryAction.CANCEL
+
+
+def test_ack_lets_the_user_take_as_long_as_they_like(monkeypatch) -> None:
+    """Once the GUI acknowledges, the ack watchdog must not fire and cancel."""
+    monkeypatch.setattr(ProcessWorker, "RETRY_PROMPT_ACK_TIMEOUT_MS", 50)
+
+    def _emit_ack_then_answer_late(_failure_arg: object) -> None:
+        GSigs().upload_retry_ack.emit()
+        QTimer.singleShot(
+            150, lambda: GSigs().upload_retry_response.emit(UploadRetryAction.SKIP)
+        )
+
+    stub = SimpleNamespace(upload_retry_signal=SimpleNamespace(emit=_emit_ack_then_answer_late))
+
+    action = ProcessWorker.upload_retry_and_wait_cb(stub, _failure())
+
+    # 150ms > the 50ms ack timeout: proves the watchdog was stopped by the ack.
+    assert action is UploadRetryAction.SKIP

--- a/tests/test_frontend/test_process_page_retry.py
+++ b/tests/test_frontend/test_process_page_retry.py
@@ -3,7 +3,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
-from PySide6.QtCore import QTimer
+from PySide6.QtCore import QObject, QThread, QTimer, Signal, Slot
 from PySide6.QtWidgets import QMessageBox, QWidget
 
 import src.frontend.wizards.process as page_module
@@ -161,21 +161,21 @@ def test_cancel_hides_the_process_button() -> None:
     stub._job_ended.assert_called_once_with()
 
 
-def test_worker_is_released_when_the_prompt_never_runs(monkeypatch) -> None:
+def test_worker_is_released_when_the_prompt_never_runs() -> None:
     """If the receiver is gone the slot never runs, so nothing would ever reply."""
-    monkeypatch.setattr(ProcessWorker, "RETRY_PROMPT_ACK_TIMEOUT_MS", 50)
     # Nothing is connected to upload_retry_signal: this is what a destroyed
     # ProcessPage looks like from the worker's side.
-    stub = SimpleNamespace(upload_retry_signal=MagicMock())
+    stub = SimpleNamespace(
+        upload_retry_signal=MagicMock(), RETRY_PROMPT_ACK_TIMEOUT_MS=50
+    )
 
     action = ProcessWorker.upload_retry_and_wait_cb(stub, _failure())
 
     assert action is UploadRetryAction.CANCEL
 
 
-def test_ack_lets_the_user_take_as_long_as_they_like(monkeypatch) -> None:
+def test_ack_lets_the_user_take_as_long_as_they_like() -> None:
     """Once the GUI acknowledges, the ack watchdog must not fire and cancel."""
-    monkeypatch.setattr(ProcessWorker, "RETRY_PROMPT_ACK_TIMEOUT_MS", 50)
 
     def _emit_ack_then_answer_late(_failure_arg: object) -> None:
         GSigs().upload_retry_ack.emit()
@@ -183,9 +183,84 @@ def test_ack_lets_the_user_take_as_long_as_they_like(monkeypatch) -> None:
             150, lambda: GSigs().upload_retry_response.emit(UploadRetryAction.SKIP)
         )
 
-    stub = SimpleNamespace(upload_retry_signal=SimpleNamespace(emit=_emit_ack_then_answer_late))
+    stub = SimpleNamespace(
+        upload_retry_signal=SimpleNamespace(emit=_emit_ack_then_answer_late),
+        RETRY_PROMPT_ACK_TIMEOUT_MS=50,
+    )
 
     action = ProcessWorker.upload_retry_and_wait_cb(stub, _failure())
 
     # 150ms > the 50ms ack timeout: proves the watchdog was stopped by the ack.
     assert action is UploadRetryAction.SKIP
+
+
+class _RetryWorkerThread(QThread):
+    """Minimal QThread stand-in that runs the real
+    ``ProcessWorker.upload_retry_and_wait_cb`` on its own OS thread, the way
+    ``ProcessWorker`` itself does. A fresh instance is used per run, exactly
+    like a fresh ``ProcessWorker`` per "Process" click in production.
+    """
+
+    upload_retry_signal = Signal(object)
+    finished_with = Signal(object)
+
+    RETRY_PROMPT_ACK_TIMEOUT_MS = 50
+
+    def run(self) -> None:
+        action = ProcessWorker.upload_retry_and_wait_cb(self, _failure())
+        self.finished_with.emit(action)
+
+
+class _MainThreadRetryReceiver(QObject):
+    """Stands in for ``ProcessPage``: one long-lived instance on the main
+    thread answers every worker's retry prompt, like the real page does
+    across repeated "Process" runs."""
+
+    @Slot(object)
+    def on_retry(self, _failure_arg: object) -> None:
+        GSigs().upload_retry_ack.emit()
+        QTimer.singleShot(
+            20, lambda: GSigs().upload_retry_response.emit(UploadRetryAction.SKIP)
+        )
+
+
+def test_second_worker_thread_still_gets_the_users_answer(qapp) -> None:
+    """Regression test for a pre-existing bug the ack watchdog only masks:
+    PySide's queued-connection delivery for a receiver is routed through an
+    internal dispatcher whose thread affinity is fixed by the first
+    connection made in the process. Connecting closures straight to a
+    long-lived global signal pins delivery to whichever worker thread
+    connected first, so a second (or later) ProcessWorker QThread silently
+    lost both the ack and the response and had its answer discarded.
+
+    Runs a real QThread through upload_retry_and_wait_cb twice against one
+    long-lived main-thread receiver and asserts the user's answer survives
+    both times, not just the first.
+    """
+    receiver = _MainThreadRetryReceiver()
+    results: list[UploadRetryAction] = []
+
+    def run_once() -> None:
+        worker = _RetryWorkerThread()
+        worker.upload_retry_signal.connect(receiver.on_retry)
+
+        def _on_finished(action: UploadRetryAction) -> None:
+            results.append(action)
+            qapp.quit()
+
+        worker.finished_with.connect(_on_finished)
+        # Safety net only: every run above should finish in well under
+        # 100ms. This must never fire in a passing run.
+        bail = QTimer()
+        bail.setSingleShot(True)
+        bail.timeout.connect(qapp.quit)
+        bail.start(1000)
+        worker.start()
+        qapp.exec()
+        bail.stop()
+        worker.wait(1000)
+
+    run_once()
+    run_once()
+
+    assert results == [UploadRetryAction.SKIP, UploadRetryAction.SKIP]

--- a/tests/test_frontend/test_process_page_retry.py
+++ b/tests/test_frontend/test_process_page_retry.py
@@ -74,6 +74,12 @@ def _failure(**overrides: object) -> UploadFailure:
     return UploadFailure(**kwargs)
 
 
+@pytest.fixture(autouse=True)
+def _reset_fake_message_box() -> None:
+    _FakeMessageBox.click_label = None
+    _FakeMessageBox.last = None
+
+
 @pytest.fixture
 def responses():
     """Record UploadRetryAction values emitted on the global response signal."""
@@ -101,3 +107,38 @@ def test_worker_released_when_dialog_raises(responses) -> None:
         ProcessPage._on_upload_retry_signal(QWidget(), _failure())
 
     assert responses == [UploadRetryAction.CANCEL]
+
+
+def test_default_button_is_not_retry_when_server_accepted(responses) -> None:
+    """The dialog must not steer a reflexive Enter press into a duplicate."""
+    _FakeMessageBox.click_label = "Skip tracker"
+    with patch.object(page_module, "QMessageBox", _FakeMessageBox):
+        ProcessPage._on_upload_retry_signal(QWidget(), _failure(server_accepted=True))
+
+    default = _FakeMessageBox.last.default_button
+    assert default is not None
+    assert "Retry" not in default.label
+
+
+def test_download_phase_offers_no_reupload(responses) -> None:
+    """The upload already succeeded, so re-POSTing is a guaranteed duplicate."""
+    _FakeMessageBox.click_label = "Keep upload, use local torrent"
+    with patch.object(page_module, "QMessageBox", _FakeMessageBox):
+        ProcessPage._on_upload_retry_signal(
+            QWidget(), _failure(phase=UploadFailurePhase.DOWNLOAD, server_accepted=True)
+        )
+
+    labels = [button.label for button in _FakeMessageBox.last.buttons]
+    assert not any("upload" in label.lower() and "keep" not in label.lower()
+                   for label in labels), labels
+    assert "Retry" not in labels
+    assert responses == [UploadRetryAction.SKIP]
+    assert "upload succeeded" in _FakeMessageBox.last.informative_text.lower()
+
+
+def test_retry_is_relabelled_when_the_tracker_may_have_the_torrent(responses) -> None:
+    _FakeMessageBox.click_label = "Re-upload (may duplicate)"
+    with patch.object(page_module, "QMessageBox", _FakeMessageBox):
+        ProcessPage._on_upload_retry_signal(QWidget(), _failure(server_accepted=True))
+
+    assert responses == [UploadRetryAction.RETRY]


### PR DESCRIPTION
Fixes and hardening for the upload retry work on `upload-retries`. Based on `3a70577` so this diff is only the fixes.

## The blocker

An upload POST that timed out, or that came back as a non-JSON error page, was automatically re-sent up to three times. Both cases mean the request body reached the tracker, so a retry can create a duplicate torrent.

Failures are now classified by whether the body provably reached the tracker. Auto-retry happens only for `ConnectTimeout` and an explicit 408 or 429 — all three mean the request was never processed. Read timeouts, HTML error pages, connection resets and 5xx responses route to the user instead.

Two subtleties worth calling out:

- A bare `ConnectionError` is not proof the body never left. niquests wraps sending the body and reading the response headers in one exception handler, so a tracker that accepted a large upload and then reset while processing it is indistinguishable from a refused connection.
- A 5xx means the tracker received and answered the request, so it may have recorded the torrent before failing. This one had regressed for TorrentLeech: annotating its status codes made 500/502/504 auto-retry when previously they did not.

The error-text heuristic that guessed retryability by substring-matching messages is gone. Trackers now annotate their own failures at the raise site, and an un-annotated error is treated as unsafe rather than guessed at. TorrentLeech interpolates the raw response body into its error message, so any tracker error page containing the word "timeout" used to flip a permanent failure into three retries.

## Pre-existing bugs found along the way

- **Prompt responses were dropped after the first upload run.** PySide routes connections made to plain closures through an internal receiver pinned to the first-connecting thread, so from the second `ProcessWorker` onward the 2FA, overview and retry prompts all silently discarded the user's answer — the worker then blocked forever. All three callbacks now use `QObject` receivers with real slots. Covered by a test driving two real `QThread`s.
- **The PassThePopcorn upload POST had no timeout**, so a hung upload blocked the worker indefinitely.
- **rTorrent credentials could reach on-screen text.** Its host URI embeds `user:password@host` and the injection error path interpolated the raw exception.

## Also included

- The retry dialog no longer defaults to the action that can duplicate, and offers no re-upload at all for a download-phase failure, where the upload definitively succeeded.
- Injection failures reach the prompt, retiring the previously dead `UploadFailurePhase.INJECTION`. Retrying an injection cannot duplicate an upload.
- Cancelling now runs the same cleanup regardless of which phase raised it, and no longer leaves the Process button offering to re-upload trackers that already finished.
- The tracker health probe's retry budget belongs to its caller, so an unreachable tracker no longer burns up to nine probes across two layers of backoff before the user can intervene.
- API tokens are redacted from failure text shown on screen and in dialogs.
- One shared retry-attempts constant, and the retry counter no longer displays "2/3" as the last attempt.

## Testing

545 to 602 tests. The additions cover the paths that had none: the classification policy as a table, the manual retry loop, attempt exhaustion, cancel cleanup, and the cross-thread prompt delivery above.

## Left for follow-up

- Whether a download-phase "keep upload" should inject the local torrent. It currently reports accurately and does not inject — that felt like your call rather than one to make here.
- Log-file scrubbing. Tokens are redacted from the UI, but `LOG.error` in the tracker modules still writes the full URL to disk.
- Retrying an injection re-runs the whole per-client loop, so a client that already succeeded gets a second attempt.