### PR TITLE
Job system: queue settlement, a queue window, and a reworked job picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,15 +21,18 @@
   - `{cut}`: subset of `{edition}` providing only **cut** editions
 - Saveable jobs. The process page now offers **Save Job** alongside Process, storing a
   fully configured upload (media, metadata, screenshots, trackers and their image-host
-  choices) as JSON under `<working directory>/jobs`. **Load Job** on the start page
-  restores one and jumps straight to the process page, ready to upload. Saved jobs keep
-  their own MediaInfo so restoring never re-reads the source file, and duplicate checks
-  still run at process time rather than at save time, so results are never stale.
+  choices) as JSON under `<working directory>/jobs`. **Jobs** on the start page opens
+  the saved-job window; picking one restores it and jumps straight to the process page,
+  ready to upload. The saved-job window filters, sorts, shows what a job contains, and
+  builds the queue as an explicit ordered list. Saved jobs keep their own MediaInfo so
+  restoring never re-reads the source file, and duplicate checks still run at process
+  time rather than at save time, so results are never stale.
   - When a run ends with trackers that were never uploaded -- a tracker that was down
     and got skipped, or trackers left unprocessed after cancelling -- NfoForge offers to
     save just those as a new job. Only trackers whose upload provably did not reach the
     tracker are included, so a deferred job can never re-upload something that already
-    went out.
+    went out. The titles and NFOs from the run are saved with the deferred job,
+    including overview edits, so it uploads exactly what was prepared.
   - Jobs record the config profile they were built under. Jobs belonging to other
     configs are still listed, but greyed out and only openable via **Switch profile and
     load**, since resuming under a different config would silently use its credentials,
@@ -41,8 +44,9 @@
     Resuming reuses all of it: screenshots already uploaded are not sent to the image
     host a second time (while the tracker's image host is unchanged), MediaInfo is
     served from the stored OLDXML and text dumps rather than re-reading the media, and
-    the torrent is cloned instead of re-hashed when the media is byte-for-byte
-    unchanged.
+    the torrent is cloned instead of being re-hashed. A saved torrent is only reused
+    when every file it covers is unchanged, so editing one episode of a pack sends the
+    run back to hashing.
   - **Prepare && Save Job** on the process page runs everything except the upload itself
     -- image uploads, torrent, titles and NFOs -- and saves a job that only needs
     uploading. Running a prepared job asks nothing: prompt-token answers and any edits
@@ -51,11 +55,14 @@
     the job says which one changed, since the saved NFO is what will actually be sent.
   - A **job queue**: select several prepared jobs on the current config and upload them
     one after another. Only prepared jobs qualify, since anything else would stop at a
-    prompt there is nobody to answer. A job is skipped and left saved for review when its
-    duplicate check finds something *or* when that check could not complete -- unverified
-    is treated the same as found, since the queue has nobody to ask what the interactive
-    flow asks. A tracker that fails is retried automatically and then passed by without
-    blocking, and no single job failing stops the ones behind it.
+    prompt there is nobody to answer. A job is skipped and left saved for review when
+    its duplicate check finds something _or_ when that check could not complete --
+    unverified is treated the same as found, since the queue has nobody to ask what the
+    interactive flow asks. Once a job has uploaded, the trackers that went out are
+    removed from it, and a job with nothing left is deleted -- so re-running a queue can
+    never re-upload what already landed. A tracker that fails is retried automatically
+    and then passed by without blocking, and no single job failing stops the ones behind
+    it.
 - Plugins:
   - Added optional post-upload plugins. Processors run once per tracker after that
     tracker's upload and torrent-client injection finish (or fail), reporting one of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,10 +59,11 @@
     its duplicate check finds something _or_ when that check could not complete --
     unverified is treated the same as found, since the queue has nobody to ask what the
     interactive flow asks. Once a job has uploaded, the trackers that went out are
-    removed from it, and a job with nothing left is deleted -- so re-running a queue can
-    never re-upload what already landed. A tracker that fails is retried automatically
-    and then passed by without blocking, and no single job failing stops the ones behind
-    it.
+    removed from it, and a job with nothing left is deleted, so re-running a queue does
+    not re-upload what already landed -- short of that bookkeeping update itself
+    failing, which is logged and leaves the job to try again next run. A tracker that
+    fails is retried automatically and then passed by without blocking, and no single
+    job failing stops the ones behind it.
 - Plugins:
   - Added optional post-upload plugins. Processors run once per tracker after that
     tracker's upload and torrent-client injection finish (or fail), reporting one of

--- a/docs/view/getting-started/using-the-wizard.md
+++ b/docs/view/getting-started/using-the-wizard.md
@@ -229,8 +229,16 @@ Two buttons on the Process Page do this:
   host, the torrent is generated, and titles and NFOs are written. The saved job then
   only needs uploading, and asks nothing when it runs.
 
-**Jobs** on the start page opens the saved-job window. Filter by name, title or tracker;
-add prepared jobs to the queue on the right to upload several in a row.
+**Jobs** on the start page opens the saved-job window. Filter by name, title or tracker,
+sort by any column, and select a job to see what it holds -- its trackers and their
+image hosts, how many screenshots it carries, where its media is and how much disk it
+uses. Add prepared jobs to the queue panel to upload several in a row.
+
+A job whose source media is no longer where it was saved is flagged with a warning icon
+and cannot be processed until the file is back. **Rename** (or F2) changes a job's name
+without touching anything else about it. Selecting several jobs and pressing **Delete**
+removes them together -- along with their screenshots, MediaInfo, NFOs and torrents,
+which cannot be undone.
 
 Each job is a self-contained folder under `<working directory>/jobs`, holding its own
 screenshots, MediaInfo, NFOs and a copy of the torrent. Settings -> General **Clean Up**

--- a/docs/view/getting-started/using-the-wizard.md
+++ b/docs/view/getting-started/using-the-wizard.md
@@ -216,3 +216,64 @@ tracker you selected.
 ```text {.scrollable-code-block}
 --8<-- "docs/snippets/successful_release.txt"
 ```
+
+### Saved jobs
+
+A configured upload can be saved and processed later, including after closing NfoForge.
+Two buttons on the Process Page do this:
+
+- **Save Job** stores the run as it stands. Loading it later picks up at the Process
+  Page, and everything that needs a decision -- prompt tokens, the overview dialog -- is
+  still asked at that point.
+- **Prepare && Save Job** runs everything except the upload: screenshots go to the image
+  host, the torrent is generated, and titles and NFOs are written. The saved job then
+  only needs uploading, and asks nothing when it runs.
+
+**Jobs** on the start page opens the saved-job window. Filter by name, title or tracker;
+add prepared jobs to the queue on the right to upload several in a row.
+
+Each job is a self-contained folder under `<working directory>/jobs`, holding its own
+screenshots, MediaInfo, NFOs and a copy of the torrent. Settings -> General **Clean Up**
+never touches it, so housekeeping cannot destroy saved work, and deleting a job reclaims
+exactly what it was using.
+
+Resuming reuses what it can. Screenshots already uploaded are not sent again while the
+tracker's image host is unchanged, MediaInfo comes from the stored dumps rather than the
+media file, and the torrent is cloned instead of re-hashed as long as every file it
+covers is unchanged.
+
+Duplicate checks are deliberately _not_ run at save time. They run immediately before
+uploading, where the answer is current.
+
+#### Jobs and config profiles
+
+A job records the config profile it was built under but stores no settings of its own --
+credentials, templates and per-tracker options are read live at resume time. Jobs
+belonging to another config are greyed out and open only via **Switch profile and
+load**, since resuming under a different config would silently use its credentials and
+templates. Loading also warns when the active config has disabled one of the job's
+trackers or is missing an NFO template it needs.
+
+NFO templates are shared across configs. A prepared job uploads the NFO it prepared, so
+editing the template afterwards does not change what it sends -- loading the job says
+which template changed so the difference is not silent.
+
+#### The queue
+
+Select prepared jobs on the current config, add them to the queue in the order you want
+them run, and press **Run Queue**. The queue window lists every job and expands the
+running one to show each tracker's status underneath it. A job that finishes cleanly
+collapses to a single line; one that had a problem stays open on the tracker that
+explains why. The queue can be stopped between jobs -- the one currently uploading is
+always left to finish, since interrupting an upload is what risks a half-sent release.
+
+Only prepared jobs qualify: anything else would stop at a prompt with nobody to answer
+it. A job is skipped and kept for review when its duplicate check finds something _or_
+when that check could not complete -- unverified counts the same as found, because the
+queue cannot ask what the interactive flow asks.
+
+Once a job has run, its files are brought into line with what actually uploaded.
+Trackers that uploaded are removed from it; if none are left, the job is deleted.
+Everything else about the job stays untouched: a tracker that failed, was never
+attempted, was skipped, or is switched off in the current config is still there to try
+again, and one whose fate could not be established is left for you to judge.

--- a/docs/view/getting-started/using-the-wizard.md
+++ b/docs/view/getting-started/using-the-wizard.md
@@ -217,7 +217,7 @@ tracker you selected.
 --8<-- "docs/snippets/successful_release.txt"
 ```
 
-### Saved jobs
+### Saved Jobs
 
 A configured upload can be saved and processed later, including after closing NfoForge.
 Two buttons on the Process Page do this:
@@ -253,7 +253,7 @@ covers is unchanged.
 Duplicate checks are deliberately _not_ run at save time. They run immediately before
 uploading, where the answer is current.
 
-#### Jobs and config profiles
+#### Jobs and Config Profiles
 
 A job records the config profile it was built under but stores no settings of its own --
 credentials, templates and per-tracker options are read live at resume time. Jobs
@@ -266,7 +266,7 @@ NFO templates are shared across configs. A prepared job uploads the NFO it prepa
 editing the template afterwards does not change what it sends -- loading the job says
 which template changed so the difference is not silent.
 
-#### The queue
+#### The Queue
 
 Select prepared jobs on the current config, add them to the queue in the order you want
 them run, and press **Run Queue**. The queue window lists every job and expands the

--- a/src/backend/job_queue.py
+++ b/src/backend/job_queue.py
@@ -138,6 +138,9 @@ class JobQueueRunner:
         status_update: Callable[[str, str], None] | None = None,
         progress_cb: Callable[[float], None] | None = None,
         is_cancelled: Callable[[], bool] | None = None,
+        job_started: Callable[[int, str], None] | None = None,
+        job_finished: Callable[[int, QueuedJobOutcome], None] | None = None,
+        text_replace_last_update: Callable[[str], None] | None = None,
     ) -> None:
         self.backend = backend
         self.config = config
@@ -145,6 +148,15 @@ class JobQueueRunner:
         self._status_update = status_update or (lambda _tracker, _status: None)
         self._progress_cb = progress_cb or (lambda _value: None)
         self._is_cancelled = is_cancelled or (lambda: False)
+        # The queue's own window lists jobs before any of them runs, so it needs
+        # to be told when each one starts and ends rather than reconstructing
+        # that from the text log.
+        self._job_started = job_started or (lambda _index, _name: None)
+        self._job_finished = job_finished or (lambda _index, _outcome: None)
+        # A caller with no way to rewrite its last line falls back to appending,
+        # which is what the queue did for everyone -- leaving both halves of
+        # every "running..." / "done" pair in the log.
+        self._text_replace_last_update = text_replace_last_update or self._text_update
 
     # ----------------------------------------------------------------------
     def run(self, job_paths: list[Path]) -> list[QueuedJobOutcome]:
@@ -160,15 +172,18 @@ class JobQueueRunner:
                 f'<br /><h3 style="margin-bottom: 0;">▶️ Job {index} of '
                 f"{len(job_paths)}</h3>"
             )
-            results.append(self._run_one(path))
+            outcome = self._run_one(path, index)
+            self._job_finished(index, outcome)
+            results.append(outcome)
         return results
 
     # ----------------------------------------------------------------------
-    def _run_one(self, path: Path) -> QueuedJobOutcome:
+    def _run_one(self, path: Path, index: int) -> QueuedJobOutcome:
         try:
             job = load_job(path)
         except JobStoreError as error:
             LOG.error(LOG.LOG_SOURCE.BE, f"Queue could not load '{path}': {error}")
+            self._job_started(index, path.name)
             return QueuedJobOutcome(
                 job_name=path.name,
                 path=path,
@@ -176,6 +191,7 @@ class JobQueueRunner:
                 detail=str(error),
             )
 
+        self._job_started(index, job.name)
         self._text_update(f"<br /><span>Loaded <b>{escape(job.name)}</b></span>")
 
         context = self._restore(job, path)
@@ -369,7 +385,7 @@ class JobQueueRunner:
                 process_dict=tracker_data,
                 queued_status_update=self._status_update,
                 queued_text_update=self._text_update,
-                queued_text_update_replace_last_line=self._text_update,
+                queued_text_update_replace_last_line=self._text_replace_last_update,
                 progress_bar_cb=self._progress_cb,
                 # `process_trackers` types this as a Qt signal because every
                 # other caller has a page to surface errors into; the queue has

--- a/src/backend/job_queue.py
+++ b/src/backend/job_queue.py
@@ -21,6 +21,7 @@ import asyncio
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from enum import Enum, auto
+from html import escape
 from pathlib import Path
 import traceback
 from typing import TYPE_CHECKING, Any, cast
@@ -30,8 +31,12 @@ from src.backend.jobs import (
     JobStoreError,
     SavedJob,
     context_from_dict,
+    delete_job,
+    filter_context_document,
     load_job,
+    prune_unreferenced_nfos,
     read_job_asset,
+    write_job_document,
 )
 from src.backend.process import ProcessBackEnd
 from src.backend.tracker_run_data import build_tracker_data
@@ -67,6 +72,19 @@ class QueuedJobResult(Enum):
     """The run raised rather than completing."""
 
 
+class JobDisposition(Enum):
+    """What the queue did with a job's files once it had run it."""
+
+    KEPT = auto()
+    """Left exactly as it was, for a human to look at."""
+
+    NARROWED = auto()
+    """Rewritten to hold only the trackers that still need uploading."""
+
+    DELETED = auto()
+    """Every tracker uploaded, so there was nothing left to keep."""
+
+
 @dataclass(frozen=True, slots=True)
 class DupeCheckResult:
     """What the duplicate check could and could not establish."""
@@ -97,6 +115,8 @@ class QueuedJobOutcome:
     result: QueuedJobResult
     detail: str = ""
     outcomes: dict[TrackerSelection, TrackerRunOutcome] = field(default_factory=dict)
+    disposition: JobDisposition = JobDisposition.KEPT
+    """What became of this job's files. See `JobQueueRunner._settle`."""
 
     def deferrable_trackers(self) -> set[TrackerSelection]:
         """Trackers this job left un-uploaded that are safe to try again."""
@@ -156,7 +176,7 @@ class JobQueueRunner:
                 detail=str(error),
             )
 
-        self._text_update(f"<br /><span>Loaded <b>{job.name}</b></span>")
+        self._text_update(f"<br /><span>Loaded <b>{escape(job.name)}</b></span>")
 
         context = self._restore(job, path)
         if isinstance(context, str):
@@ -172,7 +192,8 @@ class JobQueueRunner:
             # dialog, which is precisely what a queue cannot answer
             detail = "job is not prepared, so it would need a user to run"
             self._text_update(
-                f"<br /><span>⏭ Skipping <b>{job.name}</b>: {detail}</span>"
+                f"<br /><span>⏭ Skipping <b>{escape(job.name)}</b>: "
+                f"{escape(detail)}</span>"
             )
             return QueuedJobOutcome(
                 job_name=job.name,
@@ -184,7 +205,8 @@ class JobQueueRunner:
         unusable = self._unusable_reason(context)
         if unusable:
             self._text_update(
-                f"<br /><span>⏭ Skipping <b>{job.name}</b>: {unusable}</span>"
+                f"<br /><span>⏭ Skipping <b>{escape(job.name)}</b>: "
+                f"{escape(unusable)}</span>"
             )
             return QueuedJobOutcome(
                 job_name=job.name,
@@ -215,8 +237,8 @@ class JobQueueRunner:
                 reasons.append(f"could not check {', '.join(dupes.unverified)}")
             detail = "; ".join(reasons)
             self._text_update(
-                f"<br /><span>⏭ Skipping <b>{job.name}</b>: {detail}. The job is "
-                "kept for you to review.</span>"
+                f"<br /><span>⏭ Skipping <b>{escape(job.name)}</b>: "
+                f"{escape(detail)}. The job is kept for you to review.</span>"
             )
             return QueuedJobOutcome(
                 job_name=job.name,
@@ -231,7 +253,9 @@ class JobQueueRunner:
                 detail=detail,
             )
 
-        return self._upload(job, path, context, tracker_data)
+        outcome = self._upload(job, path, context, tracker_data)
+        self._settle(job, outcome)
+        return outcome
 
     # ----------------------------------------------------------------------
     def _restore(self, job: SavedJob, path: Path) -> ProcessingContext | str:
@@ -378,6 +402,74 @@ class JobQueueRunner:
             path=path,
             result=QueuedJobResult.UPLOADED,
             outcomes=outcomes,
+        )
+
+    def _settle(self, job: SavedJob, outcome: QueuedJobOutcome) -> None:
+        """Bring a job's files into line with what actually uploaded.
+
+        A job left on disk unchanged after uploading is a job the next queue run
+        uploads all over again, so anything that reached a tracker has to come
+        out of it. What remains is written back as an ordinary job -- structurally
+        indistinguishable from one saved before any upload was attempted -- and
+        when nothing remains, the job is gone.
+
+        Two cases deliberately change nothing. An upload whose fate is unknown
+        (`MAY_HAVE_UPLOADED`) is exactly the case a human has to judge, and
+        deleting the job would destroy what they need to judge it with. Trackers
+        that were merely switched off in config never uploaded at all, so the
+        job is still entirely ahead of it.
+        """
+        if not outcome.outcomes:
+            # the run never reached the upload stage, so there is nothing to
+            # reconcile -- a skipped job is kept for review as it was
+            return
+
+        deferrable = outcome.deferrable_trackers()
+        if len(deferrable) == len(outcome.outcomes):
+            return
+
+        uploaded_any = any(
+            tracker_outcome
+            in {TrackerRunOutcome.UPLOADED, TrackerRunOutcome.INJECTION_FAILED}
+            for tracker_outcome in outcome.outcomes.values()
+        )
+
+        if not deferrable:
+            if not uploaded_any:
+                self._text_update(
+                    f"<br /><span>Left <b>{escape(job.name)}</b> alone: none of "
+                    "its trackers can be safely retried and none provably "
+                    "uploaded, so it needs a look</span>"
+                )
+                return
+            try:
+                delete_job(outcome.path)
+            except JobStoreError as error:
+                LOG.error(
+                    LOG.LOG_SOURCE.BE, f"Could not remove a finished job: {error}"
+                )
+                return
+            outcome.disposition = JobDisposition.DELETED
+            self._text_update(
+                f"<br /><span>🧹 Removed <b>{escape(job.name)}</b>; every tracker "
+                "uploaded</span>"
+            )
+            return
+
+        job.context = filter_context_document(job.context, deferrable)
+        job.summary.trackers = [str(tracker) for tracker in sorted(deferrable, key=str)]
+        try:
+            write_job_document(job, outcome.path)
+            prune_unreferenced_nfos(outcome.path, job.context)
+        except (JobStoreError, OSError) as error:
+            LOG.error(LOG.LOG_SOURCE.BE, f"Could not narrow a finished job: {error}")
+            return
+
+        outcome.disposition = JobDisposition.NARROWED
+        remaining = ", ".join(str(tracker) for tracker in sorted(deferrable, key=str))
+        self._text_update(
+            f"<br /><span>📝 Kept <b>{escape(job.name)}</b> for {remaining}; the "
+            "trackers that uploaded were removed from it</span>"
         )
 
 

--- a/src/backend/job_queue.py
+++ b/src/backend/job_queue.py
@@ -433,7 +433,9 @@ class JobQueueRunner:
             in {TrackerRunOutcome.UPLOADED, TrackerRunOutcome.INJECTION_FAILED}
         }
         if not landed:
-            # nothing reached a tracker, so the job is still exactly itself
+            # Nothing reached a tracker, so the job is still exactly itself.
+            # It still needs saying when one of them cannot be accounted for.
+            self._warn_unconfirmed(job, outcome)
             return
 
         retained = set(outcome.outcomes) - landed
@@ -491,18 +493,31 @@ class JobQueueRunner:
             f"{escape(remaining)}; the trackers that uploaded were removed from "
             "it</span>"
         )
+        self._warn_unconfirmed(job, outcome)
 
+    def _warn_unconfirmed(self, job: SavedJob, outcome: QueuedJobOutcome) -> None:
+        """Name any tracker whose upload could not be established either way.
+
+        The queue can neither retry these nor write them off, so they are the
+        one outcome that needs a person. Said whether the job was narrowed or
+        left alone, because the question is the same either way.
+
+        Deliberately silent about a tracker whose uploads are switched off in
+        config: nothing was sent, but the user is the one who arranged that, so
+        reporting it as something to look into would be noise.
+        """
         unconfirmed = sorted(
             str(tracker)
             for tracker, tracker_outcome in outcome.outcomes.items()
             if tracker_outcome is TrackerRunOutcome.MAY_HAVE_UPLOADED
         )
-        if unconfirmed:
-            self._text_update(
-                f"<br /><span>⚠️ Check {escape(', '.join(unconfirmed))} on the "
-                "tracker before running this job again -- the upload could not "
-                "be confirmed either way</span>"
-            )
+        if not unconfirmed:
+            return
+        self._text_update(
+            f"<br /><span>⚠️ Check {escape(', '.join(unconfirmed))} on the "
+            f"tracker before running <b>{escape(job.name)}</b> again -- the "
+            "upload could not be confirmed either way</span>"
+        )
 
 
 class _LoggingSignal:

--- a/src/backend/job_queue.py
+++ b/src/backend/job_queue.py
@@ -408,45 +408,48 @@ class JobQueueRunner:
         """Bring a job's files into line with what actually uploaded.
 
         A job left on disk unchanged after uploading is a job the next queue run
-        uploads all over again, so anything that reached a tracker has to come
-        out of it. What remains is written back as an ordinary job -- structurally
-        indistinguishable from one saved before any upload was attempted -- and
-        when nothing remains, the job is gone.
+        uploads all over again, so a tracker that reached its destination has to
+        come out of it. Exactly one thing earns removal: proof the release
+        landed. Everything else stays -- never attempted, skipped, provably
+        failed, switched off in config, or an upload nobody can account for --
+        because each of those is either still to do or still to judge, and the
+        job folder is where its prepared torrent and NFO live.
 
-        Two cases deliberately change nothing. An upload whose fate is unknown
-        (`MAY_HAVE_UPLOADED`) is exactly the case a human has to judge, and
-        deleting the job would destroy what they need to judge it with. Trackers
-        that were merely switched off in config never uploaded at all, so the
-        job is still entirely ahead of it.
+        Framing this as "remove only what provably landed" rather than "keep
+        only what is safe to retry" is what makes the awkward outcomes fall out
+        correctly. `MAY_HAVE_UPLOADED` is neither retryable nor done, and
+        neither is a tracker whose uploads are disabled in config; a two-way
+        split counts both as finished and deletes their prepared work.
         """
         if not outcome.outcomes:
             # the run never reached the upload stage, so there is nothing to
             # reconcile -- a skipped job is kept for review as it was
             return
 
-        deferrable = outcome.deferrable_trackers()
-        if len(deferrable) == len(outcome.outcomes):
+        landed = {
+            tracker
+            for tracker, tracker_outcome in outcome.outcomes.items()
+            if tracker_outcome
+            in {TrackerRunOutcome.UPLOADED, TrackerRunOutcome.INJECTION_FAILED}
+        }
+        if not landed:
+            # nothing reached a tracker, so the job is still exactly itself
             return
 
-        uploaded_any = any(
-            tracker_outcome
-            in {TrackerRunOutcome.UPLOADED, TrackerRunOutcome.INJECTION_FAILED}
-            for tracker_outcome in outcome.outcomes.values()
-        )
-
-        if not deferrable:
-            if not uploaded_any:
-                self._text_update(
-                    f"<br /><span>Left <b>{escape(job.name)}</b> alone: none of "
-                    "its trackers can be safely retried and none provably "
-                    "uploaded, so it needs a look</span>"
-                )
-                return
+        retained = set(outcome.outcomes) - landed
+        if not retained:
             try:
                 delete_job(outcome.path)
             except JobStoreError as error:
                 LOG.error(
                     LOG.LOG_SOURCE.BE, f"Could not remove a finished job: {error}"
+                )
+                # the one failure that silently re-uploads everywhere next run,
+                # so it cannot be log-only
+                self._text_update(
+                    f"<br /><span>⚠️ <b>{escape(job.name)}</b> uploaded everywhere "
+                    "but could not be removed, so it is still saved and will "
+                    f"upload again if queued: {escape(str(error))}</span>"
                 )
                 return
             outcome.disposition = JobDisposition.DELETED
@@ -456,21 +459,50 @@ class JobQueueRunner:
             )
             return
 
-        job.context = filter_context_document(job.context, deferrable)
-        job.summary.trackers = [str(tracker) for tracker in sorted(deferrable, key=str)]
         try:
+            job.context = filter_context_document(job.context, retained)
+            job.summary.trackers = [
+                str(tracker) for tracker in sorted(retained, key=str)
+            ]
             write_job_document(job, outcome.path)
-            prune_unreferenced_nfos(outcome.path, job.context)
         except (JobStoreError, OSError) as error:
             LOG.error(LOG.LOG_SOURCE.BE, f"Could not narrow a finished job: {error}")
+            self._text_update(
+                f"<br /><span>⚠️ <b>{escape(job.name)}</b> still lists the trackers "
+                "that already uploaded and will send to them again if queued: "
+                f"{escape(str(error))}</span>"
+            )
             return
 
+        # the write is the commit point: from here the document on disk is
+        # correct, so the disposition is true even if the tidy-up below fails
         outcome.disposition = JobDisposition.NARROWED
-        remaining = ", ".join(str(tracker) for tracker in sorted(deferrable, key=str))
+        try:
+            prune_unreferenced_nfos(outcome.path, job.context)
+        except OSError as error:
+            LOG.warning(
+                LOG.LOG_SOURCE.BE,
+                f"Left stale NFOs behind in {outcome.path}: {error}",
+            )
+
+        remaining = ", ".join(str(tracker) for tracker in sorted(retained, key=str))
         self._text_update(
-            f"<br /><span>📝 Kept <b>{escape(job.name)}</b> for {remaining}; the "
-            "trackers that uploaded were removed from it</span>"
+            f"<br /><span>📝 Kept <b>{escape(job.name)}</b> for "
+            f"{escape(remaining)}; the trackers that uploaded were removed from "
+            "it</span>"
         )
+
+        unconfirmed = sorted(
+            str(tracker)
+            for tracker, tracker_outcome in outcome.outcomes.items()
+            if tracker_outcome is TrackerRunOutcome.MAY_HAVE_UPLOADED
+        )
+        if unconfirmed:
+            self._text_update(
+                f"<br /><span>⚠️ Check {escape(', '.join(unconfirmed))} on the "
+                "tracker before running this job again -- the upload could not "
+                "be confirmed either way</span>"
+            )
 
 
 class _LoggingSignal:

--- a/src/backend/jobs/__init__.py
+++ b/src/backend/jobs/__init__.py
@@ -38,7 +38,9 @@ from src.backend.jobs.store import (
     jobs_dir,
     list_jobs,
     load_job,
+    prune_unreferenced_nfos,
     save_job,
+    write_job_document,
 )
 
 __all__ = [
@@ -66,7 +68,9 @@ __all__ = [
     "list_jobs",
     "load_job",
     "mediainfo_xml",
+    "prune_unreferenced_nfos",
     "read_job_asset",
     "save_job",
     "template_fingerprint",
+    "write_job_document",
 ]

--- a/src/backend/jobs/__init__.py
+++ b/src/backend/jobs/__init__.py
@@ -18,8 +18,11 @@ from src.backend.jobs.assets import (
     capture_nfos,
     copy_base_torrent,
     copy_images,
+    fingerprint_files,
+    fingerprints_match,
     read_job_asset,
     template_fingerprint,
+    torrent_content_files,
 )
 from src.backend.jobs.codec import (
     JobCodecError,
@@ -63,6 +66,8 @@ __all__ = [
     "copy_images",
     "delete_job",
     "filter_context_document",
+    "fingerprint_files",
+    "fingerprints_match",
     "job_dir",
     "jobs_dir",
     "list_jobs",
@@ -72,5 +77,6 @@ __all__ = [
     "read_job_asset",
     "save_job",
     "template_fingerprint",
+    "torrent_content_files",
     "write_job_document",
 ]

--- a/src/backend/jobs/assets.py
+++ b/src/backend/jobs/assets.py
@@ -287,7 +287,10 @@ def torrent_content_files(input_path: Path) -> list[Path]:
         found: list[Path] = []
         for directory, _sub_dirs, file_names in os.walk(input_path, followlinks=True):
             found.extend(Path(directory) / name for name in file_names)
-        return sorted(found)
+        # sorted with the same casefold key torf's list_files uses (see
+        # torf/_utils.py), so the order this reports matches the order torf
+        # itself assigns the pack's files
+        return sorted(found, key=lambda path: str(path).casefold())
     return [input_path] if input_path.is_file() else []
 
 

--- a/src/backend/jobs/assets.py
+++ b/src/backend/jobs/assets.py
@@ -15,8 +15,9 @@ Three kinds of asset are captured:
   plain-text dump trackers actually receive. Between them a resumed run never
   has to call `MediaInfo.parse()` against the media again.
 - **The base torrent**, so a resumed run clones instead of re-hashing what may
-  be tens of gigabytes. Recorded with the media's size and mtime so a changed
-  file falls back to hashing rather than shipping stale piece hashes.
+  be tens of gigabytes. Recorded with the size and mtime of every file the
+  torrent covers, so a changed, added, or removed file falls back to hashing
+  rather than shipping stale piece hashes.
 
 Qt-free, so it stays unit testable.
 """
@@ -26,6 +27,7 @@ from __future__ import annotations
 from collections.abc import Iterable
 from dataclasses import dataclass
 import hashlib
+import os
 from pathlib import Path
 import shutil
 from typing import Any
@@ -267,9 +269,25 @@ def torrent_content_files(input_path: Path) -> list[Path]:
     Walks the input rather than reading `MediaInputPayload.file_list`: the
     torrent is built from `input_path`, so for a pack it also covers subtitles
     and other extras that the media file list leaves out.
+
+    Uses `os.walk(followlinks=True)` rather than `Path.rglob`: torf itself
+    walks with `followlinks=True` (see `torf/_utils.py`), and `rglob`'s `**`
+    does not descend into a symlinked directory on this project's Python
+    floor. Missing a symlinked subtree here would mean a file the torrent
+    covers is never fingerprinted, so an edit inside it would go undetected --
+    the exact failure this function exists to close.
+
+    Index sidecars such as `.lwi`/`.ffindex` are deliberately included even
+    though torrent creation excludes them (see `INDEX_SIDECAR_GLOBS` in
+    `src/backend/torrents/torrent.py`): fingerprinting a file the torrent does
+    not actually contain only costs a spurious re-hash, never a stale clone,
+    and it is not worth coupling this package to that one over it.
     """
     if input_path.is_dir():
-        return sorted(path for path in input_path.rglob("*") if path.is_file())
+        found: list[Path] = []
+        for directory, _sub_dirs, file_names in os.walk(input_path, followlinks=True):
+            found.extend(Path(directory) / name for name in file_names)
+        return sorted(found)
     return [input_path] if input_path.is_file() else []
 
 

--- a/src/backend/jobs/assets.py
+++ b/src/backend/jobs/assets.py
@@ -23,6 +23,7 @@ Qt-free, so it stays unit testable.
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass
 import hashlib
 from pathlib import Path
@@ -258,3 +259,45 @@ def base_torrent_path(directory: Path) -> Path | None:
     """The stored base torrent, if this job has one."""
     candidate = directory / JOB_BASE_TORRENT_NAME
     return candidate if candidate.is_file() else None
+
+
+def torrent_content_files(input_path: Path) -> list[Path]:
+    """Every file the generated torrent covers, in a stable order.
+
+    Walks the input rather than reading `MediaInputPayload.file_list`: the
+    torrent is built from `input_path`, so for a pack it also covers subtitles
+    and other extras that the media file list leaves out.
+    """
+    if input_path.is_dir():
+        return sorted(path for path in input_path.rglob("*") if path.is_file())
+    return [input_path] if input_path.is_file() else []
+
+
+def fingerprint_files(paths: Iterable[Path]) -> dict[str, dict[str, int]]:
+    """Size and mtime for each path, keyed by its string form."""
+    captured: dict[str, dict[str, int]] = {}
+    for path in paths:
+        try:
+            captured[str(path)] = MediaFingerprint.of(path).to_dict()
+        except OSError as error:
+            raise JobAssetError(f"Could not fingerprint '{path}': {error}") from error
+    return captured
+
+
+def fingerprints_match(stored: Any, input_path: Path) -> bool:
+    """Whether every file the torrent covers is unchanged since it was recorded.
+
+    The recorded set has to match exactly. A file added to or removed from a
+    pack changes the torrent just as surely as an edited one does, and a clone
+    made from a stale base uploads a torrent that does not describe its own
+    content.
+    """
+    if not isinstance(stored, dict) or not stored:
+        return False
+    if {str(path) for path in torrent_content_files(input_path)} != set(stored):
+        return False
+    for raw_path, raw_fingerprint in stored.items():
+        fingerprint = MediaFingerprint.from_dict(raw_fingerprint)
+        if fingerprint is None or not fingerprint.matches(Path(raw_path)):
+            return False
+    return True

--- a/src/backend/jobs/codec.py
+++ b/src/backend/jobs/codec.py
@@ -125,6 +125,21 @@ def _json_safe_mapping(mapping: dict[str, Any], label: str) -> dict[str, Any]:
     return safe
 
 
+def _json_safe_value(value: Any, label: str) -> Any:
+    """Keep a free-form value only if it survives JSON.
+
+    The metadata providers hand back decoded JSON, so this normally passes
+    untouched. A plugin is free to put anything in these fields, though, and one
+    odd object should cost that field rather than the whole job.
+    """
+    try:
+        json.dumps(value)
+    except (TypeError, ValueError):
+        LOG.warning(LOG.LOG_SOURCE.BE, f"Job save dropped non-serializable {label}")
+        return None
+    return value
+
+
 # --------------------------------------------------------------------------
 # custom types
 # --------------------------------------------------------------------------
@@ -366,11 +381,11 @@ def _media_search_to_dict(context: ProcessingContext) -> dict[str, Any]:
         "media_type": _enum_name(payload.media_type),
         "imdb_id": payload.imdb_id,
         "tmdb_id": payload.tmdb_id,
-        "tmdb_data": payload.tmdb_data,
+        "tmdb_data": _json_safe_value(payload.tmdb_data, "tmdb_data"),
         "tvdb_id": payload.tvdb_id,
-        "tvdb_data": payload.tvdb_data,
+        "tvdb_data": _json_safe_value(payload.tvdb_data, "tvdb_data"),
         "anilist_id": payload.anilist_id,
-        "anilist_data": payload.anilist_data,
+        "anilist_data": _json_safe_value(payload.anilist_data, "anilist_data"),
         "mal_id": payload.mal_id,
         "title": payload.title,
         "year": payload.year,

--- a/src/backend/jobs/models.py
+++ b/src/backend/jobs/models.py
@@ -23,6 +23,13 @@ class JobSummary:
     input_name: str | None = None
     file_count: int = 0
     trackers: list[str] = field(default_factory=list)
+    input_path: str = ""
+    """Full path of the media, so the picker can tell a broken job at a glance.
+
+    `input_name` is only the file name, which cannot be checked against the
+    filesystem. Jobs saved before this was recorded leave it empty and are
+    treated as fine rather than as broken.
+    """
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -32,6 +39,7 @@ class JobSummary:
             "input_name": self.input_name,
             "file_count": self.file_count,
             "trackers": list(self.trackers),
+            "input_path": self.input_path,
         }
 
     @classmethod
@@ -46,6 +54,7 @@ class JobSummary:
             trackers=[str(tracker) for tracker in trackers]
             if isinstance(trackers, list)
             else [],
+            input_path=str(document.get("input_path") or ""),
         )
 
 
@@ -124,6 +133,12 @@ class JobListing:
 
     Only a prepared job can be run from the queue: an unprepared one would stop
     at a prompt there is nobody to answer.
+    """
+    media_available: bool = True
+    """Whether the job's media is still where it was saved.
+
+    Checked when the list is built so a job that cannot run is visible as such
+    before the user commits to loading it.
     """
 
     def matches_profile(self, active_profile: str | None) -> bool:

--- a/src/backend/jobs/store.py
+++ b/src/backend/jobs/store.py
@@ -264,18 +264,25 @@ def list_jobs(working_dirs: Iterable[Path]) -> list[JobListing]:
             except JobStoreError as error:
                 LOG.warning(LOG.LOG_SOURCE.BE, f"Skipping unreadable job: {error}")
                 continue
-            summary = document.get("summary")
+            summary_document = document.get("summary")
+            summary = JobSummary.from_dict(
+                summary_document if isinstance(summary_document, dict) else {}
+            )
+            # cheap enough to do per job, and it is the difference between the
+            # user finding out here and finding out after clicking Load
+            media_available = (
+                Path(summary.input_path).exists() if summary.input_path else True
+            )
             listings.append(
                 JobListing(
                     job_id=str(document.get("job_id") or candidate.name),
                     name=str(document.get("name") or candidate.name),
                     created_at=str(document.get("created_at") or ""),
                     config_profile=str(document.get("config_profile") or ""),
-                    summary=JobSummary.from_dict(
-                        summary if isinstance(summary, dict) else {}
-                    ),
+                    summary=summary,
                     prepared=_document_is_prepared(document),
                     path=candidate,
+                    media_available=media_available,
                 )
             )
 

--- a/src/backend/jobs/store.py
+++ b/src/backend/jobs/store.py
@@ -128,7 +128,7 @@ def build_job(
 
 
 def write_job_document(job: SavedJob, directory: Path) -> Path:
-    """Write `job.json` into an existing job directory and return that directory.
+    """Write `job.json` into a job directory, creating it if needed, and return it.
 
     `save_job` derives the directory from a working directory plus a job id.
     This takes the directory itself, which is what a caller holding only a

--- a/src/backend/jobs/store.py
+++ b/src/backend/jobs/store.py
@@ -170,22 +170,41 @@ def prune_unreferenced_nfos(directory: Path, context: dict[str, Any]) -> None:
     Narrowing a job to fewer trackers leaves the dropped trackers' NFOs behind.
     They are dead weight, and worse, they read as evidence the job still covers
     those trackers.
+
+    A malformed context must not read as "references nothing": that would
+    delete every NFO the job owns instead of the handful a narrowing dropped.
+    So a missing or wrong-typed `tracker_release_data` bails out with nothing
+    touched, while a `tracker_release_data` that is present but genuinely
+    empty (a job with no NFOs at all) still prunes -- that mapping deliberately
+    driving zero references is not the same as not having one to read.
     """
     nfo_dir = directory / JOB_NFO_DIR_NAME
     if not nfo_dir.is_dir():
         return
 
-    referenced: set[str] = set()
     shared = context.get("shared_data")
-    if isinstance(shared, dict):
-        release_data = shared.get("tracker_release_data")
-        if isinstance(release_data, dict):
-            for entry in release_data.values():
-                if not isinstance(entry, dict):
-                    continue
-                name = entry.get("nfo_asset")
-                if isinstance(name, str) and name:
-                    referenced.add(Path(name).name)
+    if not isinstance(shared, dict):
+        LOG.warning(
+            LOG.LOG_SOURCE.BE,
+            f"Not pruning NFOs in '{directory}': context has no 'shared_data' mapping",
+        )
+        return
+    release_data = shared.get("tracker_release_data")
+    if not isinstance(release_data, dict):
+        LOG.warning(
+            LOG.LOG_SOURCE.BE,
+            f"Not pruning NFOs in '{directory}': context has no "
+            "'tracker_release_data' mapping",
+        )
+        return
+
+    referenced: set[str] = set()
+    for entry in release_data.values():
+        if not isinstance(entry, dict):
+            continue
+        name = entry.get("nfo_asset")
+        if isinstance(name, str) and name:
+            referenced.add(Path(name).name)
 
     for candidate in nfo_dir.iterdir():
         if candidate.is_file() and candidate.name not in referenced:

--- a/src/backend/jobs/store.py
+++ b/src/backend/jobs/store.py
@@ -31,6 +31,7 @@ from datetime import datetime, timezone
 import json
 from pathlib import Path
 import shutil
+from typing import Any
 
 import shortuuid
 
@@ -64,7 +65,9 @@ __all__ = [
     "jobs_dir",
     "list_jobs",
     "load_job",
+    "prune_unreferenced_nfos",
     "save_job",
+    "write_job_document",
 ]
 
 
@@ -124,6 +127,31 @@ def build_job(
     )
 
 
+def write_job_document(job: SavedJob, directory: Path) -> Path:
+    """Write `job.json` into an existing job directory and return that directory.
+
+    `save_job` derives the directory from a working directory plus a job id.
+    This takes the directory itself, which is what a caller holding only a
+    job's path has -- the queue rewriting a job it just ran, or the picker
+    renaming one.
+    """
+    directory.mkdir(parents=True, exist_ok=True)
+    try:
+        payload = json.dumps(job.to_dict(), indent=2)
+    except (TypeError, ValueError) as error:
+        # a plugin or metadata provider can put anything in the free-form
+        # fields; failing here rather than escaping as a raw TypeError is what
+        # lets the caller clean up the half-written directory
+        raise JobStoreError(
+            f"Job '{job.name}' contains data that cannot be saved: {error}"
+        ) from error
+    try:
+        atomic_write_text(directory / JOB_DOCUMENT_NAME, payload)
+    except OSError as error:
+        raise JobStoreError(f"Could not write job to '{directory}': {error}") from error
+    return directory
+
+
 def save_job(job: SavedJob, working_dir: Path) -> Path:
     """Write a job's document into its directory and return that directory.
 
@@ -131,15 +159,37 @@ def save_job(job: SavedJob, working_dir: Path) -> Path:
     been placed in the directory by the caller: this writes `job.json` last so
     the job only becomes visible once it is complete.
     """
-    directory = job_dir(working_dir, job.job_id, ensure_exists=True)
-    try:
-        atomic_write_text(
-            directory / JOB_DOCUMENT_NAME, json.dumps(job.to_dict(), indent=2)
-        )
-    except OSError as error:
-        raise JobStoreError(f"Could not write job to '{directory}': {error}") from error
+    directory = write_job_document(job, job_dir(working_dir, job.job_id))
     LOG.info(LOG.LOG_SOURCE.BE, f"Saved job '{job.name}' to {directory}")
     return directory
+
+
+def prune_unreferenced_nfos(directory: Path, context: dict[str, Any]) -> None:
+    """Delete NFO sidecars a job's context no longer points at.
+
+    Narrowing a job to fewer trackers leaves the dropped trackers' NFOs behind.
+    They are dead weight, and worse, they read as evidence the job still covers
+    those trackers.
+    """
+    nfo_dir = directory / JOB_NFO_DIR_NAME
+    if not nfo_dir.is_dir():
+        return
+
+    referenced: set[str] = set()
+    shared = context.get("shared_data")
+    if isinstance(shared, dict):
+        release_data = shared.get("tracker_release_data")
+        if isinstance(release_data, dict):
+            for entry in release_data.values():
+                if not isinstance(entry, dict):
+                    continue
+                name = entry.get("nfo_asset")
+                if isinstance(name, str) and name:
+                    referenced.add(Path(name).name)
+
+    for candidate in nfo_dir.iterdir():
+        if candidate.is_file() and candidate.name not in referenced:
+            candidate.unlink(missing_ok=True)
 
 
 def _read_document(path: Path) -> dict:

--- a/src/backend/utils/working_dir.py
+++ b/src/backend/utils/working_dir.py
@@ -57,10 +57,18 @@ def cleanable_items(working_dir: Path) -> list[Path]:
     Expressed as an exclusion rather than "only the processing folder" so that
     run folders written directly at the working directory root by older
     versions are swept up too, without needing a migration step.
+
+    Same race `cleanable_size` guards one level down: the directory can be
+    removed in the window between the `is_dir()` check and `iterdir()`
+    actually running, and an unhandled `OSError` there would surface out of
+    this function and out of `cleanable_size`, which iterates its result.
     """
     if not working_dir.is_dir():
         return []
-    return [item for item in working_dir.iterdir() if item.name != JOBS_DIR_NAME]
+    try:
+        return [item for item in working_dir.iterdir() if item.name != JOBS_DIR_NAME]
+    except OSError:
+        return []
 
 
 def cleanable_size(working_dir: Path) -> int:

--- a/src/backend/utils/working_dir.py
+++ b/src/backend/utils/working_dir.py
@@ -61,3 +61,22 @@ def cleanable_items(working_dir: Path) -> list[Path]:
     if not working_dir.is_dir():
         return []
     return [item for item in working_dir.iterdir() if item.name != JOBS_DIR_NAME]
+
+
+def cleanable_size(working_dir: Path) -> int:
+    """Bytes clean up could reclaim.
+
+    Files can vanish between being listed and being measured -- another run
+    writing into the same tree, the OS clearing a temp file -- and a status bar
+    readout is never worth an exception.
+    """
+    total = 0
+    for item in cleanable_items(working_dir):
+        candidates = item.rglob("*") if item.is_dir() else iter((item,))
+        for candidate in candidates:
+            try:
+                if candidate.is_file():
+                    total += candidate.stat().st_size
+            except OSError:
+                continue
+    return total

--- a/src/backend/utils/working_dir.py
+++ b/src/backend/utils/working_dir.py
@@ -66,17 +66,29 @@ def cleanable_items(working_dir: Path) -> list[Path]:
 def cleanable_size(working_dir: Path) -> int:
     """Bytes clean up could reclaim.
 
-    Files can vanish between being listed and being measured -- another run
-    writing into the same tree, the OS clearing a temp file -- and a status bar
-    readout is never worth an exception.
+    Two nested guards, because a scan can lose ground at two different levels.
+    A single file can vanish between being listed and being stat()'d -- the
+    inner guard skips just that file so its siblings still count toward the
+    total. But the walk itself can also vanish out from under us: rglob()
+    calls os.scandir() lazily as it descends and only swallows
+    PermissionError, so if a whole subdirectory disappears mid-descent (a
+    concurrent job's run folder, say) the exception surfaces from the `for`
+    statement itself, past a guard sitting only in the loop body. The outer
+    guard catches that case too, so one vanished top-level item doesn't cost
+    us the count already gathered for the rest.
     """
     total = 0
     for item in cleanable_items(working_dir):
-        candidates = item.rglob("*") if item.is_dir() else iter((item,))
-        for candidate in candidates:
-            try:
-                if candidate.is_file():
-                    total += candidate.stat().st_size
-            except OSError:
-                continue
+        try:
+            if item.is_dir():
+                for candidate in item.rglob("*"):
+                    try:
+                        if candidate.is_file():
+                            total += candidate.stat().st_size
+                    except OSError:
+                        continue
+            elif item.is_file():
+                total += item.stat().st_size
+        except OSError:
+            continue
     return total

--- a/src/frontend/custom_widgets/job_queue_dialog.py
+++ b/src/frontend/custom_widgets/job_queue_dialog.py
@@ -1,0 +1,411 @@
+"""Runs a set of prepared jobs and shows what is happening while it does.
+
+The queue deliberately does not borrow the wizard's process page. That page is
+built around one interactive run: it owns a tracker tree keyed to a single
+release, a per-run outcome map used to offer a deferred save, and a button
+state machine that assumes somebody is answering prompts. A queue has none of
+those and several jobs' worth of the ones it does have, so it gets its own
+window -- which is also the only place a Cancel button can sensibly live.
+"""
+
+from collections.abc import Sequence
+from html import escape
+from pathlib import Path
+import traceback
+
+from PySide6.QtCore import QObject, Qt, QThread, Signal, Slot
+from PySide6.QtGui import QTextCursor
+from PySide6.QtWidgets import (
+    QDialog,
+    QDialogButtonBox,
+    QFrame,
+    QHBoxLayout,
+    QHeaderView,
+    QLabel,
+    QMessageBox,
+    QProgressBar,
+    QPushButton,
+    QTextEdit,
+    QTreeWidget,
+    QTreeWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
+
+from src.backend.job_queue import (
+    JobDisposition,
+    JobQueueRunner,
+    QueuedJobOutcome,
+    QueuedJobResult,
+)
+from src.backend.process import ProcessBackEnd
+from src.config.config import ConfigManager
+from src.logger.nfo_forge_logger import LOG
+from src.utils.secret_redaction import scrub_secrets
+
+_RESULT_LABELS = {
+    QueuedJobResult.UPLOADED: "✅ Uploaded",
+    QueuedJobResult.SKIPPED_DUPES: "⏭ Possible duplicate",
+    QueuedJobResult.SKIPPED_UNVERIFIED: "⏭ Could not verify",
+    QueuedJobResult.SKIPPED_UNUSABLE: "⏭ Unusable",
+    QueuedJobResult.SKIPPED_NOT_PREPARED: "⏭ Not prepared",
+    QueuedJobResult.FAILED: "❌ Failed",
+}
+
+_DISPOSITION_LABELS = {
+    JobDisposition.KEPT: "kept",
+    JobDisposition.NARROWED: "kept for the trackers that did not upload",
+    JobDisposition.DELETED: "removed",
+}
+
+
+class _QueueThread(QThread):
+    """Drives `JobQueueRunner` off the GUI thread.
+
+    Nothing here waits on a dialog: a queue only accepts prepared jobs, and the
+    runner passes no prompt or retry callbacks, so it runs to completion on its
+    own. Its own thread type rather than the process page's `BaseWorker`, so the
+    queue does not import from the page it was extracted out of.
+    """
+
+    text = Signal(str)
+    text_replace = Signal(str)
+    tracker_status = Signal(str, str)
+    progress = Signal(float)
+    job_started = Signal(int, str)
+    job_finished = Signal(int, object)
+    results = Signal(object)
+    failed = Signal(str, str)
+
+    def __init__(
+        self,
+        backend: ProcessBackEnd,
+        config: ConfigManager,
+        job_paths: list[Path],
+        parent: QObject | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self.backend = backend
+        self.config = config
+        self.job_paths = job_paths
+        self._cancelled = False
+
+    def __del__(self) -> None:
+        # Qt destroying a QThread while its `run()` is still executing is
+        # undefined -- on this platform it aborts the whole process rather
+        # than just printing the usual warning. Nothing here waits on a
+        # dialog (see the class docstring), so `run()` finishing is only ever
+        # a matter of time, not user input; blocking briefly for it beats a
+        # crash whenever the dialog (or its `_thread` attribute) is dropped
+        # before the queue naturally finishes.
+        if self.isRunning():
+            self.wait()
+
+    def cancel(self) -> None:
+        """Stop before the next job. The one in flight is left to finish.
+
+        Tearing down mid-upload is what risks a half-sent release, so the only
+        safe cancel point is between jobs.
+        """
+        self._cancelled = True
+
+    def run(self) -> None:
+        try:
+            runner = JobQueueRunner(
+                backend=self.backend,
+                config=self.config,
+                text_update=self.text.emit,
+                text_replace_last_update=self.text_replace.emit,
+                status_update=self.tracker_status.emit,
+                progress_cb=self.progress.emit,
+                is_cancelled=lambda: self._cancelled,
+                job_started=self.job_started.emit,
+                job_finished=self.job_finished.emit,
+            )
+            self.results.emit(runner.run(self.job_paths))
+        except Exception as error:
+            self.failed.emit(scrub_secrets(str(error)), traceback.format_exc())
+
+
+class JobQueueDialog(QDialog):
+    """Shows a queue of prepared jobs running, one after another."""
+
+    def __init__(
+        self,
+        job_paths: Sequence[Path],
+        config: ConfigManager,
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self.setObjectName("jobQueueDialog")
+        self.setWindowTitle("Job Queue")
+        self.setSizeGripEnabled(True)
+        self.resize(900, 620)
+
+        self.job_paths = list(job_paths)
+        self.config = config
+        self.outcomes: list[QueuedJobOutcome] = []
+        self._thread: _QueueThread | None = None
+        # Every `_QueueThread` this dialog ever starts, kept independently of
+        # `_thread` itself: `_thread` is a plain attribute a caller (or a test
+        # standing in for the running state) can overwrite, but the worker
+        # object that reassignment orphans is still a Qt child of this dialog
+        # and still needs waiting for in `__del__` -- otherwise it is exactly
+        # the still-running thread that gets torn down with it.
+        self._worker_threads: list[_QueueThread] = []
+        self._current_index = 0
+        """Which job's tracker rows incoming status belongs to.
+
+        The runner is strictly sequential and always announces a job before any
+        of its trackers report, so tracking the current job here is enough to
+        key status on (job, tracker) without widening the callback.
+        """
+        self._tracker_rows: dict[tuple[int, str], QTreeWidgetItem] = {}
+
+        self.header_lbl = QLabel(
+            f"<h3 style='margin: 0;'>Running {len(self.job_paths)} job(s)</h3>"
+            "<i><span>Each job is duplicate checked immediately before it "
+            "uploads. A job that finds a duplicate, or that cannot be checked, "
+            "is skipped and kept for you to review.</span></i>",
+            wordWrap=True,
+            parent=self,
+        )
+
+        self.job_tree = QTreeWidget(self)
+        self.job_tree.setFrameShape(QFrame.Shape.Box)
+        self.job_tree.setFrameShadow(QFrame.Shadow.Sunken)
+        # jobs at the top, their trackers as children -- the one structure that
+        # can hold the same tracker appearing in more than one job
+        self.job_tree.setRootIsDecorated(True)
+        self.job_tree.setColumnCount(4)
+        self.job_tree.setHeaderLabels(("#", "Job / tracker", "Status", "Detail"))
+        self.job_tree.setTextElideMode(Qt.TextElideMode.ElideRight)
+        header = self.job_tree.header()
+        header.setSectionResizeMode(0, QHeaderView.ResizeMode.ResizeToContents)
+        header.setSectionResizeMode(1, QHeaderView.ResizeMode.Stretch)
+        header.setSectionResizeMode(2, QHeaderView.ResizeMode.ResizeToContents)
+        header.setSectionResizeMode(3, QHeaderView.ResizeMode.Stretch)
+        for index, path in enumerate(self.job_paths, start=1):
+            self.job_tree.addTopLevelItem(
+                QTreeWidgetItem((str(index), path.name, "Queued", ""))
+            )
+
+        self.text_widget = QTextEdit(self)
+        self.text_widget.setReadOnly(True)
+
+        self.progress_bar = QProgressBar(self)
+        self.progress_bar.setRange(0, 100)
+
+        self.cancel_btn = QPushButton("Cancel", self)
+        self.cancel_btn.setToolTip(
+            "Stop before the next job starts. The job currently uploading is "
+            "left to finish, since interrupting an upload is what risks a "
+            "half-sent release"
+        )
+        self.cancel_btn.clicked.connect(self._on_cancel)
+
+        self.button_box = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Close, parent=self
+        )
+        self.button_box.rejected.connect(self.reject)
+        close_button = self.button_box.button(QDialogButtonBox.StandardButton.Close)
+        if close_button:
+            close_button.setEnabled(False)
+
+        bottom_row = QHBoxLayout()
+        bottom_row.addStretch(1)
+        bottom_row.addWidget(self.cancel_btn)
+        bottom_row.addWidget(self.button_box)
+
+        main_layout = QVBoxLayout(self)
+        main_layout.addWidget(self.header_lbl)
+        main_layout.addWidget(self.job_tree, stretch=2)
+        main_layout.addWidget(self.text_widget, stretch=3)
+        main_layout.addWidget(self.progress_bar)
+        main_layout.addLayout(bottom_row)
+
+        self._start()
+
+    # ------------------------------------------------------------------
+    def _start(self) -> None:
+        self._thread = _QueueThread(
+            backend=ProcessBackEnd(self.config),
+            config=self.config,
+            job_paths=self.job_paths,
+            parent=self,
+        )
+        self._worker_threads.append(self._thread)
+        self._thread.text.connect(self._on_text)
+        self._thread.text_replace.connect(self._on_text_replace)
+        self._thread.tracker_status.connect(self._on_tracker_status)
+        self._thread.progress.connect(self._on_progress)
+        self._thread.job_started.connect(self._on_job_started)
+        self._thread.job_finished.connect(self._on_job_finished)
+        self._thread.results.connect(self._on_results)
+        self._thread.failed.connect(self._on_failed)
+        self._thread.finished.connect(self._on_queue_finished)
+        self._thread.start()
+
+    def __del__(self) -> None:
+        # Every worker thread is parented to `self`, so Qt would otherwise
+        # tear it down as part of destroying this dialog's C++ object --
+        # deleting a QThread while `run()` is still executing is undefined
+        # there and crashes the process outright rather than merely warning.
+        # Waiting here runs before that cascade starts, whenever this dialog
+        # is dropped without having gone through the normal "reject() blocks
+        # until finished" path (e.g. a test that never closes it).
+        for thread in getattr(self, "_worker_threads", ()):
+            if thread.isRunning():
+                thread.wait()
+
+    def _item(self, index: int) -> QTreeWidgetItem | None:
+        return self.job_tree.topLevelItem(index - 1)
+
+    # ------------------------------------------------------------------
+    @Slot(str)
+    def _on_text(self, message: str) -> None:
+        # scrubbed on the way in, as the process page does: queue log lines
+        # carry tracker responses, which can carry credentials
+        cursor = self.text_widget.textCursor()
+        cursor.movePosition(QTextCursor.MoveOperation.End)
+        cursor.insertHtml(scrub_secrets(message))
+        self.text_widget.setTextCursor(cursor)
+        self.text_widget.ensureCursorVisible()
+
+    @Slot(str)
+    def _on_text_replace(self, message: str) -> None:
+        """Overwrite the last line rather than appending after it.
+
+        Same mechanics as `ProcessPage._on_text_update_replace_last_line`, so the
+        two panes behave identically. Without it a "running..." line and its
+        "done" replacement both stay in the log.
+        """
+        cursor = self.text_widget.textCursor()
+        cursor.movePosition(QTextCursor.MoveOperation.End)
+        cursor.movePosition(
+            QTextCursor.MoveOperation.StartOfLine, QTextCursor.MoveMode.KeepAnchor
+        )
+        cursor.removeSelectedText()
+        cursor.insertHtml(scrub_secrets(message))
+        self.text_widget.setTextCursor(cursor)
+        self.text_widget.ensureCursorVisible()
+
+    @Slot(float)
+    def _on_progress(self, value: float) -> None:
+        self.progress_bar.setValue(int(value))
+
+    @Slot(int, str)
+    def _on_job_started(self, index: int, name: str) -> None:
+        item = self._item(index)
+        if item is None:
+            return
+        self._current_index = index
+        item.setText(1, name)
+        item.setText(2, "▶️ Running")
+        item.setExpanded(True)
+        self.job_tree.scrollToItem(item)
+        self.header_lbl.setText(
+            f"<h3 style='margin: 0;'>Job {index} of {len(self.job_paths)}</h3>"
+            f"<i><span>{escape(name)}</span></i>"
+        )
+
+    @Slot(str, str)
+    def _on_tracker_status(self, tracker: str, status: str) -> None:
+        """Record one tracker's status under the job currently running.
+
+        Keyed on (job, tracker) rather than tracker alone. Trackers recur across
+        jobs, and a tracker-only key would let the fourth job overwrite the
+        first's result in place -- a status column that quietly describes the
+        wrong release is worse than none.
+        """
+        parent = self._item(self._current_index)
+        if parent is None:
+            # status before any job announced itself; nothing to attach it to
+            return
+
+        key = (self._current_index, tracker)
+        row = self._tracker_rows.get(key)
+        if row is None:
+            row = QTreeWidgetItem(("", tracker, status, ""))
+            parent.addChild(row)
+            parent.setExpanded(True)
+            self._tracker_rows[key] = row
+            return
+        row.setText(2, status)
+
+    @Slot(int, object)
+    def _on_job_finished(self, index: int, outcome: QueuedJobOutcome) -> None:
+        item = self._item(index)
+        if item is None:
+            return
+        item.setText(1, outcome.job_name)
+        item.setText(2, _RESULT_LABELS.get(outcome.result, outcome.result.name))
+        disposition = _DISPOSITION_LABELS.get(outcome.disposition, "")
+        detail = outcome.detail
+        item.setText(
+            3, f"{detail} — job {disposition}" if detail else f"Job {disposition}"
+        )
+        # A job that went through cleanly collapses to its one summary line; one
+        # that did not stays open on the tracker that explains why. A long queue
+        # then reads as a short list with the problems already unfolded.
+        item.setExpanded(outcome.result is not QueuedJobResult.UPLOADED)
+
+    @Slot(object)
+    def _on_results(self, results: list[QueuedJobOutcome]) -> None:
+        self.outcomes = results
+        uploaded = sum(
+            1 for outcome in results if outcome.result is QueuedJobResult.UPLOADED
+        )
+        self._on_text(
+            f"<br /><h3 style='margin-bottom: 0;'>Queue finished: {uploaded} of "
+            f"{len(results)} uploaded</h3>"
+        )
+
+    @Slot(str, str)
+    def _on_failed(self, message: str, trace_back: str) -> None:
+        LOG.error(LOG.LOG_SOURCE.FE, scrub_secrets(trace_back))
+        self._on_text(f"<br /><p>{escape(message)}</p>")
+
+    @Slot()
+    def _on_cancel(self) -> None:
+        if self._thread is None or not self._thread.isRunning():
+            return
+        self._thread.cancel()
+        self.cancel_btn.setEnabled(False)
+        self.cancel_btn.setText("Finishing current job...")
+        self._on_text(
+            "<br /><span>Cancelling; the job currently uploading will finish "
+            "first</span>"
+        )
+
+    @Slot()
+    def _on_queue_finished(self) -> None:
+        self._thread = None
+        self.cancel_btn.hide()
+        self.progress_bar.setValue(0)
+        close_button = self.button_box.button(QDialogButtonBox.StandardButton.Close)
+        if close_button:
+            close_button.setEnabled(True)
+            close_button.setDefault(True)
+        self.header_lbl.setText("<h3 style='margin: 0;'>Queue finished</h3>")
+
+    # ------------------------------------------------------------------
+    def reject(self) -> None:
+        """Refuse to close while a job is in flight.
+
+        Closing the window would not stop the thread, so allowing it would leave
+        uploads running with nothing showing them.
+        """
+        if self._thread is not None and self._thread.isRunning():
+            if (
+                QMessageBox.question(
+                    self,
+                    "Queue Running",
+                    "The queue is still running. Stop it after the current job "
+                    "finishes?",
+                )
+                is QMessageBox.StandardButton.Yes
+            ):
+                self._on_cancel()
+            return
+        super().reject()

--- a/src/frontend/custom_widgets/job_queue_dialog.py
+++ b/src/frontend/custom_widgets/job_queue_dialog.py
@@ -90,17 +90,6 @@ class _QueueThread(QThread):
         self.job_paths = job_paths
         self._cancelled = False
 
-    def __del__(self) -> None:
-        # Qt destroying a QThread while its `run()` is still executing is
-        # undefined -- on this platform it aborts the whole process rather
-        # than just printing the usual warning. Nothing here waits on a
-        # dialog (see the class docstring), so `run()` finishing is only ever
-        # a matter of time, not user input; blocking briefly for it beats a
-        # crash whenever the dialog (or its `_thread` attribute) is dropped
-        # before the queue naturally finishes.
-        if self.isRunning():
-            self.wait()
-
     def cancel(self) -> None:
         """Stop before the next job. The one in flight is left to finish.
 
@@ -144,15 +133,7 @@ class JobQueueDialog(QDialog):
 
         self.job_paths = list(job_paths)
         self.config = config
-        self.outcomes: list[QueuedJobOutcome] = []
         self._thread: _QueueThread | None = None
-        # Every `_QueueThread` this dialog ever starts, kept independently of
-        # `_thread` itself: `_thread` is a plain attribute a caller (or a test
-        # standing in for the running state) can overwrite, but the worker
-        # object that reassignment orphans is still a Qt child of this dialog
-        # and still needs waiting for in `__del__` -- otherwise it is exactly
-        # the still-running thread that gets torn down with it.
-        self._worker_threads: list[_QueueThread] = []
         self._current_index = 0
         """Which job's tracker rows incoming status belongs to.
 
@@ -224,9 +205,19 @@ class JobQueueDialog(QDialog):
         main_layout.addWidget(self.progress_bar)
         main_layout.addLayout(bottom_row)
 
+    # ------------------------------------------------------------------
+    def start(self) -> None:
+        """Begin the queue. Separate from construction on purpose.
+
+        A thread started inside `__init__` is a thread the caller never chose
+        to start and cannot avoid: the object exists and is already running
+        before it is even assigned to a variable. Splitting this out gives the
+        caller (and a test) a dialog it can inspect or discard before any
+        thread exists, and means a dropped dialog is never one that still has
+        a job in flight.
+        """
         self._start()
 
-    # ------------------------------------------------------------------
     def _start(self) -> None:
         self._thread = _QueueThread(
             backend=ProcessBackEnd(self.config),
@@ -234,7 +225,6 @@ class JobQueueDialog(QDialog):
             job_paths=self.job_paths,
             parent=self,
         )
-        self._worker_threads.append(self._thread)
         self._thread.text.connect(self._on_text)
         self._thread.text_replace.connect(self._on_text_replace)
         self._thread.tracker_status.connect(self._on_tracker_status)
@@ -246,18 +236,6 @@ class JobQueueDialog(QDialog):
         self._thread.finished.connect(self._on_queue_finished)
         self._thread.start()
 
-    def __del__(self) -> None:
-        # Every worker thread is parented to `self`, so Qt would otherwise
-        # tear it down as part of destroying this dialog's C++ object --
-        # deleting a QThread while `run()` is still executing is undefined
-        # there and crashes the process outright rather than merely warning.
-        # Waiting here runs before that cascade starts, whenever this dialog
-        # is dropped without having gone through the normal "reject() blocks
-        # until finished" path (e.g. a test that never closes it).
-        for thread in getattr(self, "_worker_threads", ()):
-            if thread.isRunning():
-                thread.wait()
-
     def _item(self, index: int) -> QTreeWidgetItem | None:
         return self.job_tree.topLevelItem(index - 1)
 
@@ -266,11 +244,13 @@ class JobQueueDialog(QDialog):
     def _on_text(self, message: str) -> None:
         # scrubbed on the way in, as the process page does: queue log lines
         # carry tracker responses, which can carry credentials
+        safe_message = scrub_secrets(message)
         cursor = self.text_widget.textCursor()
         cursor.movePosition(QTextCursor.MoveOperation.End)
-        cursor.insertHtml(scrub_secrets(message))
+        cursor.insertHtml(safe_message)
         self.text_widget.setTextCursor(cursor)
         self.text_widget.ensureCursorVisible()
+        LOG.info(LOG.LOG_SOURCE.FE, f"Queue log: {safe_message}")
 
     @Slot(str)
     def _on_text_replace(self, message: str) -> None:
@@ -280,15 +260,17 @@ class JobQueueDialog(QDialog):
         two panes behave identically. Without it a "running..." line and its
         "done" replacement both stay in the log.
         """
+        safe_message = scrub_secrets(message)
         cursor = self.text_widget.textCursor()
         cursor.movePosition(QTextCursor.MoveOperation.End)
         cursor.movePosition(
             QTextCursor.MoveOperation.StartOfLine, QTextCursor.MoveMode.KeepAnchor
         )
         cursor.removeSelectedText()
-        cursor.insertHtml(scrub_secrets(message))
+        cursor.insertHtml(safe_message)
         self.text_widget.setTextCursor(cursor)
         self.text_widget.ensureCursorVisible()
+        LOG.info(LOG.LOG_SOURCE.FE, f"Queue log replace last line: {safe_message}")
 
     @Slot(float)
     def _on_progress(self, value: float) -> None:
@@ -304,6 +286,9 @@ class JobQueueDialog(QDialog):
         item.setText(2, "▶️ Running")
         item.setExpanded(True)
         self.job_tree.scrollToItem(item)
+        # a new job's progress starts from zero, not wherever the previous
+        # job's bar was left
+        self.progress_bar.setValue(0)
         self.header_lbl.setText(
             f"<h3 style='margin: 0;'>Job {index} of {len(self.job_paths)}</h3>"
             f"<i><span>{escape(name)}</span></i>"
@@ -340,7 +325,7 @@ class JobQueueDialog(QDialog):
             return
         item.setText(1, outcome.job_name)
         item.setText(2, _RESULT_LABELS.get(outcome.result, outcome.result.name))
-        disposition = _DISPOSITION_LABELS.get(outcome.disposition, "")
+        disposition = _DISPOSITION_LABELS[outcome.disposition]
         detail = outcome.detail
         item.setText(
             3, f"{detail} — job {disposition}" if detail else f"Job {disposition}"
@@ -352,7 +337,6 @@ class JobQueueDialog(QDialog):
 
     @Slot(object)
     def _on_results(self, results: list[QueuedJobOutcome]) -> None:
-        self.outcomes = results
         uploaded = sum(
             1 for outcome in results if outcome.result is QueuedJobResult.UPLOADED
         )
@@ -365,6 +349,15 @@ class JobQueueDialog(QDialog):
     def _on_failed(self, message: str, trace_back: str) -> None:
         LOG.error(LOG.LOG_SOURCE.FE, scrub_secrets(trace_back))
         self._on_text(f"<br /><p>{escape(message)}</p>")
+        # Without this the job that was running when the queue itself raised
+        # is left reading "Running" forever, under a header that already says
+        # "Queue finished" -- the one row that most needs a correct status is
+        # the one this leaves stuck.
+        item = self._item(self._current_index)
+        if item is not None:
+            item.setText(2, _RESULT_LABELS[QueuedJobResult.FAILED])
+            item.setText(3, escape(message))
+            item.setExpanded(True)
 
     @Slot()
     def _on_cancel(self) -> None:

--- a/src/frontend/custom_widgets/load_job_dialog.py
+++ b/src/frontend/custom_widgets/load_job_dialog.py
@@ -125,7 +125,15 @@ class LoadJobDialog(QDialog):
         Tracked explicitly rather than via focus -- `hasFocus()` is
         unreliable before the dialog is shown, and the tests for this file
         construct the dialog without showing it. Set by
-        `_on_tree_selection_changed` and `_on_queue_row_changed`, below.
+        `_on_tree_selection_changed` and `_on_queue_row_changed`, below --
+        which is also where `_suppress_source_tracking` is checked.
+        """
+        self._suppress_source_tracking: bool = False
+        """Set around a programmatic selection change so it cannot be
+        mistaken for user interaction. `_apply_filter` deselects rows it
+        hides, and reloading the tree re-clears and re-selects it -- neither
+        is the user switching panes, so the source-setting slots must not
+        act on the signals those changes fire.
         """
 
         self.info_lbl = QLabel(
@@ -322,7 +330,17 @@ class LoadJobDialog(QDialog):
         self._details_cache.clear()
         self._last_described_path = None
 
-        self.job_tree.clear()
+        # Deselecting whatever the tree held fires itemSelectionChanged if
+        # something was selected -- a reload triggered by a rename or delete
+        # must not use that to yank a queue-sourced pane back to the tree
+        # before the reload has even produced anything to show. Confirmed
+        # empirically: without this, the source flips here, synchronously,
+        # before `_on_listings_loaded` ever runs.
+        self._suppress_source_tracking = True
+        try:
+            self.job_tree.clear()
+        finally:
+            self._suppress_source_tracking = False
         self.job_tree.setVisible(False)
         self.empty_lbl.setText("<span>Loading saved jobs...</span>")
         self.empty_lbl.setVisible(True)
@@ -337,7 +355,16 @@ class LoadJobDialog(QDialog):
         # sorting reshuffles the tree on every insert otherwise, which is
         # wasted work and would show rows swapping places as they load
         self.job_tree.setSortingEnabled(False)
-        self.job_tree.clear()
+        # Repopulating the tree fires tree signals; see the same suppression
+        # in `_load_listings`. This clear is a no-op selection-wise today --
+        # `_load_listings` already emptied the tree before starting the
+        # loader that ends up here -- but it costs nothing to keep guarded
+        # rather than depend on that staying true.
+        self._suppress_source_tracking = True
+        try:
+            self.job_tree.clear()
+        finally:
+            self._suppress_source_tracking = False
         muted = QBrush(
             self.palette().color(
                 QPalette.ColorGroup.Disabled, QPalette.ColorRole.WindowText
@@ -406,7 +433,14 @@ class LoadJobDialog(QDialog):
         self.empty_lbl.setVisible(not has_jobs)
         first_item = self.job_tree.topLevelItem(0)
         if first_item is not None:
-            self.job_tree.setCurrentItem(first_item)
+            # Selecting the tree's own first row on every reload must not
+            # steal a queue-sourced pane back either -- same reasoning as
+            # the clear() above.
+            self._suppress_source_tracking = True
+            try:
+                self.job_tree.setCurrentItem(first_item)
+            finally:
+                self._suppress_source_tracking = False
         self._apply_filter()
 
     def _stop_loader(self) -> None:
@@ -451,31 +485,42 @@ class LoadJobDialog(QDialog):
         A hidden row that stayed selected would still be picked up by Load,
         Delete and the queue, which is exactly the kind of action-at-a-distance
         a filter is supposed to remove.
+
+        The deselect is a programmatic change, not the user picking a
+        different row -- typing in the filter box must not steal the details
+        pane away from a queue-sourced description, so it runs with source
+        tracking suppressed. `try`/`finally` so a raise mid-loop cannot leave
+        the flag stuck, which would disable source tracking for the rest of
+        the dialog's life -- worse than the bug being fixed here.
         """
         needle = self.filter_edit.text().strip().casefold()
         only_mine = self.only_this_config.isChecked()
 
-        for index in range(self.job_tree.topLevelItemCount()):
-            item = self.job_tree.topLevelItem(index)
-            if item is None:
-                continue
-            listing = item.data(0, _LISTING_ROLE)
-            if not isinstance(listing, JobListing):
-                continue
-            haystack = " ".join(
-                (
-                    listing.name,
-                    listing.summary.title or "",
-                    listing.summary.input_name or "",
-                    " ".join(listing.summary.trackers),
-                )
-            ).casefold()
-            hidden = bool(needle) and needle not in haystack
-            if only_mine and not listing.matches_profile(self.active_profile):
-                hidden = True
-            item.setHidden(hidden)
-            if hidden:
-                item.setSelected(False)
+        self._suppress_source_tracking = True
+        try:
+            for index in range(self.job_tree.topLevelItemCount()):
+                item = self.job_tree.topLevelItem(index)
+                if item is None:
+                    continue
+                listing = item.data(0, _LISTING_ROLE)
+                if not isinstance(listing, JobListing):
+                    continue
+                haystack = " ".join(
+                    (
+                        listing.name,
+                        listing.summary.title or "",
+                        listing.summary.input_name or "",
+                        " ".join(listing.summary.trackers),
+                    )
+                ).casefold()
+                hidden = bool(needle) and needle not in haystack
+                if only_mine and not listing.matches_profile(self.active_profile):
+                    hidden = True
+                item.setHidden(hidden)
+                if hidden:
+                    item.setSelected(False)
+        finally:
+            self._suppress_source_tracking = False
 
         self._update_button_state()
 
@@ -700,11 +745,18 @@ class LoadJobDialog(QDialog):
 
     @Slot()
     def _on_tree_selection_changed(self) -> None:
+        # Programmatic selection changes -- a filter hiding a row, a reload
+        # re-populating the tree -- must not be mistaken for the user
+        # switching panes. See `_suppress_source_tracking`.
+        if self._suppress_source_tracking:
+            return
         self._details_source = "tree"
         self._update_button_state()
 
     @Slot()
     def _on_queue_row_changed(self) -> None:
+        if self._suppress_source_tracking:
+            return
         self._details_source = "queue"
         self._update_button_state()
 

--- a/src/frontend/custom_widgets/load_job_dialog.py
+++ b/src/frontend/custom_widgets/load_job_dialog.py
@@ -179,6 +179,12 @@ class LoadJobDialog(QDialog):
         self.job_tree.setSelectionMode(QTreeWidget.SelectionMode.ExtendedSelection)
         self.job_tree.itemDoubleClicked.connect(self._on_double_click)
         self.job_tree.itemSelectionChanged.connect(self._on_tree_selection_changed)
+        # itemClicked fires on every press, including a re-click of a row
+        # that is already current -- itemSelectionChanged does not, which is
+        # exactly the case that leaves a re-clicked pane stuck. Keeping both
+        # connected covers clicking and keyboard navigation, which emits no
+        # click at all.
+        self.job_tree.itemClicked.connect(self._on_tree_selection_changed)
 
         self.empty_lbl = QLabel(
             "<span>No saved jobs yet. Use <b>Save Job</b> on the process page "
@@ -216,6 +222,8 @@ class LoadJobDialog(QDialog):
             "queued, since a queue has nobody to answer a prompt"
         )
         self.queue_list.currentRowChanged.connect(self._on_queue_row_changed)
+        # Same reasoning as job_tree.itemClicked, above.
+        self.queue_list.itemClicked.connect(self._on_queue_row_changed)
 
         self.add_to_queue_btn = QPushButton("Add to queue", self)
         self.add_to_queue_btn.clicked.connect(self._add_to_queue)

--- a/src/frontend/custom_widgets/load_job_dialog.py
+++ b/src/frontend/custom_widgets/load_job_dialog.py
@@ -693,8 +693,15 @@ class LoadJobDialog(QDialog):
         target = row + offset
         if row < 0 or not 0 <= target < self.queue_list.count():
             return
-        self.queue_list.insertItem(target, self.queue_list.takeItem(row))
-        self.queue_list.setCurrentRow(target)
+        # takeItem() and setCurrentRow() both fire currentRowChanged -- this
+        # is the queue reordering itself, not the user picking the queue
+        # pane, so it must not set the source. See `_suppress_source_tracking`.
+        self._suppress_source_tracking = True
+        try:
+            self.queue_list.insertItem(target, self.queue_list.takeItem(row))
+            self.queue_list.setCurrentRow(target)
+        finally:
+            self._suppress_source_tracking = False
         self._renumber_queue()
         self._update_button_state()
 
@@ -703,16 +710,29 @@ class LoadJobDialog(QDialog):
         row = self.queue_list.currentRow()
         if row < 0:
             return
-        self.queue_list.takeItem(row)
+        # takeItem() on the current row fires currentRowChanged -- removing a
+        # row is not the user picking the queue pane. See
+        # `_suppress_source_tracking`.
+        self._suppress_source_tracking = True
+        try:
+            self.queue_list.takeItem(row)
+        finally:
+            self._suppress_source_tracking = False
         self._renumber_queue()
         self._update_button_state()
 
     def _drop_from_queue(self, paths: set[Path]) -> None:
         """Take deleted jobs out of the queue, so it cannot point at nothing."""
-        for row in reversed(range(self.queue_list.count())):
-            listing = self.queue_list.item(row).data(_LISTING_ROLE)
-            if isinstance(listing, JobListing) and listing.path in paths:
-                self.queue_list.takeItem(row)
+        # Same reasoning as `_remove_queued`: a delete elsewhere is not the
+        # user picking the queue pane.
+        self._suppress_source_tracking = True
+        try:
+            for row in reversed(range(self.queue_list.count())):
+                listing = self.queue_list.item(row).data(_LISTING_ROLE)
+                if isinstance(listing, JobListing) and listing.path in paths:
+                    self.queue_list.takeItem(row)
+        finally:
+            self._suppress_source_tracking = False
         self._renumber_queue()
 
     def _selection_hint(self) -> str:

--- a/src/frontend/custom_widgets/load_job_dialog.py
+++ b/src/frontend/custom_widgets/load_job_dialog.py
@@ -14,6 +14,7 @@ from PySide6.QtWidgets import (
     QFrame,
     QHBoxLayout,
     QHeaderView,
+    QInputDialog,
     QLabel,
     QLineEdit,
     QMessageBox,
@@ -26,7 +27,14 @@ from PySide6.QtWidgets import (
 )
 import qtawesome as qta
 
-from src.backend.jobs import JobListing, JobStoreError, delete_job, list_jobs, load_job
+from src.backend.jobs import (
+    JobListing,
+    JobStoreError,
+    delete_job,
+    list_jobs,
+    load_job,
+    write_job_document,
+)
 from src.backend.utils.file_utilities import (
     file_bytes_to_str,
     get_dir_size,
@@ -172,6 +180,10 @@ class LoadJobDialog(QDialog):
         self.delete_btn.setShortcut(Qt.Key.Key_Delete)
         self.delete_btn.clicked.connect(self._delete_selected)
 
+        self.rename_btn = QPushButton("Rename", self)
+        self.rename_btn.setShortcut(Qt.Key.Key_F2)
+        self.rename_btn.clicked.connect(self._rename_selected)
+
         self.switch_btn = QPushButton("Switch profile and load", self)
         self.switch_btn.setToolTip(
             "Activate the config this job was saved under, then load it"
@@ -199,6 +211,7 @@ class LoadJobDialog(QDialog):
 
         bottom_row = QHBoxLayout()
         bottom_row.addWidget(self.delete_btn)
+        bottom_row.addWidget(self.rename_btn)
         bottom_row.addStretch(1)
         bottom_row.addWidget(self.queue_btn)
         bottom_row.addWidget(self.switch_btn)
@@ -459,6 +472,7 @@ class LoadJobDialog(QDialog):
         queueable = self.queueable_listings()
 
         self.delete_btn.setEnabled(bool(selected))
+        self.rename_btn.setEnabled(len(selected) == 1)
         self.switch_btn.setEnabled(
             len(selected) == 1 and listing is not None and not matches
         )
@@ -651,4 +665,35 @@ class LoadJobDialog(QDialog):
                 "Delete Failed",
                 "Some jobs could not be deleted:\n\n" + "\n".join(failures),
             )
+        self._load_listings()
+
+    @Slot()
+    def _rename_selected(self) -> None:
+        """Rewrite a job's display name, and nothing else.
+
+        The job id and its directory are untouched, so nothing pointing at the
+        job by path -- a queue mid-flight, a listing already on screen -- is
+        invalidated by the rename.
+        """
+        listing = self._current_listing()
+        if listing is None or len(self._selected_listings()) != 1:
+            return
+
+        name, accepted = QInputDialog.getText(
+            self, "Rename Job", "Job name:", text=listing.name
+        )
+        if not accepted or not name.strip():
+            return
+
+        try:
+            job = load_job(listing.path)
+            job.name = name.strip()
+            write_job_document(job, listing.path)
+        except JobStoreError as error:
+            LOG.error(LOG.LOG_SOURCE.FE, f"Failed to rename job: {error}")
+            QMessageBox.critical(
+                self, "Rename Failed", f"Could not rename job:\n\n{error}"
+            )
+            return
+
         self._load_listings()

--- a/src/frontend/custom_widgets/load_job_dialog.py
+++ b/src/frontend/custom_widgets/load_job_dialog.py
@@ -1,6 +1,7 @@
 """Picker for saved jobs."""
 
 from datetime import datetime
+from html import escape
 
 from PySide6.QtCore import Qt, Slot
 from PySide6.QtGui import QBrush, QPalette
@@ -15,6 +16,7 @@ from PySide6.QtWidgets import (
     QLineEdit,
     QMessageBox,
     QPushButton,
+    QScrollArea,
     QTreeWidget,
     QTreeWidgetItem,
     QVBoxLayout,
@@ -22,8 +24,15 @@ from PySide6.QtWidgets import (
 )
 import qtawesome as qta
 
-from src.backend.jobs import JobListing, JobStoreError, delete_job, list_jobs
+from src.backend.jobs import JobListing, JobStoreError, delete_job, list_jobs, load_job
+from src.backend.utils.file_utilities import (
+    file_bytes_to_str,
+    get_dir_size,
+    open_explorer,
+)
 from src.config.profiles import unique_working_dirs
+from src.enums.tracker_selection import TrackerSelection
+from src.frontend.custom_widgets.custom_splitter import CustomSplitter
 from src.logger.nfo_forge_logger import LOG
 
 _LISTING_ROLE = Qt.ItemDataRole.UserRole
@@ -116,6 +125,34 @@ class LoadJobDialog(QDialog):
         )
         self.empty_lbl.hide()
 
+        self.details_lbl = QLabel("", wordWrap=True, parent=self)
+        self.details_lbl.setTextFormat(Qt.TextFormat.RichText)
+        self.details_lbl.setAlignment(
+            Qt.AlignmentFlag.AlignTop | Qt.AlignmentFlag.AlignLeft
+        )
+        self.details_lbl.setTextInteractionFlags(
+            Qt.TextInteractionFlag.TextSelectableByMouse
+        )
+
+        self.open_folder_btn = QPushButton("Open job folder", self)
+        self.open_folder_btn.setEnabled(False)
+        self.open_folder_btn.clicked.connect(self._open_job_folder)
+
+        details_panel = QWidget(self)
+        details_layout = QVBoxLayout(details_panel)
+        details_layout.setContentsMargins(8, 0, 0, 0)
+        details_scroll = QScrollArea(details_panel)
+        details_scroll.setWidgetResizable(True)
+        details_scroll.setWidget(self.details_lbl)
+        details_layout.addWidget(details_scroll, stretch=1)
+        details_layout.addWidget(self.open_folder_btn)
+
+        self.splitter = CustomSplitter(Qt.Orientation.Horizontal, self)
+        self.splitter.addWidget(self.job_tree)
+        self.splitter.addWidget(details_panel)
+        self.splitter.setStretchFactor(0, 3)
+        self.splitter.setStretchFactor(1, 2)
+
         self.status_lbl = QLabel("", wordWrap=True, parent=self)
         self.status_lbl.setTextFormat(Qt.TextFormat.PlainText)
 
@@ -159,7 +196,7 @@ class LoadJobDialog(QDialog):
         main_layout.addWidget(self.info_lbl)
         main_layout.addLayout(filter_row)
         main_layout.addWidget(self.empty_lbl)
-        main_layout.addWidget(self.job_tree, stretch=1)
+        main_layout.addWidget(self.splitter, stretch=1)
         main_layout.addWidget(self.status_lbl)
         main_layout.addLayout(bottom_row)
 
@@ -280,6 +317,23 @@ class LoadJobDialog(QDialog):
         return f"{title} ({year})" if title and year else title
 
     @staticmethod
+    def _tracker_display_name(raw_name: object) -> str:
+        """A tracker's saved-job key, in the same casing the rest of the UI uses.
+
+        `tracker_image_hosts` is keyed by `TrackerSelection` member *name*
+        (`"AITHER"`), matching the round-trip-by-name convention the job codec
+        uses everywhere -- see `src/backend/jobs/codec.py`. That is not the
+        member's display value (`"Aither"`), which is what the tree's Trackers
+        column and `JobSummary.trackers` both show. A name a current build no
+        longer recognises -- a retired tracker -- falls back to the raw string
+        rather than raising out of the details pane.
+        """
+        try:
+            return str(TrackerSelection(str(raw_name)))
+        except ValueError:
+            return str(raw_name)
+
+    @staticmethod
     def _saved_text(created_at: str) -> str:
         """Render the stored UTC timestamp in the user's local time."""
         try:
@@ -379,6 +433,95 @@ class LoadJobDialog(QDialog):
         if open_button:
             open_button.setEnabled(matches and len(selected) == 1)
         self.status_lbl.setText(self._selection_hint())
+        self._refresh_details()
+
+    def _describe(self, listing: JobListing) -> str:
+        """Everything worth knowing about a job before committing to it.
+
+        The per-tracker image hosts and the screenshot count only exist in the
+        job's document, so it is read here rather than at list time -- one file
+        read when a row is picked, instead of one per job on every open.
+        """
+        rows: list[tuple[str, str]] = [
+            ("Saved", self._saved_text(listing.created_at)),
+            (
+                "Config",
+                escape(listing.config_profile)
+                if listing.config_profile
+                else "not recorded",
+            ),
+            ("State", "Prepared" if listing.prepared else "Needs input"),
+        ]
+        title_text = self._title_text(listing)
+        if title_text:
+            rows.append(("Title", escape(title_text)))
+        summary = listing.summary
+        if summary.media_type:
+            rows.append(("Type", summary.media_type))
+        if summary.file_count:
+            rows.append(("Files", str(summary.file_count)))
+        if summary.input_path:
+            note = "" if listing.media_available else "  (no longer there)"
+            rows.append(("Media", f"{escape(summary.input_path)}{note}"))
+
+        try:
+            job = load_job(listing.path)
+        except JobStoreError as error:
+            LOG.warning(LOG.LOG_SOURCE.FE, f"Could not describe job: {error}")
+            job = None
+
+        if job is not None:
+            shared = job.context.get("shared_data")
+            if isinstance(shared, dict):
+                images = shared.get("loaded_images")
+                if isinstance(images, list):
+                    rows.append(("Screenshots", f"{len(images)} screenshot(s)"))
+                hosts = shared.get("tracker_image_hosts")
+                if isinstance(hosts, dict) and hosts:
+                    rows.append(
+                        (
+                            "Trackers",
+                            "<br />".join(
+                                f"{escape(self._tracker_display_name(name))} &rarr; "
+                                f"{escape(str(entry.get('img_to', '?')))}"
+                                for name, entry in hosts.items()
+                                if isinstance(entry, dict)
+                            ),
+                        )
+                    )
+        if not any(label == "Trackers" for label, _ in rows) and summary.trackers:
+            rows.append(("Trackers", "<br />".join(map(escape, summary.trackers))))
+
+        try:
+            rows.append(("On disk", file_bytes_to_str(get_dir_size(listing.path))))
+        except OSError:
+            pass
+        rows.append(("Folder", escape(str(listing.path))))
+
+        body = "".join(
+            f"<tr><td style='padding-right: 10px;'><b>{label}</b></td>"
+            f"<td>{value}</td></tr>"
+            for label, value in rows
+        )
+        return (
+            f"<p style='margin: 0 0 6px 0;'><b>{escape(listing.name)}</b></p>"
+            f"<table>{body}</table>"
+        )
+
+    def _refresh_details(self) -> None:
+        listing = self._current_listing()
+        if listing is None or listing not in self._selected_listings():
+            self.details_lbl.setText("")
+            self.open_folder_btn.setEnabled(False)
+            return
+        self.details_lbl.setText(self._describe(listing))
+        self.open_folder_btn.setEnabled(listing.path.is_dir())
+
+    @Slot()
+    def _open_job_folder(self) -> None:
+        listing = self._current_listing()
+        if listing is not None:
+            open_explorer(listing.path)
 
     @Slot(QTreeWidgetItem, int)
     def _on_double_click(self, item: QTreeWidgetItem, _column: int) -> None:

--- a/src/frontend/custom_widgets/load_job_dialog.py
+++ b/src/frontend/custom_widgets/load_job_dialog.py
@@ -106,6 +106,20 @@ class LoadJobDialog(QDialog):
         self.queued_listings: list[JobListing] = []
         """Jobs to run back to back, when the user chose Run Queue."""
         self._loader: _ListingLoader | None = None
+        self._details_cache: dict[Path, str] = {}
+        """`_describe(listing)` output, keyed by job path.
+
+        `_describe` parses the job document and walks its folder -- the same
+        read this branch already moved off-thread for `list_jobs`. Cleared in
+        `_load_listings`, so a rename or delete cannot leave a stale render
+        behind.
+        """
+        self._last_described_path: Path | None = None
+        """The path `_refresh_details` last rendered, so an unrelated widget
+        update -- moving the queue selection, typing in the filter -- that
+        leaves the tree's current listing unchanged can skip the whole
+        refresh rather than re-describing the same job from scratch.
+        """
 
         self.info_lbl = QLabel(
             "<i><span>Pick a saved job to jump straight to processing. Duplicate "
@@ -287,6 +301,12 @@ class LoadJobDialog(QDialog):
         # UI today (delete and rename are disabled while the tree is empty),
         # but the invariant should not depend on that staying true.
         self._stop_loader()
+        # A path can be reused by a new render after this reload -- a rename
+        # writes a new name under the same path, and `_describe` reads the
+        # document fresh once repopulated -- so a cached render or a "nothing
+        # changed" skip from before the reload must not survive it.
+        self._details_cache.clear()
+        self._last_described_path = None
 
         self.job_tree.clear()
         self.job_tree.setVisible(False)
@@ -667,7 +687,17 @@ class LoadJobDialog(QDialog):
         The per-tracker image hosts and the screenshot count only exist in the
         job's document, so it is read here rather than at list time -- one file
         read when a row is picked, instead of one per job on every open.
+
+        Memoised by path in `self._details_cache`: this reads the job's
+        document and walks its folder on disk, and a job's rendered
+        description cannot change while it sits in the same tree between
+        reloads, so a second call for a job already described this session
+        would otherwise repeat both for no new information.
         """
+        cached = self._details_cache.get(listing.path)
+        if cached is not None:
+            return cached
+
         rows: list[tuple[str, str]] = [
             ("Saved", self._saved_text(listing.created_at)),
             (
@@ -729,14 +759,34 @@ class LoadJobDialog(QDialog):
             f"<td>{value}</td></tr>"
             for label, value in rows
         )
-        return (
+        rendered = (
             f"<p style='margin: 0 0 6px 0;'><b>{escape(listing.name)}</b></p>"
             f"<table>{body}</table>"
         )
+        self._details_cache[listing.path] = rendered
+        return rendered
 
     def _refresh_details(self) -> None:
+        """Render the details pane for the tree's current listing, if any.
+
+        `_update_button_state` runs this on every filter keystroke and on
+        `queue_list.currentRowChanged` -- neither of which necessarily moves
+        the tree's own current item. Bailing out here when the listing to
+        show has not changed since the last call is what stops those from
+        re-reading the job's document and re-walking its folder for no
+        reason; `_describe`'s own memoisation only covers the read, not the
+        `is_dir()` stat this method also does.
+        """
         listing = self._current_listing()
         if listing is None or listing not in self._selected_listings():
+            listing = None
+
+        path = listing.path if listing is not None else None
+        if path == self._last_described_path:
+            return
+        self._last_described_path = path
+
+        if listing is None:
             self.details_lbl.setText("")
             self.open_folder_btn.setEnabled(False)
             return

--- a/src/frontend/custom_widgets/load_job_dialog.py
+++ b/src/frontend/custom_widgets/load_job_dialog.py
@@ -1,7 +1,9 @@
 """Picker for saved jobs."""
 
 from datetime import datetime
+from enum import Enum
 from html import escape
+from typing import Any
 
 from PySide6.QtCore import Qt, Slot
 from PySide6.QtGui import QBrush, QPalette
@@ -31,11 +33,21 @@ from src.backend.utils.file_utilities import (
     open_explorer,
 )
 from src.config.profiles import unique_working_dirs
+from src.enums.image_host import ImageHost, ImageSource
 from src.enums.tracker_selection import TrackerSelection
 from src.frontend.custom_widgets.custom_splitter import CustomSplitter
 from src.logger.nfo_forge_logger import LOG
 
 _LISTING_ROLE = Qt.ItemDataRole.UserRole
+
+# `img_to` is stored as an enum member name, and the same name can belong to
+# either ImageHost or ImageSource -- see `_image_host_display_name`, and
+# `_image_upload_from_to_to_dict` in `src/backend/jobs/codec.py`, which is why
+# `img_to_type` is carried alongside it in the first place.
+_IMAGE_DESTINATION_ENUMS: dict[str, type[Enum]] = {
+    "ImageHost": ImageHost,
+    "ImageSource": ImageSource,
+}
 
 
 class LoadJobDialog(QDialog):
@@ -334,6 +346,30 @@ class LoadJobDialog(QDialog):
             return str(raw_name)
 
     @staticmethod
+    def _image_host_display_name(entry: dict[str, Any]) -> str:
+        """Resolve a stored image destination back to what the user picked.
+
+        The same problem `_tracker_display_name` solves, one field over. The
+        codec writes `img_to` as an enum *member name* (`CHEVERETO_V3`) and
+        carries `img_to_type` alongside it precisely because that name alone
+        cannot say whether it belongs to `ImageHost` or `ImageSource`. Render
+        the raw name and the pane shows "Aither -> CHEVERETO_V3": a humanised
+        tracker arrowing at an internal identifier, in a table whose whole job
+        is to be readable.
+
+        Falls back to the raw string, so a destination retired since the job
+        was saved still shows something.
+        """
+        raw = str(entry.get("img_to", "?"))
+        destination = _IMAGE_DESTINATION_ENUMS.get(str(entry.get("img_to_type")))
+        if destination is None:
+            return raw
+        try:
+            return str(destination[raw])
+        except KeyError:
+            return raw
+
+    @staticmethod
     def _saved_text(created_at: str) -> str:
         """Render the stored UTC timestamp in the user's local time."""
         try:
@@ -457,7 +493,7 @@ class LoadJobDialog(QDialog):
             rows.append(("Title", escape(title_text)))
         summary = listing.summary
         if summary.media_type:
-            rows.append(("Type", summary.media_type))
+            rows.append(("Type", escape(summary.media_type)))
         if summary.file_count:
             rows.append(("Files", str(summary.file_count)))
         if summary.input_path:
@@ -483,7 +519,7 @@ class LoadJobDialog(QDialog):
                             "Trackers",
                             "<br />".join(
                                 f"{escape(self._tracker_display_name(name))} &rarr; "
-                                f"{escape(str(entry.get('img_to', '?')))}"
+                                f"{escape(self._image_host_display_name(entry))}"
                                 for name, entry in hosts.items()
                                 if isinstance(entry, dict)
                             ),

--- a/src/frontend/custom_widgets/load_job_dialog.py
+++ b/src/frontend/custom_widgets/load_job_dialog.py
@@ -441,6 +441,22 @@ class LoadJobDialog(QDialog):
                 self.job_tree.setCurrentItem(first_item)
             finally:
                 self._suppress_source_tracking = False
+
+        # Queue items keep the JobListing they were queued with, which is now
+        # stale if the job was renamed since -- rebind each one to the fresh
+        # listing at the same path so `_renumber_queue` renders the current
+        # name. Only paths still present here are touched: a job missing from
+        # one scan is not proof it is gone, and dropping its queue entry
+        # would be an undisclosed side effect, the same reasoning
+        # `_delete_selected` already applies to a failed delete.
+        by_path = {listing.path: listing for listing in listings}
+        for row in range(self.queue_list.count()):
+            queue_item = self.queue_list.item(row)
+            stored = queue_item.data(_LISTING_ROLE)
+            if isinstance(stored, JobListing) and stored.path in by_path:
+                queue_item.setData(_LISTING_ROLE, by_path[stored.path])
+        self._renumber_queue()
+
         self._apply_filter()
 
     def _stop_loader(self) -> None:

--- a/src/frontend/custom_widgets/load_job_dialog.py
+++ b/src/frontend/custom_widgets/load_job_dialog.py
@@ -120,6 +120,13 @@ class LoadJobDialog(QDialog):
         leaves the tree's current listing unchanged can skip the whole
         refresh rather than re-describing the same job from scratch.
         """
+        self._details_source: str = "tree"
+        """Which pane the details view and Open Folder currently describe:
+        `"tree"` or `"queue"`. Tracked explicitly rather than via focus --
+        `hasFocus()` is unreliable before the dialog is shown, and the tests
+        for this file construct the dialog without showing it. Set by
+        `_on_tree_selection_changed` and `_on_queue_row_changed`, below.
+        """
 
         self.info_lbl = QLabel(
             "<i><span>Pick a saved job to jump straight to processing. Duplicate "
@@ -131,9 +138,7 @@ class LoadJobDialog(QDialog):
         )
 
         self.filter_edit = QLineEdit(self)
-        self.filter_edit.setPlaceholderText(
-            "Filter by name, title, file or tracker..."
-        )
+        self.filter_edit.setPlaceholderText("Filter by name, title, file or tracker...")
         self.filter_edit.setClearButtonEnabled(True)
         self.filter_edit.textChanged.connect(self._apply_filter)
 
@@ -173,7 +178,7 @@ class LoadJobDialog(QDialog):
         # multi-select so several prepared jobs can be queued in one go
         self.job_tree.setSelectionMode(QTreeWidget.SelectionMode.ExtendedSelection)
         self.job_tree.itemDoubleClicked.connect(self._on_double_click)
-        self.job_tree.itemSelectionChanged.connect(self._update_button_state)
+        self.job_tree.itemSelectionChanged.connect(self._on_tree_selection_changed)
 
         self.empty_lbl = QLabel(
             "<span>No saved jobs yet. Use <b>Save Job</b> on the process page "
@@ -210,7 +215,7 @@ class LoadJobDialog(QDialog):
             "Jobs run top to bottom. Only prepared jobs on this config can be "
             "queued, since a queue has nobody to answer a prompt"
         )
-        self.queue_list.currentRowChanged.connect(self._update_button_state)
+        self.queue_list.currentRowChanged.connect(self._on_queue_row_changed)
 
         self.add_to_queue_btn = QPushButton("Add to queue", self)
         self.add_to_queue_btn.clicked.connect(self._add_to_queue)
@@ -529,6 +534,25 @@ class LoadJobDialog(QDialog):
         listing = item.data(0, _LISTING_ROLE)
         return listing if isinstance(listing, JobListing) else None
 
+    def _details_listing(self) -> JobListing | None:
+        """The listing the details pane and Open Folder currently describe.
+
+        Follows `self._details_source` rather than the tree unconditionally,
+        so clicking a queue row describes that queued job instead of
+        whatever the tree's own selection happens to be.
+        """
+        if self._details_source == "queue":
+            item = self.queue_list.currentItem()
+            if item is None:
+                return None
+            listing = item.data(_LISTING_ROLE)
+            return listing if isinstance(listing, JobListing) else None
+
+        listing = self._current_listing()
+        if listing is None or listing not in self._selected_listings():
+            return None
+        return listing
+
     def _selected_listings(self) -> list[JobListing]:
         listings: list[JobListing] = []
         for item in self.job_tree.selectedItems():
@@ -662,6 +686,16 @@ class LoadJobDialog(QDialog):
         return f"{len(selected)} prepared job(s) selected; ready to add to the queue."
 
     @Slot()
+    def _on_tree_selection_changed(self) -> None:
+        self._details_source = "tree"
+        self._update_button_state()
+
+    @Slot()
+    def _on_queue_row_changed(self) -> None:
+        self._details_source = "queue"
+        self._update_button_state()
+
+    @Slot()
     def _update_button_state(self) -> None:
         # The selected job, not the current one -- see `_rename_selected`.
         # Enablement and the actions it gates have to agree with the same
@@ -779,19 +813,20 @@ class LoadJobDialog(QDialog):
         return rendered
 
     def _refresh_details(self) -> None:
-        """Render the details pane for the tree's current listing, if any.
+        """Render the details pane for the active source's current listing.
 
-        `_update_button_state` runs this on every filter keystroke and on
-        `queue_list.currentRowChanged` -- neither of which necessarily moves
-        the tree's own current item. Bailing out here when the listing to
-        show has not changed since the last call is what stops those from
+        The active source -- tree or queue -- comes from `_details_listing`.
+        `_update_button_state` runs this on every filter keystroke, which
+        moves neither pane's current item. Bailing out here when the listing
+        to show has not changed since the last call is what stops that from
         re-reading the job's document and re-walking its folder for no
         reason; `_describe`'s own memoisation only covers the read, not the
-        `is_dir()` stat this method also does.
+        `is_dir()` stat this method also does. Switching source to a
+        different job changes the path and so still re-renders; if the same
+        job sits in both panes the early return is correct, since the
+        rendered content would be identical either way.
         """
-        listing = self._current_listing()
-        if listing is None or listing not in self._selected_listings():
-            listing = None
+        listing = self._details_listing()
 
         path = listing.path if listing is not None else None
         if path == self._last_described_path:
@@ -807,7 +842,10 @@ class LoadJobDialog(QDialog):
 
     @Slot()
     def _open_job_folder(self) -> None:
-        listing = self._current_listing()
+        # Follows the same source as the details pane it sits under -- see
+        # `_details_listing` -- so the button never opens a different job's
+        # folder than the one the pane is currently describing.
+        listing = self._details_listing()
         if listing is not None:
             open_explorer(listing.path)
 

--- a/src/frontend/custom_widgets/load_job_dialog.py
+++ b/src/frontend/custom_widgets/load_job_dialog.py
@@ -675,9 +675,17 @@ class LoadJobDialog(QDialog):
         job by path -- a queue mid-flight, a listing already on screen -- is
         invalidated by the rename.
         """
-        listing = self._current_listing()
-        if listing is None or len(self._selected_listings()) != 1:
+        # The selected job, not the current one. `currentItem()` can sit on a
+        # row that is not selected -- ctrl+click a second row, ctrl+click it
+        # again, and the current item stays there while the first row remains
+        # the only selection. Renaming what is current would rewrite the wrong
+        # job's name on disk while the right one is still highlighted. The
+        # sibling load/switch actions have the same shape but only mis-open a
+        # job; this one writes.
+        selected = self._selected_listings()
+        if len(selected) != 1:
             return
+        listing = selected[0]
 
         name, accepted = QInputDialog.getText(
             self, "Rename Job", "Job name:", text=listing.name

--- a/src/frontend/custom_widgets/load_job_dialog.py
+++ b/src/frontend/custom_widgets/load_job_dialog.py
@@ -462,8 +462,14 @@ class LoadJobDialog(QDialog):
     def _can_queue(self, listing: JobListing) -> bool:
         return listing.prepared and listing.matches_profile(self.active_profile)
 
-    def _queued_paths(self) -> list[Path]:
-        return [listing.path for listing in self.queueable_listings()]
+    def _queued_paths(self) -> set[Path]:
+        """Paths already in the queue, for the duplicate check.
+
+        Its own method rather than an inline comprehension in `_add_to_queue`,
+        so the "what is already queued" question has one answer that
+        `_drop_from_queue` and any later caller can share.
+        """
+        return {listing.path for listing in self.queueable_listings()}
 
     def _renumber_queue(self) -> None:
         for row in range(self.queue_list.count()):
@@ -474,7 +480,7 @@ class LoadJobDialog(QDialog):
 
     @Slot()
     def _add_to_queue(self) -> None:
-        queued = {listing.path for listing in self.queueable_listings()}
+        queued = self._queued_paths()
         for listing in self._selected_listings():
             if not self._can_queue(listing) or listing.path in queued:
                 continue
@@ -714,7 +720,6 @@ class LoadJobDialog(QDialog):
         listings = self._selected_listings()
         if not listings:
             return
-        paths = {listing.path for listing in listings}
 
         # Spelled out rather than "job(s)": this is the one irreversible action
         # in the dialog, and the list of what goes with it has to match what a
@@ -745,6 +750,7 @@ class LoadJobDialog(QDialog):
         ):
             return
 
+        removed: set[Path] = set()
         failures: list[str] = []
         for listing in listings:
             try:
@@ -752,6 +758,8 @@ class LoadJobDialog(QDialog):
             except JobStoreError as error:
                 LOG.error(LOG.LOG_SOURCE.FE, f"Failed to delete job: {error}")
                 failures.append(f"{listing.name}: {error}")
+                continue
+            removed.add(listing.path)
 
         if failures:
             QMessageBox.critical(
@@ -759,7 +767,12 @@ class LoadJobDialog(QDialog):
                 "Delete Failed",
                 "Some jobs could not be deleted:\n\n" + "\n".join(failures),
             )
-        self._drop_from_queue(paths)
+
+        # Only what actually went. A job whose delete failed is still on disk
+        # and still runnable, so dropping it from the queue would be a second,
+        # silent consequence of an operation that did not happen -- and the
+        # user would lose its queue position with nothing saying so.
+        self._drop_from_queue(removed)
         self._load_listings()
 
     @Slot()

--- a/src/frontend/custom_widgets/load_job_dialog.py
+++ b/src/frontend/custom_widgets/load_job_dialog.py
@@ -617,8 +617,11 @@ class LoadJobDialog(QDialog):
         if not selected:
             return "Select a job to load, or several prepared ones to add to the queue."
 
-        listing = self._current_listing()
-        if len(selected) == 1 and listing is not None:
+        # The selected job, not the current one -- see `_rename_selected`.
+        # The hint is display-only, but it still has to name the row that is
+        # actually highlighted, not whatever `currentItem()` last landed on.
+        if len(selected) == 1:
+            listing = selected[0]
             if not listing.matches_profile(self.active_profile):
                 return (
                     f"'{listing.name}' was saved under config "

--- a/src/frontend/custom_widgets/load_job_dialog.py
+++ b/src/frontend/custom_widgets/load_job_dialog.py
@@ -3,6 +3,7 @@
 from datetime import datetime
 from enum import Enum
 from html import escape
+from pathlib import Path
 from typing import Any
 
 from PySide6.QtCore import Qt, Slot
@@ -17,6 +18,8 @@ from PySide6.QtWidgets import (
     QInputDialog,
     QLabel,
     QLineEdit,
+    QListWidget,
+    QListWidgetItem,
     QMessageBox,
     QPushButton,
     QScrollArea,
@@ -167,11 +170,43 @@ class LoadJobDialog(QDialog):
         details_layout.addWidget(details_scroll, stretch=1)
         details_layout.addWidget(self.open_folder_btn)
 
+        self.queue_list = QListWidget(self)
+        self.queue_list.setToolTip(
+            "Jobs run top to bottom. Only prepared jobs on this config can be "
+            "queued, since a queue has nobody to answer a prompt"
+        )
+        self.queue_list.currentRowChanged.connect(self._update_button_state)
+
+        self.add_to_queue_btn = QPushButton("Add to queue", self)
+        self.add_to_queue_btn.clicked.connect(self._add_to_queue)
+        self.queue_up_btn = QPushButton("Up", self)
+        self.queue_up_btn.clicked.connect(lambda: self._move_queued(-1))
+        self.queue_down_btn = QPushButton("Down", self)
+        self.queue_down_btn.clicked.connect(lambda: self._move_queued(1))
+        self.queue_remove_btn = QPushButton("Remove", self)
+        self.queue_remove_btn.setToolTip("Take it out of the queue; the job is kept")
+        self.queue_remove_btn.clicked.connect(self._remove_queued)
+
+        queue_buttons = QHBoxLayout()
+        queue_buttons.addWidget(self.queue_up_btn)
+        queue_buttons.addWidget(self.queue_down_btn)
+        queue_buttons.addWidget(self.queue_remove_btn)
+
+        queue_panel = QWidget(self)
+        queue_layout = QVBoxLayout(queue_panel)
+        queue_layout.setContentsMargins(8, 0, 8, 0)
+        queue_layout.addWidget(QLabel("<b>Queue</b>", parent=queue_panel))
+        queue_layout.addWidget(self.add_to_queue_btn)
+        queue_layout.addWidget(self.queue_list, stretch=1)
+        queue_layout.addLayout(queue_buttons)
+
         self.splitter = CustomSplitter(Qt.Orientation.Horizontal, self)
         self.splitter.addWidget(self.job_tree)
         self.splitter.addWidget(details_panel)
+        self.splitter.insertWidget(1, queue_panel)
         self.splitter.setStretchFactor(0, 3)
         self.splitter.setStretchFactor(1, 2)
+        self.splitter.setStretchFactor(2, 2)
 
         self.status_lbl = QLabel("", wordWrap=True, parent=self)
         self.status_lbl.setTextFormat(Qt.TextFormat.PlainText)
@@ -191,11 +226,7 @@ class LoadJobDialog(QDialog):
         self.switch_btn.clicked.connect(self._accept_with_switch)
 
         self.queue_btn = QPushButton("Run Queue", self)
-        self.queue_btn.setToolTip(
-            "Upload the selected jobs one after another. Only prepared jobs on "
-            "this config can be queued, since a queue has nobody to answer a "
-            "prompt"
-        )
+        self.queue_btn.setToolTip("Upload the queued jobs one after another, in order")
         self.queue_btn.clicked.connect(self._accept_queue)
 
         self.button_box = QDialogButtonBox(
@@ -415,22 +446,77 @@ class LoadJobDialog(QDialog):
         return listings
 
     def queueable_listings(self) -> list[JobListing]:
-        """Selected jobs the queue is actually allowed to run.
+        """The queue, in the order the user put it in.
 
-        Both conditions are load-bearing: a job from another config would upload
-        with the wrong credentials, and an unprepared one would stop at a prompt.
+        Membership was already gated when each job was added: a job from another
+        config would upload with the wrong credentials, and an unprepared one
+        would stop at a prompt.
         """
-        return [
-            listing
-            for listing in self._selected_listings()
-            if listing.prepared and listing.matches_profile(self.active_profile)
-        ]
+        listings: list[JobListing] = []
+        for row in range(self.queue_list.count()):
+            listing = self.queue_list.item(row).data(_LISTING_ROLE)
+            if isinstance(listing, JobListing):
+                listings.append(listing)
+        return listings
+
+    def _can_queue(self, listing: JobListing) -> bool:
+        return listing.prepared and listing.matches_profile(self.active_profile)
+
+    def _queued_paths(self) -> list[Path]:
+        return [listing.path for listing in self.queueable_listings()]
+
+    def _renumber_queue(self) -> None:
+        for row in range(self.queue_list.count()):
+            item = self.queue_list.item(row)
+            listing = item.data(_LISTING_ROLE)
+            if isinstance(listing, JobListing):
+                item.setText(f"{row + 1}. {listing.name}")
+
+    @Slot()
+    def _add_to_queue(self) -> None:
+        queued = {listing.path for listing in self.queueable_listings()}
+        for listing in self._selected_listings():
+            if not self._can_queue(listing) or listing.path in queued:
+                continue
+            item = QListWidgetItem(listing.name)
+            item.setData(_LISTING_ROLE, listing)
+            self.queue_list.addItem(item)
+            queued.add(listing.path)
+        self._renumber_queue()
+        self._update_button_state()
+
+    def _move_queued(self, offset: int) -> None:
+        row = self.queue_list.currentRow()
+        target = row + offset
+        if row < 0 or not 0 <= target < self.queue_list.count():
+            return
+        self.queue_list.insertItem(target, self.queue_list.takeItem(row))
+        self.queue_list.setCurrentRow(target)
+        self._renumber_queue()
+        self._update_button_state()
+
+    @Slot()
+    def _remove_queued(self) -> None:
+        row = self.queue_list.currentRow()
+        if row < 0:
+            return
+        self.queue_list.takeItem(row)
+        self._renumber_queue()
+        self._update_button_state()
+
+    def _drop_from_queue(self, paths: set[Path]) -> None:
+        """Take deleted jobs out of the queue, so it cannot point at nothing."""
+        for row in reversed(range(self.queue_list.count())):
+            listing = self.queue_list.item(row).data(_LISTING_ROLE)
+            if isinstance(listing, JobListing) and listing.path in paths:
+                self.queue_list.takeItem(row)
+        self._renumber_queue()
 
     def _selection_hint(self) -> str:
         """One line saying what the current selection can and cannot do."""
         selected = self._selected_listings()
         if not selected:
-            return "Select a job to load, or several prepared ones to queue."
+            return "Select a job to load, or several prepared ones to add to the queue."
 
         listing = self._current_listing()
         if len(selected) == 1 and listing is not None:
@@ -443,9 +529,9 @@ class LoadJobDialog(QDialog):
             if not listing.prepared:
                 return (
                     f"'{listing.name}' still needs input, so it can be loaded "
-                    "but not queued."
+                    "but not added to the queue."
                 )
-            return f"'{listing.name}' is ready to load or queue."
+            return f"'{listing.name}' is ready to load or add to the queue."
 
         unprepared = sum(1 for entry in selected if not entry.prepared)
         other_config = sum(
@@ -458,27 +544,34 @@ class LoadJobDialog(QDialog):
             reasons.append(f"{other_config} on another config")
         if reasons:
             return (
-                f"{len(selected)} selected; cannot queue because "
+                f"{len(selected)} selected; cannot add to the queue because "
                 + " and ".join(reasons)
                 + ". A queue has nobody to answer a prompt."
             )
-        return f"{len(selected)} prepared job(s) selected; ready to queue."
+        return f"{len(selected)} prepared job(s) selected; ready to add to the queue."
 
     @Slot()
     def _update_button_state(self) -> None:
         listing = self._current_listing()
         matches = listing is not None and listing.matches_profile(self.active_profile)
         selected = self._selected_listings()
-        queueable = self.queueable_listings()
 
         self.delete_btn.setEnabled(bool(selected))
         self.rename_btn.setEnabled(len(selected) == 1)
         self.switch_btn.setEnabled(
             len(selected) == 1 and listing is not None and not matches
         )
-        # every selected job has to be runnable, so a mixed selection cannot
+        # every selected job has to be addable, so a mixed selection cannot
         # silently drop the ones it would skip
-        self.queue_btn.setEnabled(bool(queueable) and len(queueable) == len(selected))
+        addable = [listing for listing in selected if self._can_queue(listing)]
+        self.add_to_queue_btn.setEnabled(
+            bool(addable) and len(addable) == len(selected)
+        )
+        self.queue_btn.setEnabled(self.queue_list.count() > 0)
+        row = self.queue_list.currentRow()
+        self.queue_up_btn.setEnabled(row > 0)
+        self.queue_down_btn.setEnabled(0 <= row < self.queue_list.count() - 1)
+        self.queue_remove_btn.setEnabled(row >= 0)
         open_button = self.button_box.button(QDialogButtonBox.StandardButton.Open)
         if open_button:
             open_button.setEnabled(matches and len(selected) == 1)
@@ -600,10 +693,10 @@ class LoadJobDialog(QDialog):
 
     @Slot()
     def _accept_queue(self) -> None:
-        queueable = self.queueable_listings()
-        if not queueable or len(queueable) != len(self._selected_listings()):
+        queued = self.queueable_listings()
+        if not queued:
             return
-        self.queued_listings = queueable
+        self.queued_listings = queued
         self.selected_listing = None
         self.accept()
 
@@ -621,6 +714,7 @@ class LoadJobDialog(QDialog):
         listings = self._selected_listings()
         if not listings:
             return
+        paths = {listing.path for listing in listings}
 
         # Spelled out rather than "job(s)": this is the one irreversible action
         # in the dialog, and the list of what goes with it has to match what a
@@ -665,6 +759,7 @@ class LoadJobDialog(QDialog):
                 "Delete Failed",
                 "Some jobs could not be deleted:\n\n" + "\n".join(failures),
             )
+        self._drop_from_queue(paths)
         self._load_listings()
 
     @Slot()

--- a/src/frontend/custom_widgets/load_job_dialog.py
+++ b/src/frontend/custom_widgets/load_job_dialog.py
@@ -1,5 +1,6 @@
 """Picker for saved jobs."""
 
+from contextlib import suppress
 from datetime import datetime
 from enum import Enum
 from html import escape
@@ -278,6 +279,15 @@ class LoadJobDialog(QDialog):
         self._load_listings()
 
     def _load_listings(self) -> None:
+        # Retire any loader still in flight before starting another. Without
+        # this, a second call replaces `self._loader` and the previous thread
+        # becomes unreachable -- still running, still parented, and no longer
+        # something `done()` can wait on, which is exactly the destroy-a-live-
+        # thread abort this change exists to avoid. Not reachable through the
+        # UI today (delete and rename are disabled while the tree is empty),
+        # but the invariant should not depend on that staying true.
+        self._stop_loader()
+
         self.job_tree.clear()
         self.job_tree.setVisible(False)
         self.empty_lbl.setText("<span>Loading saved jobs...</span>")
@@ -365,19 +375,33 @@ class LoadJobDialog(QDialog):
             self.job_tree.setCurrentItem(first_item)
         self._apply_filter()
 
-    def done(self, result: int) -> None:
-        """Stop the loader before the dialog is torn down.
+    def _stop_loader(self) -> None:
+        """Detach and finish the current loader before moving on.
 
-        Qt aborts the process outright if a `QThread` is still running when
-        its C++ object is destroyed, and `_loader` is parented to this dialog
-        -- so a dialog closed mid-load would otherwise take the whole app down
-        with it, not just fail to show the results. Disconnecting first means
-        a load that finishes just after this point does not deliver into a
-        dialog that is already on its way out.
+        Disconnect first, and unconditionally. A queued `loaded` is delivered
+        only if the connection is still live when it is dispatched, so severing
+        it cancels an emission already in flight. Gating the disconnect on
+        `isRunning()` would miss a loader that finished in the window between
+        the check and the call, letting its result land in a dialog that is
+        already closing.
+
+        Then wait with no cap. An earlier version waited two seconds, which is
+        precisely the wrong bound: the case this has to survive is the slow
+        network scan the whole change exists to get off the GUI thread, and
+        that is exactly the case that exceeds two seconds. Returning early
+        leaves a running thread to be destroyed, which aborts the process. A
+        brief freeze while closing is much the lesser cost.
         """
-        if self._loader is not None and self._loader.isRunning():
-            self._loader.loaded.disconnect(self._on_listings_loaded)
-            self._loader.wait(2000)
+        loader = self._loader
+        self._loader = None
+        if loader is None:
+            return
+        with suppress(RuntimeError, TypeError):
+            loader.loaded.disconnect(self._on_listings_loaded)
+        loader.wait()
+
+    def done(self, result: int) -> None:
+        self._stop_loader()
         super().done(result)
 
     @Slot()

--- a/src/frontend/custom_widgets/load_job_dialog.py
+++ b/src/frontend/custom_widgets/load_job_dialog.py
@@ -6,7 +6,7 @@ from html import escape
 from pathlib import Path
 from typing import Any
 
-from PySide6.QtCore import Qt, Slot
+from PySide6.QtCore import Qt, QThread, Signal, Slot
 from PySide6.QtGui import QBrush, QPalette
 from PySide6.QtWidgets import (
     QCheckBox,
@@ -61,6 +61,24 @@ _IMAGE_DESTINATION_ENUMS: dict[str, type[Enum]] = {
 }
 
 
+class _ListingLoader(QThread):
+    """Reads the saved-job list off the GUI thread.
+
+    Listing walks every config profile's working directory and parses every
+    `job.json` in it. That is fine locally and a visible stall on a network
+    share, and the dialog has nothing to show until it finishes either way.
+    """
+
+    loaded = Signal(object)  # list[JobListing]
+
+    def run(self) -> None:
+        try:
+            self.loaded.emit(list_jobs(unique_working_dirs()))
+        except Exception as error:
+            LOG.error(LOG.LOG_SOURCE.FE, f"Could not list saved jobs: {error}")
+            self.loaded.emit([])
+
+
 class LoadJobDialog(QDialog):
     """Lists saved jobs and reports which one the user chose to load.
 
@@ -86,6 +104,7 @@ class LoadJobDialog(QDialog):
         self.switch_profile_requested = False
         self.queued_listings: list[JobListing] = []
         """Jobs to run back to back, when the user chose Run Queue."""
+        self._loader: _ListingLoader | None = None
 
         self.info_lbl = QLabel(
             "<i><span>Pick a saved job to jump straight to processing. Duplicate "
@@ -259,11 +278,22 @@ class LoadJobDialog(QDialog):
         self._load_listings()
 
     def _load_listings(self) -> None:
+        self.job_tree.clear()
+        self.job_tree.setVisible(False)
+        self.empty_lbl.setText("<span>Loading saved jobs...</span>")
+        self.empty_lbl.setVisible(True)
+        self._update_button_state()
+
+        self._loader = _ListingLoader(self)
+        self._loader.loaded.connect(self._on_listings_loaded)
+        self._loader.start()
+
+    @Slot(object)
+    def _on_listings_loaded(self, listings: list[JobListing]) -> None:
         # sorting reshuffles the tree on every insert otherwise, which is
         # wasted work and would show rows swapping places as they load
         self.job_tree.setSortingEnabled(False)
         self.job_tree.clear()
-        listings = list_jobs(unique_working_dirs())
         muted = QBrush(
             self.palette().color(
                 QPalette.ColorGroup.Disabled, QPalette.ColorRole.WindowText
@@ -325,11 +355,30 @@ class LoadJobDialog(QDialog):
 
         has_jobs = bool(listings)
         self.job_tree.setVisible(has_jobs)
+        self.empty_lbl.setText(
+            "<span>No saved jobs yet. Use <b>Save Job</b> on the process page "
+            "to create one.</span>"
+        )
         self.empty_lbl.setVisible(not has_jobs)
         first_item = self.job_tree.topLevelItem(0)
         if first_item is not None:
             self.job_tree.setCurrentItem(first_item)
         self._apply_filter()
+
+    def done(self, result: int) -> None:
+        """Stop the loader before the dialog is torn down.
+
+        Qt aborts the process outright if a `QThread` is still running when
+        its C++ object is destroyed, and `_loader` is parented to this dialog
+        -- so a dialog closed mid-load would otherwise take the whole app down
+        with it, not just fail to show the results. Disconnecting first means
+        a load that finishes just after this point does not deliver into a
+        dialog that is already on its way out.
+        """
+        if self._loader is not None and self._loader.isRunning():
+            self._loader.loaded.disconnect(self._on_listings_loaded)
+            self._loader.wait(2000)
+        super().done(result)
 
     @Slot()
     def _apply_filter(self) -> None:

--- a/src/frontend/custom_widgets/load_job_dialog.py
+++ b/src/frontend/custom_widgets/load_job_dialog.py
@@ -418,14 +418,30 @@ class LoadJobDialog(QDialog):
         if not listings:
             return
 
+        # Spelled out rather than "job(s)": this is the one irreversible action
+        # in the dialog, and the list of what goes with it has to match what a
+        # job directory actually holds -- images/, mediainfo/, nfo/ and the
+        # base torrent. Omitting any of them understates the loss.
+        count = len(listings)
         names = "\n".join(f"  {listing.name}" for listing in listings)
+        if count == 1:
+            title = "Delete Job"
+            question = "Delete this saved job?"
+            consequence = (
+                "This also removes its screenshots, MediaInfo, NFOs and torrent."
+            )
+        else:
+            title = "Delete Jobs"
+            question = f"Delete these {count} saved jobs?"
+            consequence = (
+                "This also removes their screenshots, MediaInfo, NFOs and torrents."
+            )
+
         if (
             QMessageBox.question(
                 self,
-                "Delete Job" if len(listings) == 1 else "Delete Jobs",
-                f"Delete {len(listings)} saved job(s)?\n\n{names}\n\n"
-                "This also removes their screenshots, MediaInfo and torrents. "
-                "It cannot be undone.",
+                title,
+                f"{question}\n\n{names}\n\n{consequence} It cannot be undone.",
             )
             is not QMessageBox.StandardButton.Yes
         ):

--- a/src/frontend/custom_widgets/load_job_dialog.py
+++ b/src/frontend/custom_widgets/load_job_dialog.py
@@ -20,6 +20,7 @@ from PySide6.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
+import qtawesome as qta
 
 from src.backend.jobs import JobListing, JobStoreError, delete_job, list_jobs
 from src.config.profiles import unique_working_dirs
@@ -174,6 +175,9 @@ class LoadJobDialog(QDialog):
                 QPalette.ColorGroup.Disabled, QPalette.ColorRole.WindowText
             )
         )
+        icon_color = self.palette().color(QPalette.ColorRole.WindowText).name()
+        prepared_icon = qta.icon("mdi6.package-variant-closed", color=icon_color)
+        needs_input_icon = qta.icon("mdi6.pencil-outline", color=icon_color)
 
         for listing in listings:
             item = QTreeWidgetItem(
@@ -188,6 +192,7 @@ class LoadJobDialog(QDialog):
                 )
             )
             item.setData(0, _LISTING_ROLE, listing)
+            item.setIcon(5, prepared_icon if listing.prepared else needs_input_icon)
             # the Trackers column is Interactive and elides, so the full list
             # has to be reachable somewhere
             if listing.summary.trackers:

--- a/src/frontend/custom_widgets/load_job_dialog.py
+++ b/src/frontend/custom_widgets/load_job_dialog.py
@@ -184,6 +184,7 @@ class LoadJobDialog(QDialog):
         icon_color = self.palette().color(QPalette.ColorRole.WindowText).name()
         prepared_icon = qta.icon("mdi6.package-variant-closed", color=icon_color)
         needs_input_icon = qta.icon("mdi6.pencil-outline", color=icon_color)
+        missing_icon = qta.icon("mdi6.alert-outline", color=icon_color)
 
         for listing in listings:
             item = QTreeWidgetItem(
@@ -213,6 +214,16 @@ class LoadJobDialog(QDialog):
                     0,
                     f"Saved under config '{listing.config_profile}'. "
                     "Use 'Switch profile and load' to open it.",
+                )
+            if not listing.media_available:
+                # after the cross-profile tooltip so this one wins -- a job
+                # that cannot run at all is the more urgent fact
+                item.setIcon(0, missing_icon)
+                item.setToolTip(
+                    0,
+                    "The media this job was built from is no longer at "
+                    f"'{listing.summary.input_path}', so it cannot be processed "
+                    "until the file is back.",
                 )
             self.job_tree.addTopLevelItem(item)
 

--- a/src/frontend/custom_widgets/load_job_dialog.py
+++ b/src/frontend/custom_widgets/load_job_dialog.py
@@ -866,8 +866,10 @@ class LoadJobDialog(QDialog):
 
         # Spelled out rather than "job(s)": this is the one irreversible action
         # in the dialog, and the list of what goes with it has to match what a
-        # job directory actually holds -- images/, mediainfo/, nfo/ and the
-        # base torrent. Omitting any of them understates the loss.
+        # job directory actually holds. On disk that's images/, mediainfo/,
+        # nfo/ and the base torrent; the text below names the same four
+        # things in the terms a user recognizes -- screenshots, MediaInfo,
+        # NFOs and torrent(s). Omitting any of them understates the loss.
         count = len(listings)
         names = "\n".join(f"  {listing.name}" for listing in listings)
         if count == 1:

--- a/src/frontend/custom_widgets/load_job_dialog.py
+++ b/src/frontend/custom_widgets/load_job_dialog.py
@@ -631,9 +631,13 @@ class LoadJobDialog(QDialog):
 
     @Slot()
     def _update_button_state(self) -> None:
-        listing = self._current_listing()
-        matches = listing is not None and listing.matches_profile(self.active_profile)
+        # The selected job, not the current one -- see `_rename_selected`.
+        # Enablement and the actions it gates have to agree with the same
+        # row, or a coherent-looking UI can act on one job while highlighting
+        # another.
         selected = self._selected_listings()
+        listing = selected[0] if len(selected) == 1 else None
+        matches = listing is not None and listing.matches_profile(self.active_profile)
 
         self.delete_btn.setEnabled(bool(selected))
         self.rename_btn.setEnabled(len(selected) == 1)
@@ -763,8 +767,14 @@ class LoadJobDialog(QDialog):
 
     @Slot()
     def _accept_selection(self) -> None:
-        listing = self._current_listing()
-        if listing is None or not listing.matches_profile(self.active_profile):
+        # The selected job, not the current one -- see `_rename_selected`.
+        # This is what lands on the process page, where the next action is
+        # Process: loading the wrong release here uploads it to a tracker.
+        selected = self._selected_listings()
+        if len(selected) != 1:
+            return
+        listing = selected[0]
+        if not listing.matches_profile(self.active_profile):
             return
         self.selected_listing = listing
         self.switch_profile_requested = False
@@ -781,8 +791,15 @@ class LoadJobDialog(QDialog):
 
     @Slot()
     def _accept_with_switch(self) -> None:
-        listing = self._current_listing()
-        if listing is None or listing.matches_profile(self.active_profile):
+        # The selected job, not the current one -- see `_rename_selected`.
+        # This drives `_switch_config_profile`, which loads a profile and
+        # emits `settings_refresh`: a persistent, global config change made
+        # on the strength of a row the user did not select.
+        selected = self._selected_listings()
+        if len(selected) != 1:
+            return
+        listing = selected[0]
+        if listing.matches_profile(self.active_profile):
             return
         self.selected_listing = listing
         self.switch_profile_requested = True

--- a/src/frontend/custom_widgets/load_job_dialog.py
+++ b/src/frontend/custom_widgets/load_job_dialog.py
@@ -456,6 +456,18 @@ class LoadJobDialog(QDialog):
             if isinstance(stored, JobListing) and stored.path in by_path:
                 queue_item.setData(_LISTING_ROLE, by_path[stored.path])
         self._renumber_queue()
+        # The rebind above can change a queue-sourced listing's rendered
+        # content without changing its path -- a rename keeps the same path.
+        # `_load_listings` already cleared `_details_cache` and reset
+        # `_last_described_path` once at the start of this reload, but the
+        # button-state refresh that runs there (while the tree is still
+        # empty and the queue not yet rebound) reads and caches the *old*
+        # queue listing at that same path -- both `_describe`'s cache and
+        # `_refresh_details`'s memo -- before this rebind has a chance to
+        # matter. Clearing and resetting again here is what lets the
+        # `_apply_filter` call below actually re-render it.
+        self._details_cache.clear()
+        self._last_described_path = None
 
         self._apply_filter()
 

--- a/src/frontend/custom_widgets/load_job_dialog.py
+++ b/src/frontend/custom_widgets/load_job_dialog.py
@@ -120,6 +120,7 @@ class LoadJobDialog(QDialog):
         self.status_lbl.setTextFormat(Qt.TextFormat.PlainText)
 
         self.delete_btn = QPushButton("Delete", self)
+        self.delete_btn.setShortcut(Qt.Key.Key_Delete)
         self.delete_btn.clicked.connect(self._delete_selected)
 
         self.switch_btn = QPushButton("Switch profile and load", self)
@@ -356,7 +357,7 @@ class LoadJobDialog(QDialog):
         selected = self._selected_listings()
         queueable = self.queueable_listings()
 
-        self.delete_btn.setEnabled(len(selected) == 1)
+        self.delete_btn.setEnabled(bool(selected))
         self.switch_btn.setEnabled(
             len(selected) == 1 and listing is not None and not matches
         )
@@ -413,24 +414,35 @@ class LoadJobDialog(QDialog):
 
     @Slot()
     def _delete_selected(self) -> None:
-        listing = self._current_listing()
-        if listing is None or len(self._selected_listings()) != 1:
+        listings = self._selected_listings()
+        if not listings:
             return
+
+        names = "\n".join(f"  {listing.name}" for listing in listings)
         if (
             QMessageBox.question(
                 self,
-                "Delete Job",
-                f"Delete saved job '{listing.name}'?\n\nThis cannot be undone.",
+                "Delete Job" if len(listings) == 1 else "Delete Jobs",
+                f"Delete {len(listings)} saved job(s)?\n\n{names}\n\n"
+                "This also removes their screenshots, MediaInfo and torrents. "
+                "It cannot be undone.",
             )
             is not QMessageBox.StandardButton.Yes
         ):
             return
-        try:
-            delete_job(listing.path)
-        except JobStoreError as error:
-            LOG.error(LOG.LOG_SOURCE.FE, f"Failed to delete job: {error}")
+
+        failures: list[str] = []
+        for listing in listings:
+            try:
+                delete_job(listing.path)
+            except JobStoreError as error:
+                LOG.error(LOG.LOG_SOURCE.FE, f"Failed to delete job: {error}")
+                failures.append(f"{listing.name}: {error}")
+
+        if failures:
             QMessageBox.critical(
-                self, "Delete Failed", f"Could not delete job:\n\n{error}"
+                self,
+                "Delete Failed",
+                "Some jobs could not be deleted:\n\n" + "\n".join(failures),
             )
-            return
         self._load_listings()

--- a/src/frontend/custom_widgets/load_job_dialog.py
+++ b/src/frontend/custom_widgets/load_job_dialog.py
@@ -962,7 +962,9 @@ class LoadJobDialog(QDialog):
         except JobStoreError as error:
             LOG.error(LOG.LOG_SOURCE.FE, f"Failed to rename job: {error}")
             QMessageBox.critical(
-                self, "Rename Failed", f"Could not rename job:\n\n{error}"
+                self,
+                "Rename Failed",
+                f"Could not rename '{listing.name}':\n\n{error}",
             )
             return
 

--- a/src/frontend/custom_widgets/load_job_dialog.py
+++ b/src/frontend/custom_widgets/load_job_dialog.py
@@ -168,7 +168,6 @@ class LoadJobDialog(QDialog):
         header.setSectionResizeMode(6, QHeaderView.ResizeMode.ResizeToContents)
         header.resizeSection(3, 180)
         self.job_tree.setTextElideMode(Qt.TextElideMode.ElideRight)
-        self.job_tree.setSortingEnabled(True)
         # multi-select so several prepared jobs can be queued in one go
         self.job_tree.setSelectionMode(QTreeWidget.SelectionMode.ExtendedSelection)
         self.job_tree.itemDoubleClicked.connect(self._on_double_click)

--- a/src/frontend/custom_widgets/load_job_dialog.py
+++ b/src/frontend/custom_widgets/load_job_dialog.py
@@ -645,11 +645,19 @@ class LoadJobDialog(QDialog):
             reasons.append(f"{unprepared} not prepared")
         if other_config:
             reasons.append(f"{other_config} on another config")
-        if reasons:
+        # Counted once here for the headline, even though a job that is both
+        # unprepared and on another config is counted in both `reasons` --
+        # otherwise one such job selected reads as two problem jobs.
+        blocked = [
+            entry
+            for entry in selected
+            if not entry.prepared or not entry.matches_profile(self.active_profile)
+        ]
+        if blocked:
             return (
-                f"{len(selected)} selected; cannot add to the queue because "
-                + " and ".join(reasons)
-                + ". A queue has nobody to answer a prompt."
+                f"{len(selected)} selected; {len(blocked)} cannot be added to "
+                "the queue (" + ", ".join(reasons) + "). A queue has nobody to "
+                "answer a prompt."
             )
         return f"{len(selected)} prepared job(s) selected; ready to add to the queue."
 

--- a/src/frontend/custom_widgets/load_job_dialog.py
+++ b/src/frontend/custom_widgets/load_job_dialog.py
@@ -5,12 +5,14 @@ from datetime import datetime
 from PySide6.QtCore import Qt, Slot
 from PySide6.QtGui import QBrush, QPalette
 from PySide6.QtWidgets import (
+    QCheckBox,
     QDialog,
     QDialogButtonBox,
     QFrame,
     QHBoxLayout,
     QHeaderView,
     QLabel,
+    QLineEdit,
     QMessageBox,
     QPushButton,
     QTreeWidget,
@@ -60,6 +62,23 @@ class LoadJobDialog(QDialog):
             wordWrap=True,
             parent=self,
         )
+
+        self.filter_edit = QLineEdit(self)
+        self.filter_edit.setPlaceholderText("Filter by name, title or tracker...")
+        self.filter_edit.setClearButtonEnabled(True)
+        self.filter_edit.textChanged.connect(self._apply_filter)
+
+        self.only_this_config = QCheckBox("Only this config", self)
+        self.only_this_config.setChecked(True)
+        self.only_this_config.setToolTip(
+            "Jobs saved under another config can still be opened, but only via "
+            "'Switch profile and load'"
+        )
+        self.only_this_config.toggled.connect(self._apply_filter)
+
+        filter_row = QHBoxLayout()
+        filter_row.addWidget(self.filter_edit, stretch=1)
+        filter_row.addWidget(self.only_this_config)
 
         self.job_tree = QTreeWidget(self)
         self.job_tree.setFrameShape(QFrame.Shape.Box)
@@ -133,6 +152,7 @@ class LoadJobDialog(QDialog):
 
         main_layout = QVBoxLayout(self)
         main_layout.addWidget(self.info_lbl)
+        main_layout.addLayout(filter_row)
         main_layout.addWidget(self.empty_lbl)
         main_layout.addWidget(self.job_tree, stretch=1)
         main_layout.addLayout(bottom_row)
@@ -190,6 +210,41 @@ class LoadJobDialog(QDialog):
         first_item = self.job_tree.topLevelItem(0)
         if first_item is not None:
             self.job_tree.setCurrentItem(first_item)
+        self._apply_filter()
+
+    @Slot()
+    def _apply_filter(self) -> None:
+        """Hide rows that do not match the filter, and deselect what it hides.
+
+        A hidden row that stayed selected would still be picked up by Load,
+        Delete and the queue, which is exactly the kind of action-at-a-distance
+        a filter is supposed to remove.
+        """
+        needle = self.filter_edit.text().strip().casefold()
+        only_mine = self.only_this_config.isChecked()
+
+        for index in range(self.job_tree.topLevelItemCount()):
+            item = self.job_tree.topLevelItem(index)
+            if item is None:
+                continue
+            listing = item.data(0, _LISTING_ROLE)
+            if not isinstance(listing, JobListing):
+                continue
+            haystack = " ".join(
+                (
+                    listing.name,
+                    listing.summary.title or "",
+                    listing.summary.input_name or "",
+                    " ".join(listing.summary.trackers),
+                )
+            ).casefold()
+            hidden = bool(needle) and needle not in haystack
+            if only_mine and not listing.matches_profile(self.active_profile):
+                hidden = True
+            item.setHidden(hidden)
+            if hidden:
+                item.setSelected(False)
+
         self._update_button_state()
 
     @staticmethod
@@ -223,6 +278,8 @@ class LoadJobDialog(QDialog):
     def _selected_listings(self) -> list[JobListing]:
         listings: list[JobListing] = []
         for item in self.job_tree.selectedItems():
+            if item.isHidden():
+                continue
             listing = item.data(0, _LISTING_ROLE)
             if isinstance(listing, JobListing):
                 listings.append(listing)

--- a/src/frontend/custom_widgets/load_job_dialog.py
+++ b/src/frontend/custom_widgets/load_job_dialog.py
@@ -1,6 +1,7 @@
 """Picker for saved jobs."""
 
-from contextlib import suppress
+from collections.abc import Generator
+from contextlib import contextmanager, suppress
 from datetime import datetime
 from enum import Enum
 from html import escape
@@ -129,11 +130,13 @@ class LoadJobDialog(QDialog):
         which is also where `_suppress_source_tracking` is checked.
         """
         self._suppress_source_tracking: bool = False
-        """Set around a programmatic selection change so it cannot be
-        mistaken for user interaction. `_apply_filter` deselects rows it
-        hides, and reloading the tree re-clears and re-selects it -- neither
-        is the user switching panes, so the source-setting slots must not
-        act on the signals those changes fire.
+        """Set by `_programmatic_selection`, below, around a selection
+        change that is queue/tree bookkeeping rather than user interaction --
+        `_apply_filter` deselecting a hidden row, a reload re-clearing and
+        re-selecting the tree, the queue reordering or dropping a row.
+        Checked directly here rather than through the context manager, since
+        these two slots are the signal handlers it is guarding against, not
+        callers of it.
         """
 
         self.info_lbl = QLabel(
@@ -336,11 +339,8 @@ class LoadJobDialog(QDialog):
         # before the reload has even produced anything to show. Confirmed
         # empirically: without this, the source flips here, synchronously,
         # before `_on_listings_loaded` ever runs.
-        self._suppress_source_tracking = True
-        try:
+        with self._programmatic_selection():
             self.job_tree.clear()
-        finally:
-            self._suppress_source_tracking = False
         self.job_tree.setVisible(False)
         self.empty_lbl.setText("<span>Loading saved jobs...</span>")
         self.empty_lbl.setVisible(True)
@@ -360,11 +360,8 @@ class LoadJobDialog(QDialog):
         # `_load_listings` already emptied the tree before starting the
         # loader that ends up here -- but it costs nothing to keep guarded
         # rather than depend on that staying true.
-        self._suppress_source_tracking = True
-        try:
+        with self._programmatic_selection():
             self.job_tree.clear()
-        finally:
-            self._suppress_source_tracking = False
         muted = QBrush(
             self.palette().color(
                 QPalette.ColorGroup.Disabled, QPalette.ColorRole.WindowText
@@ -436,11 +433,8 @@ class LoadJobDialog(QDialog):
             # Selecting the tree's own first row on every reload must not
             # steal a queue-sourced pane back either -- same reasoning as
             # the clear() above.
-            self._suppress_source_tracking = True
-            try:
+            with self._programmatic_selection():
                 self.job_tree.setCurrentItem(first_item)
-            finally:
-                self._suppress_source_tracking = False
 
         # Queue items keep the JobListing they were queued with, which is now
         # stale if the job was renamed since -- rebind each one to the fresh
@@ -516,16 +510,13 @@ class LoadJobDialog(QDialog):
 
         The deselect is a programmatic change, not the user picking a
         different row -- typing in the filter box must not steal the details
-        pane away from a queue-sourced description, so it runs with source
-        tracking suppressed. `try`/`finally` so a raise mid-loop cannot leave
-        the flag stuck, which would disable source tracking for the rest of
-        the dialog's life -- worse than the bug being fixed here.
+        pane away from a queue-sourced description, so it runs inside
+        `_programmatic_selection`.
         """
         needle = self.filter_edit.text().strip().casefold()
         only_mine = self.only_this_config.isChecked()
 
-        self._suppress_source_tracking = True
-        try:
+        with self._programmatic_selection():
             for index in range(self.job_tree.topLevelItemCount()):
                 item = self.job_tree.topLevelItem(index)
                 if item is None:
@@ -547,8 +538,6 @@ class LoadJobDialog(QDialog):
                 item.setHidden(hidden)
                 if hidden:
                     item.setSelected(False)
-        finally:
-            self._suppress_source_tracking = False
 
         self._update_button_state()
 
@@ -707,13 +696,10 @@ class LoadJobDialog(QDialog):
             return
         # takeItem() and setCurrentRow() both fire currentRowChanged -- this
         # is the queue reordering itself, not the user picking the queue
-        # pane, so it must not set the source. See `_suppress_source_tracking`.
-        self._suppress_source_tracking = True
-        try:
+        # pane, so it must not set the source. See `_programmatic_selection`.
+        with self._programmatic_selection():
             self.queue_list.insertItem(target, self.queue_list.takeItem(row))
             self.queue_list.setCurrentRow(target)
-        finally:
-            self._suppress_source_tracking = False
         self._renumber_queue()
         self._update_button_state()
 
@@ -724,12 +710,9 @@ class LoadJobDialog(QDialog):
             return
         # takeItem() on the current row fires currentRowChanged -- removing a
         # row is not the user picking the queue pane. See
-        # `_suppress_source_tracking`.
-        self._suppress_source_tracking = True
-        try:
+        # `_programmatic_selection`.
+        with self._programmatic_selection():
             self.queue_list.takeItem(row)
-        finally:
-            self._suppress_source_tracking = False
         self._renumber_queue()
         self._update_button_state()
 
@@ -737,14 +720,11 @@ class LoadJobDialog(QDialog):
         """Take deleted jobs out of the queue, so it cannot point at nothing."""
         # Same reasoning as `_remove_queued`: a delete elsewhere is not the
         # user picking the queue pane.
-        self._suppress_source_tracking = True
-        try:
+        with self._programmatic_selection():
             for row in reversed(range(self.queue_list.count())):
                 listing = self.queue_list.item(row).data(_LISTING_ROLE)
                 if isinstance(listing, JobListing) and listing.path in paths:
                     self.queue_list.takeItem(row)
-        finally:
-            self._suppress_source_tracking = False
         self._renumber_queue()
 
     def _selection_hint(self) -> str:
@@ -796,11 +776,32 @@ class LoadJobDialog(QDialog):
             )
         return f"{len(selected)} prepared job(s) selected; ready to add to the queue."
 
+    @contextmanager
+    def _programmatic_selection(self) -> Generator[None, None, None]:
+        """Mark a block that changes tree or queue selection without the
+        user having picked anything, so the source-setting slots below
+        ignore whatever `itemSelectionChanged`/`currentRowChanged` it fires.
+
+        Not reentrant -- nothing in this file nests one of these blocks
+        inside another, and if that ever changes, the inner block's own
+        `finally` would clear the flag while the outer block is still in
+        progress. Centralising the flag toggle here exists specifically so a
+        future call site is a single self-documenting line instead of a
+        try/finally to notice and copy correctly: the sites needing this
+        have been missed by enumeration three times over this feature's
+        review history.
+        """
+        self._suppress_source_tracking = True
+        try:
+            yield
+        finally:
+            self._suppress_source_tracking = False
+
     @Slot()
     def _on_tree_selection_changed(self) -> None:
         # Programmatic selection changes -- a filter hiding a row, a reload
         # re-populating the tree -- must not be mistaken for the user
-        # switching panes. See `_suppress_source_tracking`.
+        # switching panes. See `_programmatic_selection`.
         if self._suppress_source_tracking:
             return
         self._details_source = "tree"

--- a/src/frontend/custom_widgets/load_job_dialog.py
+++ b/src/frontend/custom_widgets/load_job_dialog.py
@@ -417,6 +417,11 @@ class LoadJobDialog(QDialog):
         that is exactly the case that exceeds two seconds. Returning early
         leaves a running thread to be destroyed, which aborts the process. A
         brief freeze while closing is much the lesser cost.
+
+        The wait is itself guarded against `RuntimeError`: if the underlying
+        C++ object is already destroyed, that is exactly the post-condition
+        this method wants -- no live thread left to wait for -- so suppressing
+        it there is correct rather than masking a real failure.
         """
         loader = self._loader
         self._loader = None
@@ -424,7 +429,8 @@ class LoadJobDialog(QDialog):
             return
         with suppress(RuntimeError, TypeError):
             loader.loaded.disconnect(self._on_listings_loaded)
-        loader.wait()
+        with suppress(RuntimeError):
+            loader.wait()
 
     def done(self, result: int) -> None:
         self._stop_loader()

--- a/src/frontend/custom_widgets/load_job_dialog.py
+++ b/src/frontend/custom_widgets/load_job_dialog.py
@@ -104,7 +104,7 @@ class LoadJobDialog(QDialog):
         self.job_tree.setSortingEnabled(True)
         # multi-select so several prepared jobs can be queued in one go
         self.job_tree.setSelectionMode(QTreeWidget.SelectionMode.ExtendedSelection)
-        self.job_tree.itemDoubleClicked.connect(self._accept_selection)
+        self.job_tree.itemDoubleClicked.connect(self._on_double_click)
         self.job_tree.itemSelectionChanged.connect(self._update_button_state)
 
         self.empty_lbl = QLabel(
@@ -114,6 +114,9 @@ class LoadJobDialog(QDialog):
             parent=self,
         )
         self.empty_lbl.hide()
+
+        self.status_lbl = QLabel("", wordWrap=True, parent=self)
+        self.status_lbl.setTextFormat(Qt.TextFormat.PlainText)
 
         self.delete_btn = QPushButton("Delete", self)
         self.delete_btn.clicked.connect(self._delete_selected)
@@ -155,6 +158,7 @@ class LoadJobDialog(QDialog):
         main_layout.addLayout(filter_row)
         main_layout.addWidget(self.empty_lbl)
         main_layout.addWidget(self.job_tree, stretch=1)
+        main_layout.addWidget(self.status_lbl)
         main_layout.addLayout(bottom_row)
 
         self._load_listings()
@@ -297,6 +301,44 @@ class LoadJobDialog(QDialog):
             if listing.prepared and listing.matches_profile(self.active_profile)
         ]
 
+    def _selection_hint(self) -> str:
+        """One line saying what the current selection can and cannot do."""
+        selected = self._selected_listings()
+        if not selected:
+            return "Select a job to load, or several prepared ones to queue."
+
+        listing = self._current_listing()
+        if len(selected) == 1 and listing is not None:
+            if not listing.matches_profile(self.active_profile):
+                return (
+                    f"'{listing.name}' was saved under config "
+                    f"'{listing.config_profile}'. Use 'Switch profile and load' "
+                    "to open it."
+                )
+            if not listing.prepared:
+                return (
+                    f"'{listing.name}' still needs input, so it can be loaded "
+                    "but not queued."
+                )
+            return f"'{listing.name}' is ready to load or queue."
+
+        unprepared = sum(1 for entry in selected if not entry.prepared)
+        other_config = sum(
+            1 for entry in selected if not entry.matches_profile(self.active_profile)
+        )
+        reasons: list[str] = []
+        if unprepared:
+            reasons.append(f"{unprepared} not prepared")
+        if other_config:
+            reasons.append(f"{other_config} on another config")
+        if reasons:
+            return (
+                f"{len(selected)} selected; cannot queue because "
+                + " and ".join(reasons)
+                + ". A queue has nobody to answer a prompt."
+            )
+        return f"{len(selected)} prepared job(s) selected; ready to queue."
+
     @Slot()
     def _update_button_state(self) -> None:
         listing = self._current_listing()
@@ -314,6 +356,23 @@ class LoadJobDialog(QDialog):
         open_button = self.button_box.button(QDialogButtonBox.StandardButton.Open)
         if open_button:
             open_button.setEnabled(matches and len(selected) == 1)
+        self.status_lbl.setText(self._selection_hint())
+
+    @Slot(QTreeWidgetItem, int)
+    def _on_double_click(self, item: QTreeWidgetItem, _column: int) -> None:
+        """Open on double click, routing a cross-profile job to the switch.
+
+        Doing nothing is what this used to do, and it reads as the dialog being
+        broken rather than as the job needing a different config.
+        """
+        listing = item.data(0, _LISTING_ROLE)
+        if not isinstance(listing, JobListing):
+            return
+        self.job_tree.setCurrentItem(item)
+        if listing.matches_profile(self.active_profile):
+            self._accept_selection()
+        else:
+            self._accept_with_switch()
 
     @Slot()
     def _accept_selection(self) -> None:

--- a/src/frontend/custom_widgets/load_job_dialog.py
+++ b/src/frontend/custom_widgets/load_job_dialog.py
@@ -592,10 +592,15 @@ class LoadJobDialog(QDialog):
         """
         if self._details_source == "queue":
             item = self.queue_list.currentItem()
-            if item is None:
-                return None
-            listing = item.data(_LISTING_ROLE)
-            return listing if isinstance(listing, JobListing) else None
+            if item is not None:
+                listing = item.data(_LISTING_ROLE)
+                if isinstance(listing, JobListing):
+                    return listing
+            # The queue emptied, or lost the row being described, out from
+            # under a queue-sourced pane -- a different widget's action, not
+            # the user switching away. Falling through to the tree below
+            # always leaves something sensible on screen, rather than a pane
+            # that goes blank for no reason the user did anything about.
 
         # an empty tree has no current item, so emptiness needs no separate
         # check here -- and must not be inferred from widget visibility, which

--- a/src/frontend/custom_widgets/load_job_dialog.py
+++ b/src/frontend/custom_widgets/load_job_dialog.py
@@ -42,8 +42,9 @@ class LoadJobDialog(QDialog):
     ) -> None:
         super().__init__(parent)
         self.setObjectName("loadJobDialog")
-        self.setWindowTitle("Load Job")
+        self.setWindowTitle("Saved Jobs")
         self.resize(860, 400)
+        self.setSizeGripEnabled(True)
 
         self.active_profile = active_profile or ""
         self.selected_listing: JobListing | None = None
@@ -51,8 +52,7 @@ class LoadJobDialog(QDialog):
         self.queued_listings: list[JobListing] = []
         """Jobs to run back to back, when the user chose Run Queue."""
 
-        info_lbl = QLabel(
-            f'<h3 style="margin: 0; margin-bottom: 6px;">{self.windowTitle()}</h3>'
+        self.info_lbl = QLabel(
             "<i><span>Pick a saved job to jump straight to processing. Duplicate "
             "checks still run when you process it.<br />Jobs saved under another "
             "config are shown greyed out; use <b>Switch profile and load</b> to "
@@ -69,7 +69,20 @@ class LoadJobDialog(QDialog):
         self.job_tree.setHeaderLabels(
             ("Name", "Title", "Type", "Trackers", "Config", "State", "Saved")
         )
-        self.job_tree.header().setSectionResizeMode(QHeaderView.ResizeMode.Stretch)
+        # Column widths carry meaning here: Name and Title are what a job is
+        # recognised by, Trackers is an open-ended list the user may want wider,
+        # and the rest are short enough to size themselves.
+        header = self.job_tree.header()
+        header.setSectionResizeMode(0, QHeaderView.ResizeMode.Stretch)
+        header.setSectionResizeMode(1, QHeaderView.ResizeMode.Stretch)
+        header.setSectionResizeMode(2, QHeaderView.ResizeMode.ResizeToContents)
+        header.setSectionResizeMode(3, QHeaderView.ResizeMode.Interactive)
+        header.setSectionResizeMode(4, QHeaderView.ResizeMode.ResizeToContents)
+        header.setSectionResizeMode(5, QHeaderView.ResizeMode.ResizeToContents)
+        header.setSectionResizeMode(6, QHeaderView.ResizeMode.ResizeToContents)
+        header.resizeSection(3, 180)
+        self.job_tree.setTextElideMode(Qt.TextElideMode.ElideRight)
+        self.job_tree.setSortingEnabled(True)
         # multi-select so several prepared jobs can be queued in one go
         self.job_tree.setSelectionMode(QTreeWidget.SelectionMode.ExtendedSelection)
         self.job_tree.itemDoubleClicked.connect(self._accept_selection)
@@ -119,7 +132,7 @@ class LoadJobDialog(QDialog):
         bottom_row.addWidget(self.button_box)
 
         main_layout = QVBoxLayout(self)
-        main_layout.addWidget(info_lbl)
+        main_layout.addWidget(self.info_lbl)
         main_layout.addWidget(self.empty_lbl)
         main_layout.addWidget(self.job_tree, stretch=1)
         main_layout.addLayout(bottom_row)
@@ -127,6 +140,9 @@ class LoadJobDialog(QDialog):
         self._load_listings()
 
     def _load_listings(self) -> None:
+        # sorting reshuffles the tree on every insert otherwise, which is
+        # wasted work and would show rows swapping places as they load
+        self.job_tree.setSortingEnabled(False)
         self.job_tree.clear()
         listings = list_jobs(unique_working_dirs())
         muted = QBrush(
@@ -148,6 +164,10 @@ class LoadJobDialog(QDialog):
                 )
             )
             item.setData(0, _LISTING_ROLE, listing)
+            # the Trackers column is Interactive and elides, so the full list
+            # has to be reachable somewhere
+            if listing.summary.trackers:
+                item.setToolTip(3, "\n".join(listing.summary.trackers))
             if not listing.matches_profile(self.active_profile):
                 # muted rather than disabled: a disabled item cannot be
                 # selected at all, and selecting it is exactly how the user
@@ -160,6 +180,9 @@ class LoadJobDialog(QDialog):
                     "Use 'Switch profile and load' to open it.",
                 )
             self.job_tree.addTopLevelItem(item)
+
+        self.job_tree.setSortingEnabled(True)
+        self.job_tree.sortByColumn(6, Qt.SortOrder.DescendingOrder)
 
         has_jobs = bool(listings)
         self.job_tree.setVisible(has_jobs)

--- a/src/frontend/custom_widgets/load_job_dialog.py
+++ b/src/frontend/custom_widgets/load_job_dialog.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from enum import Enum
 from html import escape
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from PySide6.QtCore import Qt, QThread, Signal, Slot
 from PySide6.QtGui import QBrush, QPalette
@@ -120,11 +120,11 @@ class LoadJobDialog(QDialog):
         leaves the tree's current listing unchanged can skip the whole
         refresh rather than re-describing the same job from scratch.
         """
-        self._details_source: str = "tree"
-        """Which pane the details view and Open Folder currently describe:
-        `"tree"` or `"queue"`. Tracked explicitly rather than via focus --
-        `hasFocus()` is unreliable before the dialog is shown, and the tests
-        for this file construct the dialog without showing it. Set by
+        self._details_source: Literal["tree", "queue"] = "tree"
+        """Which pane the details view and Open Folder currently describe.
+        Tracked explicitly rather than via focus -- `hasFocus()` is
+        unreliable before the dialog is shown, and the tests for this file
+        construct the dialog without showing it. Set by
         `_on_tree_selection_changed` and `_on_queue_row_changed`, below.
         """
 
@@ -530,16 +530,6 @@ class LoadJobDialog(QDialog):
         except ValueError:
             return created_at
 
-    def _current_listing(self) -> JobListing | None:
-        # an empty tree has no current item, so emptiness needs no separate
-        # check here -- and must not be inferred from widget visibility, which
-        # is still false before the dialog is shown
-        item = self.job_tree.currentItem()
-        if item is None:
-            return None
-        listing = item.data(0, _LISTING_ROLE)
-        return listing if isinstance(listing, JobListing) else None
-
     def _details_listing(self) -> JobListing | None:
         """The listing the details pane and Open Folder currently describe.
 
@@ -554,8 +544,17 @@ class LoadJobDialog(QDialog):
             listing = item.data(_LISTING_ROLE)
             return listing if isinstance(listing, JobListing) else None
 
-        listing = self._current_listing()
-        if listing is None or listing not in self._selected_listings():
+        # an empty tree has no current item, so emptiness needs no separate
+        # check here -- and must not be inferred from widget visibility, which
+        # is still false before the dialog is shown
+        item = self.job_tree.currentItem()
+        if item is None:
+            return None
+        listing = item.data(0, _LISTING_ROLE)
+        if (
+            not isinstance(listing, JobListing)
+            or listing not in self._selected_listings()
+        ):
             return None
         return listing
 

--- a/src/frontend/custom_widgets/load_job_dialog.py
+++ b/src/frontend/custom_widgets/load_job_dialog.py
@@ -131,7 +131,9 @@ class LoadJobDialog(QDialog):
         )
 
         self.filter_edit = QLineEdit(self)
-        self.filter_edit.setPlaceholderText("Filter by name, title or tracker...")
+        self.filter_edit.setPlaceholderText(
+            "Filter by name, title, file or tracker..."
+        )
         self.filter_edit.setClearButtonEnabled(True)
         self.filter_edit.textChanged.connect(self._apply_filter)
 

--- a/src/frontend/custom_widgets/load_job_dialog.py
+++ b/src/frontend/custom_widgets/load_job_dialog.py
@@ -175,6 +175,11 @@ class LoadJobDialog(QDialog):
                 QPalette.ColorGroup.Disabled, QPalette.ColorRole.WindowText
             )
         )
+        # Built here from the live palette rather than registered with
+        # QTAThemeSwap: that helper only takes QToolButton / QPushButton /
+        # qta.IconWidget, and a QTreeWidgetItem is none of those. The cost is
+        # that a colour-scheme change mid-dialog leaves these until the next
+        # populate -- which every load and delete triggers anyway.
         icon_color = self.palette().color(QPalette.ColorRole.WindowText).name()
         prepared_icon = qta.icon("mdi6.package-variant-closed", color=icon_color)
         needs_input_icon = qta.icon("mdi6.pencil-outline", color=icon_color)

--- a/src/frontend/global_signals.py
+++ b/src/frontend/global_signals.py
@@ -46,7 +46,6 @@ class GlobalSignals(QObject):
     wizard_process_btn_clicked = Signal()
     wizard_process_btn_change_txt = Signal(str)
     wizard_process_btn_set_hidden = Signal()
-    wizard_run_job_queue = Signal(object)  # list[Path] of job directories
 
     # process
     prompt_tokens_response = Signal(object)  # dict[str, str]

--- a/src/frontend/stacked_windows/settings/general.py
+++ b/src/frontend/stacked_windows/settings/general.py
@@ -22,10 +22,9 @@ from PySide6.QtWidgets import (
 
 from src.backend.utils.file_utilities import (
     file_bytes_to_str,
-    get_dir_size,
     open_explorer,
 )
-from src.backend.utils.working_dir import cleanable_items
+from src.backend.utils.working_dir import cleanable_items, cleanable_size
 from src.config.config import ConfigManager
 from src.enums.logging_settings import LogLevel
 from src.enums.settings_window import SettingsTabs
@@ -480,10 +479,7 @@ class GeneralSettings(BaseSettings):
     def _handle_working_dir_clean_up_click(self) -> None:
         working_dir = self.config.settings.general.working_dir
         removable = cleanable_items(working_dir)
-        total_size = sum(
-            get_dir_size(item) if item.is_dir() else item.stat().st_size
-            for item in removable
-        )
+        total_size = cleanable_size(working_dir)
 
         msg = (
             "Would you like to clean up the working directory now?\n\n"

--- a/src/frontend/windows/main_window.py
+++ b/src/frontend/windows/main_window.py
@@ -16,8 +16,8 @@ from PySide6.QtWidgets import (
 )
 
 from src.backend.main_window import kill_child_processes
-from src.backend.utils.file_utilities import file_bytes_to_str, get_dir_size
-from src.backend.utils.working_dir import cleanable_items
+from src.backend.utils.file_utilities import file_bytes_to_str
+from src.backend.utils.working_dir import cleanable_size
 from src.config.config import ConfigManager
 from src.enums.screen_shot_mode import ScreenShotMode
 from src.enums.settings_window import SettingsTabs
@@ -221,10 +221,7 @@ class MainWindow(QMainWindow):
     def display_temp_directory_size(self) -> None:
         # only what clean up could actually reclaim; saved jobs are kept and
         # would otherwise inflate a number the user reads as "reclaimable"
-        size = sum(
-            get_dir_size(item) if item.is_dir() else item.stat().st_size
-            for item in cleanable_items(self.config.settings.general.working_dir)
-        )
+        size = cleanable_size(self.config.settings.general.working_dir)
         if size <= 0:
             return
         GSigs().main_window_update_status_tip.emit(

--- a/src/frontend/wizards/process.py
+++ b/src/frontend/wizards/process.py
@@ -478,12 +478,20 @@ class ProcessPage(BaseWizardPage):
             return
 
         self._announce_saved_job(job.name)
-        QMessageBox.information(
-            self,
-            "Job Saved",
+        saved_box = QMessageBox(self)
+        saved_box.setWindowTitle("Job Saved")
+        # PlainText rather than the default AutoText: the job name is free text
+        # from a prompt, and one containing angle brackets would otherwise flip
+        # the box into rich-text mode, swallowing the name and collapsing the
+        # line breaks below it. Escaping is not the fix here -- it would show
+        # the entities literally instead of the name the user typed.
+        saved_box.setTextFormat(Qt.TextFormat.PlainText)
+        saved_box.setIcon(QMessageBox.Icon.Information)
+        saved_box.setText(
             f"Saved '{job.name}'.\n\nUse 'Load Job' on the start page to come "
-            f"back to it.\n\n{job_path}",
+            f"back to it.\n\n{job_path}"
         )
+        saved_box.exec()
 
     def _build_job_document(
         self, directory: Path, keep_trackers: set[TrackerSelection] | None

--- a/src/frontend/wizards/process.py
+++ b/src/frontend/wizards/process.py
@@ -29,7 +29,6 @@ from src.backend.jobs import (
     JobCodecError,
     JobStoreError,
     JobSummary,
-    MediaFingerprint,
     build_job,
     capture_mediainfo,
     capture_nfos,
@@ -37,8 +36,10 @@ from src.backend.jobs import (
     copy_base_torrent,
     copy_images,
     filter_context_document,
+    fingerprint_files,
     job_dir,
     save_job,
+    torrent_content_files,
 )
 from src.backend.process import ProcessBackEnd
 from src.backend.tracker_run_data import build_tracker_data, image_host_label
@@ -521,11 +522,12 @@ class ProcessPage(BaseWizardPage):
                 str(image) for image in copied_images
             ]
         if base_torrent:
+            input_path = media_input.require_input_path()
             document["base_torrent"] = {
-                "media": str(media_input.require_first_file()),
-                "fingerprint": MediaFingerprint.of(
-                    media_input.require_first_file()
-                ).to_dict(),
+                "media": str(input_path),
+                # every file, not just the first: the torrent is built from
+                # `input_path`, so one file of a pack cannot vouch for the rest
+                "fingerprints": fingerprint_files(torrent_content_files(input_path)),
             }
         if keep_trackers is not None:
             document = filter_context_document(document, keep_trackers)

--- a/src/frontend/wizards/process.py
+++ b/src/frontend/wizards/process.py
@@ -996,16 +996,22 @@ class ProcessPage(BaseWizardPage):
     @Slot(str)
     def _on_text_update_replace_last_line(self, txt: str) -> None:
         """Updates last line of text from the start of line"""
+        # Same reason `_on_text_update` scrubs before inserting: this channel
+        # is reachable from plugins (`UploadReporter.replace_last_line`), and
+        # it is what the user actually sees in the log pane -- LOG.info's own
+        # sink already scrubs centrally (`nfo_forge_logger.py`), but the
+        # inserted HTML does not go through that.
+        safe_txt = scrub_secrets(txt)
         cursor = self.text_widget.textCursor()
         cursor.movePosition(QTextCursor.MoveOperation.End)
         cursor.movePosition(
             QTextCursor.MoveOperation.StartOfLine, QTextCursor.MoveMode.KeepAnchor
         )
         cursor.removeSelectedText()
-        cursor.insertHtml(txt)
+        cursor.insertHtml(safe_txt)
         self.text_widget.setTextCursor(cursor)
         self.text_widget.ensureCursorVisible()
-        LOG.info(LOG.LOG_SOURCE.FE, f"Process log replace last line: {txt}")
+        LOG.info(LOG.LOG_SOURCE.FE, f"Process log replace last line: {safe_txt}")
 
     @Slot(str)
     def _log_caught_error(self, txt: str) -> None:

--- a/src/frontend/wizards/process.py
+++ b/src/frontend/wizards/process.py
@@ -499,7 +499,10 @@ class ProcessPage(BaseWizardPage):
         """Capture the job's assets, then serialize it pointing at those copies.
 
         Everything a resumed run needs is copied beside the job so it stops
-        depending on `processing/`, which Clean Up is meant to empty.
+        depending on `processing/`, which Clean Up is meant to empty. When
+        `keep_trackers` is given, only the NFOs for those trackers are
+        captured -- a narrowed job must not keep sidecars for trackers it no
+        longer covers.
         """
         media_input = self.context.media_input
 

--- a/src/frontend/wizards/process.py
+++ b/src/frontend/wizards/process.py
@@ -24,7 +24,6 @@ from PySide6.QtWidgets import (
     QVBoxLayout,
 )
 
-from src.backend.job_queue import JobQueueRunner, QueuedJobOutcome, QueuedJobResult
 from src.backend.jobs import (
     JobAssetError,
     JobCodecError,
@@ -123,53 +122,6 @@ class DupeWorker(BaseWorker):
             self.job_failed.emit(str(e), traceback.format_exc())
         finally:
             async_loop.close()
-
-
-class QueueWorker(BaseWorker):
-    """Drives `JobQueueRunner` off the GUI thread.
-
-    Nothing here waits on a dialog: a queue only accepts prepared jobs, and the
-    runner passes no prompt or retry callbacks, so it runs to completion on its
-    own.
-    """
-
-    results = Signal(object)  # list[QueuedJobOutcome]
-    queued_status_update = Signal(str, str)
-    progress_signal = Signal(float)
-
-    def __init__(
-        self,
-        backend: ProcessBackEnd,
-        config: ConfigManager,
-        job_paths: list[Path],
-        parent: QObject | None = None,
-    ) -> None:
-        super().__init__(parent)
-        self.backend = backend
-        self.config = config
-        self.job_paths = job_paths
-        self._cancelled = False
-
-    def cancel(self) -> None:
-        """Stop before the next job; the one in flight is left to finish."""
-        self._cancelled = True
-
-    def run(self) -> None:
-        try:
-            runner = JobQueueRunner(
-                backend=self.backend,
-                config=self.config,
-                text_update=self._queued_text_update_cb,
-                status_update=lambda tracker, status: self.queued_status_update.emit(
-                    tracker, status
-                ),
-                progress_cb=self.progress_signal.emit,
-                is_cancelled=lambda: self._cancelled,
-            )
-            self.results.emit(runner.run(self.job_paths))
-            self.job_finished.emit()
-        except Exception as e:
-            self.job_failed.emit(f"Job queue failed: {e}", traceback.format_exc())
 
 
 class _TokenPromptWaiter(QObject):
@@ -395,8 +347,6 @@ class ProcessPage(BaseWizardPage):
         self.processing_mode = UploadProcessMode.DUPE_CHECK
         self.dupe_worker: DupeWorker | None = None
         self.process_worker: ProcessWorker | None = None
-        self.queue_worker: QueueWorker | None = None
-        GSigs().wizard_run_job_queue.connect(self._run_job_queue)
 
         # Per-run only, and deliberately not on the payload: this must never
         # reach a job file. It answers which trackers may still be uploaded
@@ -707,57 +657,6 @@ class ProcessPage(BaseWizardPage):
         self.process_worker.upload_retry_signal.connect(self._on_upload_retry_signal)
         self.process_worker.run_outcome_signal.connect(self._on_run_outcome)
         self.process_worker.start()
-
-    @Slot(object)
-    def _run_job_queue(self, job_paths: list[Path]) -> None:
-        """Upload a set of prepared jobs one after another."""
-        if self.queue_worker or self.process_worker:
-            return
-
-        self.tracker_process_tree.clear()
-        self._on_text_update(
-            f'<h3 style="margin: 0; padding: 0;">📚 Running {len(job_paths)} '
-            "queued job(s)</h3>"
-        )
-        GSigs().wizard_set_disabled.emit(True)
-        GSigs().wizard_process_btn_set_hidden.emit()
-        self.save_job_btn.hide()
-        self.prepare_job_btn.hide()
-
-        self.queue_worker = QueueWorker(
-            backend=self.backend,
-            config=self.config,
-            job_paths=job_paths,
-            parent=self,
-        )
-        self.queue_worker.queued_text_update.connect(self._on_text_update)
-        self.queue_worker.progress_signal.connect(self._on_progress_update)
-        self.queue_worker.results.connect(self._on_queue_results)
-        self.queue_worker.job_failed.connect(self._on_failed)
-        self.queue_worker.job_finished.connect(self._on_queue_finished)
-        self.queue_worker.start()
-
-    @Slot(object)
-    def _on_queue_results(self, results: list[QueuedJobOutcome]) -> None:
-        counts: dict[QueuedJobResult, int] = {}
-        lines: list[str] = []
-        for outcome in results:
-            counts[outcome.result] = counts.get(outcome.result, 0) + 1
-            label = outcome.result.name.replace("_", " ").lower()
-            detail = f" — {outcome.detail}" if outcome.detail else ""
-            lines.append(f"<li><b>{outcome.job_name}</b>: {label}{detail}</li>")
-
-        uploaded = counts.get(QueuedJobResult.UPLOADED, 0)
-        self._on_text_update(
-            f'<br /><h3 style="margin-bottom: 0;">📚 Queue finished: '
-            f"{uploaded} of {len(results)} uploaded</h3><ul>" + "".join(lines) + "</ul>"
-        )
-
-    @Slot()
-    def _on_queue_finished(self) -> None:
-        self.queue_worker = None
-        GSigs().wizard_set_disabled.emit(False)
-        self.text_widget.ensureCursorVisible()
 
     @Slot(object, object)
     def _on_run_outcome(

--- a/src/frontend/wizards/process.py
+++ b/src/frontend/wizards/process.py
@@ -2,6 +2,7 @@ import asyncio
 from collections.abc import Sequence
 from copy import deepcopy
 from dataclasses import fields
+from html import escape
 from pathlib import Path
 import shutil
 import traceback
@@ -408,6 +409,17 @@ class ProcessPage(BaseWizardPage):
         main_layout.addLayout(button_row)
         self.setLayout(main_layout)
 
+    def _announce_saved_job(self, name: str) -> None:
+        """Note a save in the log pane.
+
+        Escaped because the name is free text from a prompt, and the pane
+        renders HTML -- an unescaped `<` silently swallows the rest of the line.
+        """
+        self._on_text_update(
+            f"<br /><span>💾 Saved job '{escape(name)}'. Load it from the start "
+            "page to process it later.</span>"
+        )
+
     @Slot()
     def _save_job(self, keep_trackers: set[TrackerSelection] | None = None) -> None:
         """Persist this configured run so it can be processed later.
@@ -465,10 +477,7 @@ class ProcessPage(BaseWizardPage):
             QMessageBox.critical(self, "Save Failed", f"Could not save job:\n\n{error}")
             return
 
-        self._on_text_update(
-            f"<br /><span>💾 Saved job '{job.name}'. Load it from the start page "
-            "to process it later.</span>"
-        )
+        self._announce_saved_job(job.name)
         QMessageBox.information(
             self,
             "Job Saved",

--- a/src/frontend/wizards/process.py
+++ b/src/frontend/wizards/process.py
@@ -584,6 +584,7 @@ class ProcessPage(BaseWizardPage):
             year=self.context.media_search.year,
             media_type=str(media_type) if media_type else None,
             input_name=input_path.name if input_path else None,
+            input_path=str(input_path) if input_path else "",
             file_count=len(self.context.media_input.file_list),
             trackers=[
                 str(tracker)

--- a/src/frontend/wizards/process.py
+++ b/src/frontend/wizards/process.py
@@ -504,10 +504,16 @@ class ProcessPage(BaseWizardPage):
             copy_base_torrent(directory, base_torrent)
 
         # a prepared job's NFOs are the ones that get uploaded, so they cannot
-        # be left in `processing/` where Clean Up would take them
-        nfo_assets = capture_nfos(
-            directory, self.context.shared_data.tracker_release_data
-        )
+        # be left in `processing/` where Clean Up would take them -- and a
+        # narrowed job must not keep sidecars for trackers it no longer covers
+        release_data = self.context.shared_data.tracker_release_data
+        if keep_trackers is not None:
+            release_data = {
+                tracker: release
+                for tracker, release in release_data.items()
+                if tracker in keep_trackers
+            }
+        nfo_assets = capture_nfos(directory, release_data)
 
         document = context_to_dict(self.context, mediainfo_assets, nfo_assets)
         if copied_images:
@@ -821,8 +827,9 @@ class ProcessPage(BaseWizardPage):
                 "Save Remaining Trackers",
                 f"{len(deferrable)} tracker(s) were not uploaded:\n\n{described}\n\n"
                 "Save them as a job so they can be uploaded later?\n\n"
-                "Note: any title or NFO edits made during this run are not kept; "
-                "they are regenerated when the job is processed.",
+                "The titles and NFOs from this run are saved with the job, "
+                "including any edits you made in the overview, so it will "
+                "upload exactly what you saw here.",
             )
             is not QMessageBox.StandardButton.Yes
         ):

--- a/src/frontend/wizards/process.py
+++ b/src/frontend/wizards/process.py
@@ -488,7 +488,7 @@ class ProcessPage(BaseWizardPage):
         saved_box.setTextFormat(Qt.TextFormat.PlainText)
         saved_box.setIcon(QMessageBox.Icon.Information)
         saved_box.setText(
-            f"Saved '{job.name}'.\n\nUse 'Load Job' on the start page to come "
+            f"Saved '{job.name}'.\n\nUse 'Jobs' on the start page to come "
             f"back to it.\n\n{job_path}"
         )
         saved_box.exec()

--- a/src/frontend/wizards/wizard.py
+++ b/src/frontend/wizards/wizard.py
@@ -350,10 +350,11 @@ class MainWindowWizard(QWizard):
         """Offer the job's stored torrent for reuse, if the media is unchanged.
 
         Hashing is the most expensive part of a run, so a job that carries a
-        finished torrent can skip it -- but only while the media is byte-for-byte
-        what it was. Cloning a torrent whose piece hashes no longer match would
-        upload a torrent that simply does not work, so a changed (or missing)
-        file silently falls back to hashing.
+        finished torrent can skip it -- but only while the media's size and
+        modified time still match what `MediaFingerprint` recorded. Cloning a
+        torrent whose piece hashes no longer match would upload a torrent that
+        simply does not work, so a changed (or missing) file silently falls
+        back to hashing.
         """
         stored = base_torrent_path(directory)
         if stored is None:

--- a/src/frontend/wizards/wizard.py
+++ b/src/frontend/wizards/wizard.py
@@ -162,6 +162,12 @@ class MainWindowWizard(QWizard):
 
     @Slot()
     def reset_wizard(self) -> None:
+        # A job load caches each file's MediaInfo text dump globally so the
+        # media never has to be re-read. Starting over means a genuinely new
+        # run, which must measure the file itself rather than inherit a dump
+        # that may now describe a different encode.
+        clear_full_mi_str_cache()
+
         self.context = create_processing_context(
             self.config.settings,
             self.config.plugin_manager,

--- a/src/frontend/wizards/wizard.py
+++ b/src/frontend/wizards/wizard.py
@@ -95,10 +95,12 @@ class MainWindowWizard(QWizard):
         self.setOption(QWizard.WizardOption.HaveCustomButton3)
 
         # all three CustomButton slots are already spoken for, so the unused
-        # HelpButton slot carries "Load Job" -- the same re-purposing this
+        # HelpButton slot carries "Jobs" -- the same re-purposing this
         # wizard already does by putting "Next" on the CommitButton
-        self.load_job_button = QPushButton("Load Job", self)
-        self.load_job_button.setToolTip("Load a previously saved job and process it")
+        self.load_job_button = QPushButton("Jobs", self)
+        self.load_job_button.setToolTip(
+            "Browse saved jobs: load one to process it, or queue several"
+        )
         self.load_job_button.clicked.connect(self.open_load_job_dialog)
         self.setButton(QWizard.WizardButton.HelpButton, self.load_job_button)
         self.setOption(QWizard.WizardOption.HaveHelpButton)

--- a/src/frontend/wizards/wizard.py
+++ b/src/frontend/wizards/wizard.py
@@ -350,6 +350,11 @@ class MainWindowWizard(QWizard):
         details = job.context.get("base_torrent")
         input_path = context.media_input.input_path
         if not isinstance(details, dict) or input_path is None:
+            LOG.info(
+                LOG.LOG_SOURCE.FE,
+                f"Not reusing the torrent saved with job '{job.name}': its "
+                "saved fingerprint details or current input path are missing",
+            )
             return
 
         recorded = details.get("fingerprints")

--- a/src/frontend/wizards/wizard.py
+++ b/src/frontend/wizards/wizard.py
@@ -13,6 +13,7 @@ from src.backend.jobs import (
     SavedJob,
     base_torrent_path,
     context_from_dict,
+    fingerprints_match,
     load_job,
     read_job_asset,
     template_fingerprint,
@@ -347,13 +348,27 @@ class MainWindowWizard(QWizard):
             return
 
         details = job.context.get("base_torrent")
-        fingerprint = (
-            MediaFingerprint.from_dict(details.get("fingerprint"))
-            if isinstance(details, dict)
-            else None
-        )
-        media = context.media_input.get_first_file()
-        if fingerprint is None or media is None or not fingerprint.matches(media):
+        input_path = context.media_input.input_path
+        if not isinstance(details, dict) or input_path is None:
+            return
+
+        recorded = details.get("fingerprints")
+        if isinstance(recorded, dict) and recorded:
+            unchanged = fingerprints_match(recorded, input_path)
+        else:
+            # Jobs saved before the whole-release fingerprint recorded only the
+            # first file. Honour that for a single-file release, where it is the
+            # same thing; for a directory it proves nothing, so re-hash.
+            legacy = MediaFingerprint.from_dict(details.get("fingerprint"))
+            media = context.media_input.get_first_file()
+            unchanged = (
+                not input_path.is_dir()
+                and legacy is not None
+                and media is not None
+                and legacy.matches(media)
+            )
+
+        if not unchanged:
             LOG.info(
                 LOG.LOG_SOURCE.FE,
                 f"Not reusing the torrent saved with job '{job.name}': its media "

--- a/src/frontend/wizards/wizard.py
+++ b/src/frontend/wizards/wizard.py
@@ -187,11 +187,22 @@ class MainWindowWizard(QWizard):
             return
 
         if dialog.queued_listings:
-            JobQueueDialog(
+            # A bare temporary here would still leak: parenting to `self`
+            # transfers ownership to C++, so a dialog built and immediately
+            # `.exec()`'d without ever being assigned would survive the call
+            # as a hidden child of the wizard for the rest of its life --
+            # log widget, finished thread, `ProcessBackEnd` and all, one per
+            # queue run. `reject()` already guarantees the thread has
+            # finished by the time `exec()` returns, so `deleteLater()` here
+            # is never asked to tear down anything still running.
+            queue_dialog = JobQueueDialog(
                 job_paths=[listing.path for listing in dialog.queued_listings],
                 config=self.config,
                 parent=self,
-            ).exec()
+            )
+            queue_dialog.start()
+            queue_dialog.exec()
+            queue_dialog.deleteLater()
             return
 
         listing = dialog.selected_listing

--- a/src/frontend/wizards/wizard.py
+++ b/src/frontend/wizards/wizard.py
@@ -25,6 +25,7 @@ from src.context.processing_context import ProcessingContext
 from src.enums.media_type import MediaType
 from src.enums.wizard import WizardPages
 from src.exceptions import ConfigSchemaError
+from src.frontend.custom_widgets.job_queue_dialog import JobQueueDialog
 from src.frontend.custom_widgets.load_job_dialog import LoadJobDialog
 from src.frontend.global_signals import GSigs
 from src.frontend.wizards.images import ImagesPage
@@ -186,9 +187,11 @@ class MainWindowWizard(QWizard):
             return
 
         if dialog.queued_listings:
-            GSigs().wizard_run_job_queue.emit(
-                [listing.path for listing in dialog.queued_listings]
-            )
+            JobQueueDialog(
+                job_paths=[listing.path for listing in dialog.queued_listings],
+                config=self.config,
+                parent=self,
+            ).exec()
             return
 
         listing = dialog.selected_listing

--- a/src/frontend/wizards/wizard.py
+++ b/src/frontend/wizards/wizard.py
@@ -192,7 +192,17 @@ class MainWindowWizard(QWizard):
     def open_load_job_dialog(self) -> None:
         """Pick saved jobs and either resume one or run several as a queue."""
         dialog = LoadJobDialog(self.config.program.current_config, self)
-        if dialog.exec() != QDialog.DialogCode.Accepted:
+        accepted = dialog.exec() == QDialog.DialogCode.Accepted
+        # Same leak `queue_dialog` is guarded against below, and parenting
+        # gives this one longer to matter: it holds a listing tree, a details
+        # pane and one retired-but-parented `_ListingLoader` per
+        # `_load_listings()` call. `done()` already blocks `exec()` from
+        # returning until any in-flight loader has stopped, so there is
+        # nothing left running for `deleteLater()` to tear down. Scheduled
+        # once here, right after `exec()`, so it covers every return below
+        # regardless of which one is taken.
+        dialog.deleteLater()
+        if not accepted:
             return
 
         if dialog.queued_listings:

--- a/tests/test_backend/test_job_settlement.py
+++ b/tests/test_backend/test_job_settlement.py
@@ -10,13 +10,14 @@ from typing import Any
 
 import pytest
 
+from src.backend import job_queue as job_queue_module
 from src.backend.job_queue import (
     JobDisposition,
     JobQueueRunner,
     QueuedJobOutcome,
     QueuedJobResult,
 )
-from src.backend.jobs import store
+from src.backend.jobs import JobStoreError, store
 from src.backend.jobs.models import JobSummary
 from src.backend.upload_retry import TrackerRunOutcome
 from src.enums.tracker_selection import TrackerSelection
@@ -52,8 +53,18 @@ def _job(working_dir: Path) -> tuple[Any, Path]:
     return job, directory
 
 
-def _runner() -> JobQueueRunner:
-    return JobQueueRunner(backend=SimpleNamespace(), config=SimpleNamespace())
+def _runner(messages: list[str] | None = None) -> JobQueueRunner:
+    """A runner whose queue-log lines land in `messages`, when given one.
+
+    Nothing in the original ten tests cares what gets logged, only what
+    happens to the job's files -- which is exactly how a message emitted by
+    `_settle` could vanish without a single test failing.
+    """
+    return JobQueueRunner(
+        backend=SimpleNamespace(),
+        config=SimpleNamespace(),
+        text_update=messages.append if messages is not None else None,
+    )
 
 
 def test_a_job_whose_trackers_all_uploaded_is_deleted(working_dir: Path) -> None:
@@ -292,3 +303,158 @@ def test_a_job_that_never_reached_upload_is_untouched(working_dir: Path) -> None
 
     assert outcome.disposition is JobDisposition.KEPT
     assert directory.exists()
+
+
+# --------------------------------------------------------------------------
+# what actually reaches the queue log -- the regression this file exists to
+# catch is a message that silently stops being emitted
+# --------------------------------------------------------------------------
+def test_every_tracker_unconfirmed_is_named_in_the_log(working_dir: Path) -> None:
+    """The one outcome nobody can retry or write off must say so, or the
+    fully-unconfirmed run leaves no trace for a human to act on."""
+    job, directory = _job(working_dir)
+    outcome = QueuedJobOutcome(
+        job_name=job.name,
+        path=directory,
+        result=QueuedJobResult.FAILED,
+        outcomes={
+            TrackerSelection.AITHER: TrackerRunOutcome.MAY_HAVE_UPLOADED,
+            TrackerSelection.HUNO: TrackerRunOutcome.MAY_HAVE_UPLOADED,
+        },
+    )
+    messages: list[str] = []
+
+    _runner(messages)._settle(job, outcome)
+
+    assert outcome.disposition is JobDisposition.KEPT
+    assert directory.exists()
+    logged = " ".join(messages)
+    assert "Aither" in logged
+    assert "HUNO" in logged
+
+
+def test_every_tracker_disabled_emits_nothing(working_dir: Path) -> None:
+    """Uploads switched off in config is the user's own choice, not a warning."""
+    job, directory = _job(working_dir)
+    outcome = QueuedJobOutcome(
+        job_name=job.name,
+        path=directory,
+        result=QueuedJobResult.UPLOADED,
+        outcomes={
+            TrackerSelection.AITHER: TrackerRunOutcome.UPLOAD_DISABLED,
+            TrackerSelection.HUNO: TrackerRunOutcome.UPLOAD_DISABLED,
+        },
+    )
+    messages: list[str] = []
+
+    _runner(messages)._settle(job, outcome)
+
+    assert outcome.disposition is JobDisposition.KEPT
+    assert directory.exists()
+    assert messages == []
+
+
+def test_every_tracker_not_attempted_emits_nothing(working_dir: Path) -> None:
+    """A run that never got as far as a tracker has nothing to report yet."""
+    job, directory = _job(working_dir)
+    outcome = QueuedJobOutcome(
+        job_name=job.name,
+        path=directory,
+        result=QueuedJobResult.FAILED,
+        outcomes={
+            TrackerSelection.AITHER: TrackerRunOutcome.NOT_ATTEMPTED,
+            TrackerSelection.HUNO: TrackerRunOutcome.NOT_ATTEMPTED,
+        },
+    )
+    messages: list[str] = []
+
+    _runner(messages)._settle(job, outcome)
+
+    assert outcome.disposition is JobDisposition.KEPT
+    assert directory.exists()
+    assert messages == []
+
+
+def test_a_narrowed_job_logs_both_the_kept_line_and_the_unconfirmed_warning(
+    working_dir: Path,
+) -> None:
+    """Narrowing and the unconfirmed warning answer different questions, so a
+    job that hits both must say both, not just the one that fired first."""
+    job, directory = _job(working_dir)
+    outcome = QueuedJobOutcome(
+        job_name=job.name,
+        path=directory,
+        result=QueuedJobResult.UPLOADED,
+        outcomes={
+            TrackerSelection.AITHER: TrackerRunOutcome.MAY_HAVE_UPLOADED,
+            TrackerSelection.HUNO: TrackerRunOutcome.UPLOADED,
+        },
+    )
+    messages: list[str] = []
+
+    _runner(messages)._settle(job, outcome)
+
+    assert outcome.disposition is JobDisposition.NARROWED
+    assert any("Kept" in message for message in messages)
+    assert any("Check" in message and "Aither" in message for message in messages)
+
+
+def test_a_failed_delete_is_reported_not_just_logged(
+    working_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A delete that fails leaves a fully-uploaded job on disk -- exactly the
+    state that re-uploads everywhere next run, so it cannot be silent."""
+    job, directory = _job(working_dir)
+
+    def _boom(_directory: Path) -> None:
+        raise JobStoreError("disk is read-only")
+
+    monkeypatch.setattr(job_queue_module, "delete_job", _boom)
+    messages: list[str] = []
+    outcome = QueuedJobOutcome(
+        job_name=job.name,
+        path=directory,
+        result=QueuedJobResult.UPLOADED,
+        outcomes={
+            TrackerSelection.AITHER: TrackerRunOutcome.UPLOADED,
+            TrackerSelection.HUNO: TrackerRunOutcome.UPLOADED,
+        },
+    )
+
+    _runner(messages)._settle(job, outcome)
+
+    assert outcome.disposition is JobDisposition.KEPT
+    assert directory.exists()
+    assert any("could not be removed" in message for message in messages)
+
+
+def test_a_failed_narrow_is_reported_not_just_logged(
+    working_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A narrow that fails to write leaves the uploaded trackers still listed
+    -- exactly the state that re-uploads them next run -- so it too must
+    reach the queue log, not just the application log."""
+    job, directory = _job(working_dir)
+
+    def _boom(*_args: Any, **_kwargs: Any) -> Path:
+        raise JobStoreError("disk is read-only")
+
+    monkeypatch.setattr(job_queue_module, "write_job_document", _boom)
+    messages: list[str] = []
+    outcome = QueuedJobOutcome(
+        job_name=job.name,
+        path=directory,
+        result=QueuedJobResult.UPLOADED,
+        outcomes={
+            TrackerSelection.AITHER: TrackerRunOutcome.UPLOADED,
+            TrackerSelection.HUNO: TrackerRunOutcome.UPLOAD_FAILED,
+        },
+    )
+
+    _runner(messages)._settle(job, outcome)
+
+    assert outcome.disposition is JobDisposition.KEPT
+    assert any(
+        "already uploaded and will send to them again" in message
+        for message in messages
+    )

--- a/tests/test_backend/test_job_settlement.py
+++ b/tests/test_backend/test_job_settlement.py
@@ -75,14 +75,21 @@ def test_a_job_whose_trackers_all_uploaded_is_deleted(working_dir: Path) -> None
 
 
 def test_a_partly_uploaded_job_is_narrowed_to_what_is_left(working_dir: Path) -> None:
+    """HUNO uploads and is dropped; AITHER failed and is retained.
+
+    Retaining AITHER rather than HUNO matters: TrackerSelection.AITHER's name
+    ("AITHER") and value ("Aither") differ, while HUNO's are both "HUNO". A
+    test that retains HUNO passes whether the narrowing keys on .name, .value
+    or str() -- it would not catch the wrong one. Retaining AITHER pins it.
+    """
     job, directory = _job(working_dir)
     outcome = QueuedJobOutcome(
         job_name=job.name,
         path=directory,
         result=QueuedJobResult.UPLOADED,
         outcomes={
-            TrackerSelection.AITHER: TrackerRunOutcome.UPLOADED,
-            TrackerSelection.HUNO: TrackerRunOutcome.UPLOAD_FAILED,
+            TrackerSelection.AITHER: TrackerRunOutcome.UPLOAD_FAILED,
+            TrackerSelection.HUNO: TrackerRunOutcome.UPLOADED,
         },
     )
 
@@ -91,15 +98,12 @@ def test_a_partly_uploaded_job_is_narrowed_to_what_is_left(working_dir: Path) ->
     assert outcome.disposition is JobDisposition.NARROWED
     reloaded = store.load_job(directory)
     shared = reloaded.context["shared_data"]
-    assert set(shared["tracker_release_data"]) == {"HUNO"}
-    assert shared["selected_trackers"] == ["HUNO"]
-    # TrackerSelection.HUNO's value is the literal string "HUNO" (unlike
-    # AITHER's "Aither"), and str(tracker) -- the same conversion
-    # _job_summary() in the wizard already uses -- reflects that casing
-    assert reloaded.summary.trackers == ["HUNO"]
+    assert set(shared["tracker_release_data"]) == {"AITHER"}
+    assert shared["selected_trackers"] == ["AITHER"]
+    assert reloaded.summary.trackers == ["Aither"]
     # the uploaded tracker's NFO must not linger and imply the job still covers it
     assert {p.name for p in (directory / store.JOB_NFO_DIR_NAME).iterdir()} == {
-        "huno.txt"
+        "aither.txt"
     }
 
 
@@ -158,6 +162,121 @@ def test_upload_disabled_alone_never_deletes_the_job(working_dir: Path) -> None:
 
     assert outcome.disposition is JobDisposition.KEPT
     assert directory.exists()
+
+
+def test_an_uploaded_tracker_alongside_an_unknown_one_is_narrowed_not_deleted(
+    working_dir: Path,
+) -> None:
+    """`MAY_HAVE_UPLOADED` is neither retryable nor done, so mixed with a
+    provable upload the job must be narrowed to the unknown tracker, not
+    deleted -- deleting would destroy the only record of it."""
+    job, directory = _job(working_dir)
+    outcome = QueuedJobOutcome(
+        job_name=job.name,
+        path=directory,
+        result=QueuedJobResult.UPLOADED,
+        outcomes={
+            TrackerSelection.AITHER: TrackerRunOutcome.MAY_HAVE_UPLOADED,
+            TrackerSelection.HUNO: TrackerRunOutcome.UPLOADED,
+        },
+    )
+
+    _runner()._settle(job, outcome)
+
+    assert outcome.disposition is JobDisposition.NARROWED
+    reloaded = store.load_job(directory)
+    shared = reloaded.context["shared_data"]
+    assert set(shared["tracker_release_data"]) == {"AITHER"}
+    assert shared["selected_trackers"] == ["AITHER"]
+    assert reloaded.summary.trackers == ["Aither"]
+    assert {p.name for p in (directory / store.JOB_NFO_DIR_NAME).iterdir()} == {
+        "aither.txt"
+    }
+
+
+def test_an_uploaded_tracker_alongside_a_disabled_one_is_narrowed_not_deleted(
+    working_dir: Path,
+) -> None:
+    """A disabled tracker never uploaded, so mixed with a provable upload the
+    job must be narrowed to the disabled tracker, not deleted -- deleting
+    would throw away its prepared torrent and NFO before it ever ran."""
+    job, directory = _job(working_dir)
+    outcome = QueuedJobOutcome(
+        job_name=job.name,
+        path=directory,
+        result=QueuedJobResult.UPLOADED,
+        outcomes={
+            TrackerSelection.AITHER: TrackerRunOutcome.UPLOAD_DISABLED,
+            TrackerSelection.HUNO: TrackerRunOutcome.UPLOADED,
+        },
+    )
+
+    _runner()._settle(job, outcome)
+
+    assert outcome.disposition is JobDisposition.NARROWED
+    reloaded = store.load_job(directory)
+    shared = reloaded.context["shared_data"]
+    assert set(shared["tracker_release_data"]) == {"AITHER"}
+    assert shared["selected_trackers"] == ["AITHER"]
+    assert reloaded.summary.trackers == ["Aither"]
+    assert {p.name for p in (directory / store.JOB_NFO_DIR_NAME).iterdir()} == {
+        "aither.txt"
+    }
+
+
+def test_a_failed_tracker_alongside_an_unknown_one_is_left_untouched(
+    working_dir: Path,
+) -> None:
+    """Nothing provably landed, so the job is exactly itself -- narrowing here
+    would drop the unknown tracker's NFO while nothing was actually confirmed
+    uploaded anywhere."""
+    job, directory = _job(working_dir)
+    before = (directory / store.JOB_DOCUMENT_NAME).read_text(encoding="utf-8")
+    outcome = QueuedJobOutcome(
+        job_name=job.name,
+        path=directory,
+        result=QueuedJobResult.FAILED,
+        outcomes={
+            TrackerSelection.AITHER: TrackerRunOutcome.UPLOAD_FAILED,
+            TrackerSelection.HUNO: TrackerRunOutcome.MAY_HAVE_UPLOADED,
+        },
+    )
+
+    _runner()._settle(job, outcome)
+
+    assert outcome.disposition is JobDisposition.KEPT
+    assert (directory / store.JOB_DOCUMENT_NAME).read_text(encoding="utf-8") == before
+    assert {p.name for p in (directory / store.JOB_NFO_DIR_NAME).iterdir()} == {
+        "aither.txt",
+        "huno.txt",
+    }
+
+
+def test_a_failed_tracker_alongside_a_disabled_one_is_left_untouched(
+    working_dir: Path,
+) -> None:
+    """Nothing provably landed here either, so the job is left exactly as it
+    was rather than narrowed down to the disabled tracker."""
+    job, directory = _job(working_dir)
+    before = (directory / store.JOB_DOCUMENT_NAME).read_text(encoding="utf-8")
+    outcome = QueuedJobOutcome(
+        job_name=job.name,
+        path=directory,
+        result=QueuedJobResult.FAILED,
+        outcomes={
+            TrackerSelection.AITHER: TrackerRunOutcome.UPLOAD_FAILED,
+            TrackerSelection.HUNO: TrackerRunOutcome.UPLOAD_DISABLED,
+        },
+    )
+
+    _runner()._settle(job, outcome)
+
+    assert outcome.disposition is JobDisposition.KEPT
+    assert (directory / store.JOB_DOCUMENT_NAME).read_text(encoding="utf-8") == before
+    assert {p.name for p in (directory / store.JOB_NFO_DIR_NAME).iterdir()} == {
+        "aither.txt",
+        "huno.txt",
+    }
 
 
 def test_a_job_that_never_reached_upload_is_untouched(working_dir: Path) -> None:

--- a/tests/test_backend/test_job_settlement.py
+++ b/tests/test_backend/test_job_settlement.py
@@ -1,0 +1,175 @@
+"""What the queue does to a job's files once it has run it.
+
+A job that survives a successful upload unchanged is a job the next queue run
+uploads again, so these are the tests that keep the queue from duplicating.
+"""
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from src.backend.job_queue import (
+    JobDisposition,
+    JobQueueRunner,
+    QueuedJobOutcome,
+    QueuedJobResult,
+)
+from src.backend.jobs import store
+from src.backend.jobs.models import JobSummary
+from src.backend.upload_retry import TrackerRunOutcome
+from src.enums.tracker_selection import TrackerSelection
+
+
+@pytest.fixture
+def working_dir(tmp_path: Path) -> Path:
+    return tmp_path / "nfoforge"
+
+
+def _job(working_dir: Path) -> tuple[Any, Path]:
+    """A saved job covering two trackers, each with a stored NFO."""
+    context = {
+        "shared_data": {
+            "selected_trackers": ["AITHER", "HUNO"],
+            "tracker_release_data": {
+                "AITHER": {"title": "a", "nfo_asset": "nfo/aither.txt"},
+                "HUNO": {"title": "h", "nfo_asset": "nfo/huno.txt"},
+            },
+        }
+    }
+    job = store.build_job(
+        "Two trackers",
+        JobSummary(trackers=["Aither", "Huno"]),
+        context,
+    )
+    directory = store.job_dir(working_dir, job.job_id, ensure_exists=True)
+    nfo_dir = directory / store.JOB_NFO_DIR_NAME
+    nfo_dir.mkdir(parents=True)
+    (nfo_dir / "aither.txt").write_text("a", encoding="utf-8")
+    (nfo_dir / "huno.txt").write_text("h", encoding="utf-8")
+    store.write_job_document(job, directory)
+    return job, directory
+
+
+def _runner() -> JobQueueRunner:
+    return JobQueueRunner(backend=SimpleNamespace(), config=SimpleNamespace())
+
+
+def test_a_job_whose_trackers_all_uploaded_is_deleted(working_dir: Path) -> None:
+    job, directory = _job(working_dir)
+    outcome = QueuedJobOutcome(
+        job_name=job.name,
+        path=directory,
+        result=QueuedJobResult.UPLOADED,
+        outcomes={
+            TrackerSelection.AITHER: TrackerRunOutcome.UPLOADED,
+            TrackerSelection.HUNO: TrackerRunOutcome.UPLOADED,
+        },
+    )
+
+    _runner()._settle(job, outcome)
+
+    assert outcome.disposition is JobDisposition.DELETED
+    assert not directory.exists()
+
+
+def test_a_partly_uploaded_job_is_narrowed_to_what_is_left(working_dir: Path) -> None:
+    job, directory = _job(working_dir)
+    outcome = QueuedJobOutcome(
+        job_name=job.name,
+        path=directory,
+        result=QueuedJobResult.UPLOADED,
+        outcomes={
+            TrackerSelection.AITHER: TrackerRunOutcome.UPLOADED,
+            TrackerSelection.HUNO: TrackerRunOutcome.UPLOAD_FAILED,
+        },
+    )
+
+    _runner()._settle(job, outcome)
+
+    assert outcome.disposition is JobDisposition.NARROWED
+    reloaded = store.load_job(directory)
+    shared = reloaded.context["shared_data"]
+    assert set(shared["tracker_release_data"]) == {"HUNO"}
+    assert shared["selected_trackers"] == ["HUNO"]
+    # TrackerSelection.HUNO's value is the literal string "HUNO" (unlike
+    # AITHER's "Aither"), and str(tracker) -- the same conversion
+    # _job_summary() in the wizard already uses -- reflects that casing
+    assert reloaded.summary.trackers == ["HUNO"]
+    # the uploaded tracker's NFO must not linger and imply the job still covers it
+    assert {p.name for p in (directory / store.JOB_NFO_DIR_NAME).iterdir()} == {
+        "huno.txt"
+    }
+
+
+def test_a_job_that_uploaded_nothing_is_left_alone(working_dir: Path) -> None:
+    job, directory = _job(working_dir)
+    before = (directory / store.JOB_DOCUMENT_NAME).read_text(encoding="utf-8")
+    outcome = QueuedJobOutcome(
+        job_name=job.name,
+        path=directory,
+        result=QueuedJobResult.FAILED,
+        outcomes={
+            TrackerSelection.AITHER: TrackerRunOutcome.UPLOAD_FAILED,
+            TrackerSelection.HUNO: TrackerRunOutcome.NOT_ATTEMPTED,
+        },
+    )
+
+    _runner()._settle(job, outcome)
+
+    assert outcome.disposition is JobDisposition.KEPT
+    assert (directory / store.JOB_DOCUMENT_NAME).read_text(encoding="utf-8") == before
+
+
+def test_an_unknown_outcome_never_deletes_the_job(working_dir: Path) -> None:
+    """`MAY_HAVE_UPLOADED` means nobody can say. Deleting would destroy the evidence."""
+    job, directory = _job(working_dir)
+    outcome = QueuedJobOutcome(
+        job_name=job.name,
+        path=directory,
+        result=QueuedJobResult.FAILED,
+        outcomes={
+            TrackerSelection.AITHER: TrackerRunOutcome.MAY_HAVE_UPLOADED,
+            TrackerSelection.HUNO: TrackerRunOutcome.MAY_HAVE_UPLOADED,
+        },
+    )
+
+    _runner()._settle(job, outcome)
+
+    assert outcome.disposition is JobDisposition.KEPT
+    assert directory.exists()
+
+
+def test_upload_disabled_alone_never_deletes_the_job(working_dir: Path) -> None:
+    """Uploads switched off in config is a dry run, not a finished job."""
+    job, directory = _job(working_dir)
+    outcome = QueuedJobOutcome(
+        job_name=job.name,
+        path=directory,
+        result=QueuedJobResult.UPLOADED,
+        outcomes={
+            TrackerSelection.AITHER: TrackerRunOutcome.UPLOAD_DISABLED,
+            TrackerSelection.HUNO: TrackerRunOutcome.UPLOAD_DISABLED,
+        },
+    )
+
+    _runner()._settle(job, outcome)
+
+    assert outcome.disposition is JobDisposition.KEPT
+    assert directory.exists()
+
+
+def test_a_job_that_never_reached_upload_is_untouched(working_dir: Path) -> None:
+    job, directory = _job(working_dir)
+    outcome = QueuedJobOutcome(
+        job_name=job.name,
+        path=directory,
+        result=QueuedJobResult.SKIPPED_DUPES,
+        detail="possible duplicates on Aither",
+    )
+
+    _runner()._settle(job, outcome)
+
+    assert outcome.disposition is JobDisposition.KEPT
+    assert directory.exists()

--- a/tests/test_backend/test_jobs_assets.py
+++ b/tests/test_backend/test_jobs_assets.py
@@ -14,7 +14,10 @@ from src.backend.jobs.assets import (
     capture_mediainfo,
     copy_base_torrent,
     copy_images,
+    fingerprint_files,
+    fingerprints_match,
     read_job_asset,
+    torrent_content_files,
 )
 from src.backend.utils.media_info_utils import (
     MinimalMediaInfo,
@@ -210,3 +213,77 @@ def test_fingerprint_round_trips(sample_media: Path) -> None:
     assert MediaFingerprint.from_dict(fingerprint.to_dict()) == fingerprint
     assert MediaFingerprint.from_dict({"size": "nope"}) is None
     assert MediaFingerprint.from_dict(None) is None
+
+
+def test_torrent_content_files_walks_a_directory(tmp_path: Path) -> None:
+    pack = tmp_path / "Pack.S01"
+    (pack / "sub").mkdir(parents=True)
+    (pack / "e01.mkv").write_bytes(b"a")
+    (pack / "sub" / "e02.mkv").write_bytes(b"b")
+
+    assert torrent_content_files(pack) == [
+        pack / "e01.mkv",
+        pack / "sub" / "e02.mkv",
+    ]
+
+
+def test_torrent_content_files_of_a_single_file_is_that_file(tmp_path: Path) -> None:
+    media = tmp_path / "movie.mkv"
+    media.write_bytes(b"a")
+
+    assert torrent_content_files(media) == [media]
+
+
+def test_fingerprints_match_an_unchanged_pack(tmp_path: Path) -> None:
+    pack = tmp_path / "Pack.S01"
+    pack.mkdir()
+    (pack / "e01.mkv").write_bytes(b"a")
+    (pack / "e02.mkv").write_bytes(b"bb")
+
+    stored = fingerprint_files(torrent_content_files(pack))
+
+    assert fingerprints_match(stored, pack) is True
+
+
+def test_a_changed_second_file_invalidates_the_pack(tmp_path: Path) -> None:
+    """The whole point: episode 1 alone cannot vouch for the torrent."""
+    pack = tmp_path / "Pack.S01"
+    pack.mkdir()
+    (pack / "e01.mkv").write_bytes(b"a")
+    (pack / "e02.mkv").write_bytes(b"bb")
+    stored = fingerprint_files(torrent_content_files(pack))
+
+    (pack / "e02.mkv").write_bytes(b"changed")
+
+    assert fingerprints_match(stored, pack) is False
+
+
+def test_an_added_file_invalidates_the_pack(tmp_path: Path) -> None:
+    pack = tmp_path / "Pack.S01"
+    pack.mkdir()
+    (pack / "e01.mkv").write_bytes(b"a")
+    stored = fingerprint_files(torrent_content_files(pack))
+
+    (pack / "e02.mkv").write_bytes(b"b")
+
+    assert fingerprints_match(stored, pack) is False
+
+
+def test_a_removed_file_invalidates_the_pack(tmp_path: Path) -> None:
+    pack = tmp_path / "Pack.S01"
+    pack.mkdir()
+    (pack / "e01.mkv").write_bytes(b"a")
+    (pack / "e02.mkv").write_bytes(b"b")
+    stored = fingerprint_files(torrent_content_files(pack))
+
+    (pack / "e02.mkv").unlink()
+
+    assert fingerprints_match(stored, pack) is False
+
+
+def test_an_empty_record_never_matches(tmp_path: Path) -> None:
+    media = tmp_path / "movie.mkv"
+    media.write_bytes(b"a")
+
+    assert fingerprints_match({}, media) is False
+    assert fingerprints_match(None, media) is False

--- a/tests/test_backend/test_jobs_assets.py
+++ b/tests/test_backend/test_jobs_assets.py
@@ -1,5 +1,6 @@
 """Coverage for the files a job copies in so it stops depending on `processing/`."""
 
+import os
 from pathlib import Path
 import struct
 import wave
@@ -199,6 +200,21 @@ def test_fingerprint_detects_a_changed_media_file(sample_media: Path) -> None:
     sample_media.write_bytes(b"completely different content")
 
     assert not fingerprint.matches(sample_media)
+
+
+def test_fingerprint_detects_a_changed_mtime_at_the_same_size(tmp_path: Path) -> None:
+    """Isolates the mtime half of the comparison: the test above changes size
+    too, so it alone would still pass with mtime comparison dropped."""
+    media = tmp_path / "movie.mkv"
+    media.write_bytes(b"same length")
+    fingerprint = MediaFingerprint.of(media)
+
+    media.write_bytes(b"still same!")  # same byte count, different content
+    bumped = fingerprint.mtime_ns + 1_000_000_000
+    os.utime(media, ns=(bumped, bumped))
+
+    assert media.stat().st_size == fingerprint.size
+    assert not fingerprint.matches(media)
 
 
 def test_fingerprint_of_a_missing_file_never_matches(tmp_path: Path) -> None:

--- a/tests/test_backend/test_jobs_codec.py
+++ b/tests/test_backend/test_jobs_codec.py
@@ -1,5 +1,6 @@
 """Round-trip coverage for saving and restoring a processing context."""
 
+import json
 from pathlib import Path
 import struct
 from types import SimpleNamespace
@@ -352,3 +353,16 @@ def test_filtering_to_nothing_yields_an_empty_tracker_set(
 
     assert filtered["shared_data"]["selected_trackers"] == []
     assert filtered["shared_data"]["tracker_image_hosts"] == {}
+
+
+def test_an_unserializable_provider_payload_is_dropped_not_fatal() -> None:
+    context = ProcessingContext()
+    context.media_search.tmdb_data = {"ok": 1}
+    context.media_search.tvdb_data = object()
+
+    document = context_to_dict(context)
+
+    assert document["media_search"]["tmdb_data"] == {"ok": 1}
+    assert document["media_search"]["tvdb_data"] is None
+    # the whole document must still survive a round trip through JSON
+    json.dumps(document)

--- a/tests/test_backend/test_jobs_store.py
+++ b/tests/test_backend/test_jobs_store.py
@@ -272,6 +272,56 @@ def test_prune_unreferenced_nfos_is_a_no_op_without_an_nfo_dir(
     store.prune_unreferenced_nfos(directory, {"shared_data": {}})
 
 
+@pytest.mark.parametrize(
+    "context",
+    [
+        {},
+        {"shared_data": "not a mapping"},
+        {"shared_data": {}},
+        {"shared_data": {"tracker_release_data": "not a mapping either"}},
+    ],
+)
+def test_prune_unreferenced_nfos_guards_a_malformed_context(
+    working_dir: Path,
+    context: dict,
+) -> None:
+    """A context with no usable tracker_release_data must not read as 'references nothing'.
+
+    Deleting every NFO on a malformed context would turn a bug elsewhere in
+    the pipeline into a data-loss bug here too.
+    """
+    job = store.build_job("job", JobSummary(), {})
+    directory = store.job_dir(working_dir, job.job_id, ensure_exists=True)
+    nfo_dir = directory / store.JOB_NFO_DIR_NAME
+    nfo_dir.mkdir(parents=True)
+    (nfo_dir / "aither.txt").write_text("kept", encoding="utf-8")
+
+    store.prune_unreferenced_nfos(directory, context)
+
+    assert {path.name for path in nfo_dir.iterdir()} == {"aither.txt"}
+
+
+def test_prune_unreferenced_nfos_prunes_a_legitimately_empty_mapping(
+    working_dir: Path,
+) -> None:
+    """An empty tracker_release_data (a job with no NFOs) still means prune everything.
+
+    That is distinct from a missing mapping: here the context did say what is
+    referenced, and the answer is nothing.
+    """
+    job = store.build_job("job", JobSummary(), {})
+    directory = store.job_dir(working_dir, job.job_id, ensure_exists=True)
+    nfo_dir = directory / store.JOB_NFO_DIR_NAME
+    nfo_dir.mkdir(parents=True)
+    (nfo_dir / "orphaned.txt").write_text("orphaned", encoding="utf-8")
+
+    store.prune_unreferenced_nfos(
+        directory, {"shared_data": {"tracker_release_data": {}}}
+    )
+
+    assert list(nfo_dir.iterdir()) == []
+
+
 def test_a_listing_reports_whether_its_media_is_still_there(
     working_dir: Path, tmp_path: Path
 ) -> None:

--- a/tests/test_backend/test_jobs_store.py
+++ b/tests/test_backend/test_jobs_store.py
@@ -270,3 +270,31 @@ def test_prune_unreferenced_nfos_is_a_no_op_without_an_nfo_dir(
 
     # must not raise
     store.prune_unreferenced_nfos(directory, {"shared_data": {}})
+
+
+def test_a_listing_reports_whether_its_media_is_still_there(
+    working_dir: Path, tmp_path: Path
+) -> None:
+    media = tmp_path / "present.mkv"
+    media.write_bytes(b"x")
+    store.save_job(
+        store.build_job("here", JobSummary(input_path=str(media)), {}), working_dir
+    )
+    store.save_job(
+        store.build_job(
+            "gone", JobSummary(input_path=str(tmp_path / "missing.mkv")), {}
+        ),
+        working_dir,
+    )
+
+    listings = {entry.name: entry for entry in store.list_jobs([working_dir])}
+
+    assert listings["here"].media_available is True
+    assert listings["gone"].media_available is False
+
+
+def test_a_job_that_recorded_no_media_path_is_not_flagged(working_dir: Path) -> None:
+    """Jobs saved before the path was recorded must not all look broken."""
+    store.save_job(store.build_job("old", JobSummary(), {}), working_dir)
+
+    assert store.list_jobs([working_dir])[0].media_available is True

--- a/tests/test_backend/test_jobs_store.py
+++ b/tests/test_backend/test_jobs_store.py
@@ -217,3 +217,56 @@ def test_migration_chain_guard_catches_a_bump_without_a_migration(
 
     with pytest.raises(RuntimeError, match="migrations are incomplete"):
         check_migration_chain()
+
+
+def test_write_job_document_rewrites_an_existing_job(working_dir: Path) -> None:
+    job = store.build_job("original", JobSummary(), {"shared_data": {}})
+    directory = store.save_job(job, working_dir)
+
+    job.name = "renamed"
+    returned = store.write_job_document(job, directory)
+
+    assert returned == directory
+    assert store.load_job(directory).name == "renamed"
+
+
+def test_write_job_document_reports_unserializable_content(working_dir: Path) -> None:
+    job = store.build_job("bad", JobSummary(), {"oops": object()})
+    directory = store.job_dir(working_dir, job.job_id, ensure_exists=True)
+
+    with pytest.raises(store.JobStoreError, match="cannot be saved"):
+        store.write_job_document(job, directory)
+
+
+def test_prune_unreferenced_nfos_keeps_only_what_the_context_points_at(
+    working_dir: Path,
+) -> None:
+    job = store.build_job("job", JobSummary(), {})
+    directory = store.job_dir(working_dir, job.job_id, ensure_exists=True)
+    nfo_dir = directory / store.JOB_NFO_DIR_NAME
+    nfo_dir.mkdir(parents=True)
+    (nfo_dir / "aither.txt").write_text("kept", encoding="utf-8")
+    (nfo_dir / "huno.txt").write_text("dropped", encoding="utf-8")
+
+    store.prune_unreferenced_nfos(
+        directory,
+        {
+            "shared_data": {
+                "tracker_release_data": {
+                    "AITHER": {"title": "t", "nfo_asset": "nfo/aither.txt"}
+                }
+            }
+        },
+    )
+
+    assert {path.name for path in nfo_dir.iterdir()} == {"aither.txt"}
+
+
+def test_prune_unreferenced_nfos_is_a_no_op_without_an_nfo_dir(
+    working_dir: Path,
+) -> None:
+    job = store.build_job("job", JobSummary(), {})
+    directory = store.job_dir(working_dir, job.job_id, ensure_exists=True)
+
+    # must not raise
+    store.prune_unreferenced_nfos(directory, {"shared_data": {}})

--- a/tests/test_backend/test_working_dir_layout.py
+++ b/tests/test_backend/test_working_dir_layout.py
@@ -64,6 +64,30 @@ def test_cleanable_items_is_empty_for_a_missing_directory(tmp_path: Path) -> Non
     assert cleanable_items(tmp_path / "never-created") == []
 
 
+def test_cleanable_items_survives_the_directory_vanishing_before_iterdir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The directory can be removed between the is_dir() check and iterdir().
+
+    Same race cleanable_size guards one level down; unguarded here it would
+    surface straight out of cleanable_items and out of cleanable_size too,
+    since cleanable_size iterates this function's result.
+    """
+    working_dir = tmp_path / "nfoforge"
+    working_dir.mkdir()
+
+    real_iterdir = Path.iterdir
+
+    def vanishing(self: Path) -> object:
+        if self == working_dir:
+            raise OSError("directory vanished mid-scan")
+        return real_iterdir(self)
+
+    monkeypatch.setattr(Path, "iterdir", vanishing)
+
+    assert cleanable_items(working_dir) == []
+
+
 def test_cleanable_size_adds_up_what_clean_up_would_remove(tmp_path: Path) -> None:
     processing = tmp_path / "processing" / "run"
     processing.mkdir(parents=True)

--- a/tests/test_backend/test_working_dir_layout.py
+++ b/tests/test_backend/test_working_dir_layout.py
@@ -1,5 +1,6 @@
 """Coverage for the working directory layout that keeps jobs safe from cleanup."""
 
+import os
 from pathlib import Path
 
 import pytest
@@ -92,4 +93,42 @@ def test_cleanable_size_survives_a_file_disappearing(
 
     monkeypatch.setattr(Path, "stat", vanishing)
 
+    assert cleanable_size(tmp_path) == 0
+
+
+def test_cleanable_size_survives_a_directory_disappearing_mid_walk(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A whole subdirectory can vanish while rglob() is still descending into it.
+
+    That surfaces as an exception from the `for` statement driving the walk,
+    not from a stat() call inside the loop body, so it needs its own guard
+    one level up from the per-file one.
+    """
+    keep = tmp_path / "processing" / "keep"
+    keep.mkdir(parents=True)
+    (keep / "shot.png").write_bytes(b"x" * 50)
+
+    gone = tmp_path / "gone"
+    gone.mkdir()
+    (gone / "trace.log").write_bytes(b"x" * 30)
+
+    real_scandir = os.scandir
+
+    def vanishing(path: object = ".") -> object:
+        if Path(path).name == "gone":
+            raise FileNotFoundError("directory vanished mid-scan")
+        return real_scandir(path)
+
+    monkeypatch.setattr(os, "scandir", vanishing)
+
+    # "gone" disappears out from under the walk; only "keep" can still be measured
+    assert cleanable_size(tmp_path) == 50
+
+
+def test_cleanable_size_is_zero_for_a_missing_directory(tmp_path: Path) -> None:
+    assert cleanable_size(tmp_path / "never-created") == 0
+
+
+def test_cleanable_size_is_zero_for_an_empty_directory(tmp_path: Path) -> None:
     assert cleanable_size(tmp_path) == 0

--- a/tests/test_backend/test_working_dir_layout.py
+++ b/tests/test_backend/test_working_dir_layout.py
@@ -2,10 +2,13 @@
 
 from pathlib import Path
 
+import pytest
+
 from src.backend.utils.working_dir import (
     JOBS_DIR_NAME,
     PROCESSING_DIR_NAME,
     cleanable_items,
+    cleanable_size,
     jobs_dir,
     processing_dir,
 )
@@ -58,3 +61,35 @@ def test_cleanup_sweeps_run_folders_left_at_the_root(tmp_path: Path) -> None:
 
 def test_cleanable_items_is_empty_for_a_missing_directory(tmp_path: Path) -> None:
     assert cleanable_items(tmp_path / "never-created") == []
+
+
+def test_cleanable_size_adds_up_what_clean_up_would_remove(tmp_path: Path) -> None:
+    processing = tmp_path / "processing" / "run"
+    processing.mkdir(parents=True)
+    (processing / "shot.png").write_bytes(b"x" * 100)
+    jobs = tmp_path / "jobs" / "abc"
+    jobs.mkdir(parents=True)
+    (jobs / "job.json").write_bytes(b"y" * 500)
+    (tmp_path / "stray.log").write_bytes(b"z" * 10)
+
+    # jobs/ is never reclaimable, so it must not be counted
+    assert cleanable_size(tmp_path) == 110
+
+
+def test_cleanable_size_survives_a_file_disappearing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    processing = tmp_path / "processing"
+    processing.mkdir()
+    (processing / "gone.png").write_bytes(b"x" * 100)
+
+    real_stat = Path.stat
+
+    def vanishing(self: Path, *args: object, **kwargs: object) -> object:
+        if self.name == "gone.png":
+            raise OSError("file vanished mid-scan")
+        return real_stat(self, *args, **kwargs)  # pyright: ignore[reportCallIssue]
+
+    monkeypatch.setattr(Path, "stat", vanishing)
+
+    assert cleanable_size(tmp_path) == 0

--- a/tests/test_frontend/test_job_queue_dialog.py
+++ b/tests/test_frontend/test_job_queue_dialog.py
@@ -13,18 +13,18 @@ from PySide6.QtWidgets import QDialogButtonBox, QMessageBox
 import pytest
 
 from src.backend.job_queue import JobDisposition, QueuedJobOutcome, QueuedJobResult
-from src.frontend.custom_widgets import job_queue_dialog as dialog_module
 from src.frontend.custom_widgets.job_queue_dialog import JobQueueDialog
 
 
 @pytest.fixture
-def dialog(
-    qapp: Any, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> JobQueueDialog:
-    """A dialog whose backend is never built, so no config is needed."""
-    monkeypatch.setattr(
-        dialog_module, "ProcessBackEnd", lambda _config: SimpleNamespace()
-    )
+def dialog(qapp: Any, tmp_path: Path) -> JobQueueDialog:
+    """A dialog that has not been started.
+
+    `start()` is deliberately separate from construction, so building this
+    dialog never touches `ProcessBackEnd` or spins up a real `_QueueThread` --
+    no config or monkeypatching needed. Tests exercise its slots directly, the
+    same way the queue's own worker thread would call them.
+    """
     return JobQueueDialog(
         job_paths=[tmp_path / "jobs" / "one", tmp_path / "jobs" / "two"],
         config=SimpleNamespace(),
@@ -145,22 +145,95 @@ def test_cancelling_asks_the_thread_to_stop(dialog: JobQueueDialog) -> None:
 def test_the_dialog_refuses_to_close_while_a_job_is_in_flight(
     dialog: JobQueueDialog, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    dialog._thread = SimpleNamespace(isRunning=lambda: True)  # pyright: ignore[reportAttributeAccessIssue]
-    # reject() asks before stopping the queue; answering "No" here means
-    # "don't stop it", which is what leaves `_thread` untouched below. Without
-    # this the real QMessageBox would pop up and block the test forever.
+    """Answering "stop it" cancels the run; it must not also close the window.
+
+    `dialog.result()` can't be trusted to prove that on its own: `Rejected` and
+    a dialog's untouched default result are both `0`, so a check against
+    `result()` alone passes whether or not `reject()` ever ran (see the
+    companion test below, where the real value the class actually produces is
+    pinned down). Spying on `done()` -- the method `QDialog.reject()` calls
+    internally to actually close -- is what tells "refused" apart from
+    "closed", regardless of what `result()` reads.
+    """
+    stopped: list[bool] = []
+    dialog._thread = SimpleNamespace(  # pyright: ignore[reportAttributeAccessIssue]
+        isRunning=lambda: True, cancel=lambda: stopped.append(True)
+    )
+    done_calls: list[object] = []
+    monkeypatch.setattr(dialog, "done", lambda *args: done_calls.append(args))
+    # answering "Yes" (stop it) is the harder case: it must still stop short
+    # of actually closing, only asking the thread to cancel
     monkeypatch.setattr(
-        QMessageBox, "question", lambda *_a, **_k: QMessageBox.StandardButton.No
+        QMessageBox, "question", lambda *_a, **_k: QMessageBox.StandardButton.Yes
     )
 
     dialog.reject()
 
-    assert (
-        dialog.result() != int(JobQueueDialog.DialogCode.Rejected)
-        or dialog.isVisible() is False
-    )
-    # the real assertion: rejecting mid-run must not tear the dialog down
+    assert stopped == [True]
+    assert done_calls == []
     assert dialog._thread is not None
+
+
+def test_the_dialog_closes_when_nothing_is_running(
+    dialog: JobQueueDialog, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The companion to the refusal above: with no job in flight, `reject()`
+    must still close rather than refusing unconditionally."""
+    dialog._thread = None
+    done_calls: list[object] = []
+    monkeypatch.setattr(dialog, "done", lambda *args: done_calls.append(args))
+
+    dialog.reject()
+
+    assert done_calls == [(int(JobQueueDialog.DialogCode.Rejected),)]
+
+
+def test_a_known_secret_does_not_survive_into_the_log(
+    dialog: JobQueueDialog,
+) -> None:
+    """`_on_text` carries tracker responses, which can carry credentials --
+    the same reason `ProcessPage._on_text_update` scrubs before inserting."""
+    dialog._on_text(
+        "<span>https://tracker.example/deadbeefdeadbeefdeadbeefdeadbeef/announce</span>"
+    )
+
+    assert "deadbeefdeadbeefdeadbeefdeadbeef" not in dialog.text_widget.toPlainText()
+
+
+def test_replacing_the_last_line_scrubs_too_and_leaves_one_line(
+    dialog: JobQueueDialog,
+) -> None:
+    """The replace path is scrubbed the same as the append path -- unlike
+    `ProcessPage`'s equivalent, which does not -- because it carries the same
+    tracker responses and is if anything the more exposed of the two. This
+    also guards the overwrite mechanic itself: the line being replaced must
+    not survive alongside its replacement.
+    """
+    dialog._on_text("<span>running...</span>")
+
+    dialog._on_text_replace(
+        "<span>done: https://tracker.example/"
+        "deadbeefdeadbeefdeadbeefdeadbeef/announce</span>"
+    )
+
+    text = dialog.text_widget.toPlainText()
+    assert "deadbeefdeadbeefdeadbeefdeadbeef" not in text
+    assert "running" not in text
+    assert text.count("\n") == 0
+
+
+def test_a_crash_marks_the_running_job_as_failed_rather_than_leaving_it_stuck(
+    dialog: JobQueueDialog,
+) -> None:
+    """Without this the job that was running when the queue itself raised is
+    left reading "Running" under a header that already says "Queue finished".
+    """
+    dialog._on_job_started(1, "Example")
+
+    dialog._on_failed("boom", "traceback text")
+
+    item = dialog.job_tree.topLevelItem(0)
+    assert "Failed" in item.text(2)
 
 
 def test_the_dialog_closes_once_the_queue_is_done(dialog: JobQueueDialog) -> None:

--- a/tests/test_frontend/test_job_queue_dialog.py
+++ b/tests/test_frontend/test_job_queue_dialog.py
@@ -101,6 +101,11 @@ def test_a_clean_job_collapses_and_a_problem_job_stays_open(
     )
     dialog._on_job_started(2, "Broken")
     dialog._on_tracker_status("Huno", "❌ Failed")
+    # The row is already open from `_on_job_started`, so asserting it is expanded
+    # after a failure proves nothing on its own. Collapse it first -- the way a
+    # user can mid-run -- and the assertion then pins the thing that matters:
+    # a failed job re-opens itself rather than staying hidden.
+    dialog.job_tree.topLevelItem(1).setExpanded(False)
     dialog._on_job_finished(
         2,
         QueuedJobOutcome(

--- a/tests/test_frontend/test_job_queue_dialog.py
+++ b/tests/test_frontend/test_job_queue_dialog.py
@@ -1,0 +1,171 @@
+"""Coverage for the queue's own window.
+
+The queue does not borrow the process page, so what is tested here is the state
+machine that replaced it: a cancel that reaches the runner, a close that cannot
+happen mid-run, and a summary that reports what became of each job.
+"""
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+from PySide6.QtWidgets import QDialogButtonBox, QMessageBox
+import pytest
+
+from src.backend.job_queue import JobDisposition, QueuedJobOutcome, QueuedJobResult
+from src.frontend.custom_widgets import job_queue_dialog as dialog_module
+from src.frontend.custom_widgets.job_queue_dialog import JobQueueDialog
+
+
+@pytest.fixture
+def dialog(
+    qapp: Any, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> JobQueueDialog:
+    """A dialog whose backend is never built, so no config is needed."""
+    monkeypatch.setattr(
+        dialog_module, "ProcessBackEnd", lambda _config: SimpleNamespace()
+    )
+    return JobQueueDialog(
+        job_paths=[tmp_path / "jobs" / "one", tmp_path / "jobs" / "two"],
+        config=SimpleNamespace(),
+    )
+
+
+def test_every_job_gets_a_row_up_front(dialog: JobQueueDialog) -> None:
+    assert dialog.job_tree.topLevelItemCount() == 2
+    assert dialog.job_tree.topLevelItem(0).text(0) == "1"
+
+
+def test_a_started_job_is_marked_running(dialog: JobQueueDialog) -> None:
+    dialog._on_job_started(1, "Example (2024)")
+
+    item = dialog.job_tree.topLevelItem(0)
+    assert item.text(1) == "Example (2024)"
+    assert "Running" in item.text(2)
+
+
+def test_tracker_status_lands_under_the_running_job(dialog: JobQueueDialog) -> None:
+    dialog._on_job_started(1, "Example")
+
+    dialog._on_tracker_status("Aither", "▶️ Processing")
+
+    parent = dialog.job_tree.topLevelItem(0)
+    assert parent.childCount() == 1
+    assert parent.child(0).text(1) == "Aither"
+    assert parent.child(0).text(2) == "▶️ Processing"
+
+
+def test_a_repeated_status_updates_the_row_rather_than_adding_one(
+    dialog: JobQueueDialog,
+) -> None:
+    dialog._on_job_started(1, "Example")
+    dialog._on_tracker_status("Aither", "▶️ Processing")
+
+    dialog._on_tracker_status("Aither", "✅ Complete")
+
+    parent = dialog.job_tree.topLevelItem(0)
+    assert parent.childCount() == 1
+    assert parent.child(0).text(2) == "✅ Complete"
+
+
+def test_the_same_tracker_in_two_jobs_gets_two_rows(dialog: JobQueueDialog) -> None:
+    """The flat tracker tree could not do this: one row, last write wins."""
+    dialog._on_job_started(1, "First")
+    dialog._on_tracker_status("Aither", "✅ Complete")
+    dialog._on_job_started(2, "Second")
+    dialog._on_tracker_status("Aither", "❌ Failed")
+
+    assert dialog.job_tree.topLevelItem(0).child(0).text(2) == "✅ Complete"
+    assert dialog.job_tree.topLevelItem(1).child(0).text(2) == "❌ Failed"
+
+
+def test_tracker_status_before_any_job_starts_is_ignored(
+    dialog: JobQueueDialog,
+) -> None:
+    dialog._on_tracker_status("Aither", "▶️ Processing")
+
+    assert dialog.job_tree.topLevelItem(0).childCount() == 0
+
+
+def test_a_clean_job_collapses_and_a_problem_job_stays_open(
+    dialog: JobQueueDialog, tmp_path: Path
+) -> None:
+    """A finished queue should read as a short list with the problems opened."""
+    dialog._on_job_started(1, "Clean")
+    dialog._on_tracker_status("Aither", "✅ Complete")
+    dialog._on_job_finished(
+        1,
+        QueuedJobOutcome(
+            job_name="Clean", path=tmp_path, result=QueuedJobResult.UPLOADED
+        ),
+    )
+    dialog._on_job_started(2, "Broken")
+    dialog._on_tracker_status("Huno", "❌ Failed")
+    dialog._on_job_finished(
+        2,
+        QueuedJobOutcome(
+            job_name="Broken", path=tmp_path, result=QueuedJobResult.FAILED
+        ),
+    )
+
+    assert not dialog.job_tree.topLevelItem(0).isExpanded()
+    assert dialog.job_tree.topLevelItem(1).isExpanded()
+
+
+def test_a_finished_job_reports_its_result_and_disposition(
+    dialog: JobQueueDialog, tmp_path: Path
+) -> None:
+    dialog._on_job_finished(
+        1,
+        QueuedJobOutcome(
+            job_name="Example",
+            path=tmp_path,
+            result=QueuedJobResult.UPLOADED,
+            disposition=JobDisposition.DELETED,
+        ),
+    )
+
+    item = dialog.job_tree.topLevelItem(0)
+    assert "Uploaded" in item.text(2)
+    assert "removed" in item.text(3).lower()
+
+
+def test_cancelling_asks_the_thread_to_stop(dialog: JobQueueDialog) -> None:
+    stopped: list[bool] = []
+    dialog._thread = SimpleNamespace(  # pyright: ignore[reportAttributeAccessIssue]
+        isRunning=lambda: True, cancel=lambda: stopped.append(True)
+    )
+
+    dialog._on_cancel()
+
+    assert stopped == [True]
+    assert not dialog.cancel_btn.isEnabled()
+
+
+def test_the_dialog_refuses_to_close_while_a_job_is_in_flight(
+    dialog: JobQueueDialog, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    dialog._thread = SimpleNamespace(isRunning=lambda: True)  # pyright: ignore[reportAttributeAccessIssue]
+    # reject() asks before stopping the queue; answering "No" here means
+    # "don't stop it", which is what leaves `_thread` untouched below. Without
+    # this the real QMessageBox would pop up and block the test forever.
+    monkeypatch.setattr(
+        QMessageBox, "question", lambda *_a, **_k: QMessageBox.StandardButton.No
+    )
+
+    dialog.reject()
+
+    assert (
+        dialog.result() != int(JobQueueDialog.DialogCode.Rejected)
+        or dialog.isVisible() is False
+    )
+    # the real assertion: rejecting mid-run must not tear the dialog down
+    assert dialog._thread is not None
+
+
+def test_the_dialog_closes_once_the_queue_is_done(dialog: JobQueueDialog) -> None:
+    dialog._thread = None
+    dialog._on_queue_finished()
+
+    assert dialog.cancel_btn.isHidden()
+    assert dialog.button_box.button(QDialogButtonBox.StandardButton.Close).isEnabled()

--- a/tests/test_frontend/test_job_save_resume.py
+++ b/tests/test_frontend/test_job_save_resume.py
@@ -9,6 +9,7 @@ import wave
 from pymediainfo import MediaInfo
 from PySide6.QtWidgets import (
     QDialog,
+    QInputDialog,
     QMessageBox,
     QPushButton,
     QWizard,
@@ -1043,3 +1044,100 @@ def test_a_job_name_with_markup_is_escaped_in_the_log(qapp: Any) -> None:
 
     assert "&lt;b&gt;" in written[0]
     assert "<b>bold</b> job" not in written[0]
+
+
+def test_a_job_name_with_markup_is_rendered_as_plain_text_in_the_saved_box(
+    qapp: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The save confirmation box must show the job name verbatim, not interpret
+    markup. Verifies that the box uses PlainText format so angle brackets do
+    not flip it into rich-text mode.
+    """
+    from PySide6.QtGui import Qt
+
+    captured_boxes: list[Any] = []
+
+    class MockMessageBox:
+        """Mock that accepts any parent and captures the instance."""
+
+        Icon = QMessageBox.Icon
+        Accepted = QMessageBox.Accepted
+
+        def __init__(self, parent: Any = None) -> None:
+            self.parent_obj = parent
+            self.title = ""
+            self.icon = None
+            self.text_format = Qt.TextFormat.AutoText
+            self.icon_val = None
+            self.text_val = ""
+            captured_boxes.append(self)
+
+        def setWindowTitle(self, title: str) -> None:
+            self.title = title
+
+        def setTextFormat(self, fmt: Any) -> None:
+            self.text_format = fmt
+
+        def textFormat(self) -> Any:
+            return self.text_format
+
+        def setIcon(self, icon: Any) -> None:
+            self.icon_val = icon
+
+        def setText(self, text: str) -> None:
+            self.text_val = text
+
+        def text(self) -> str:
+            return self.text_val
+
+        def exec(self) -> int:
+            return self.Accepted
+
+    monkeypatch.setattr(process_module, "QMessageBox", MockMessageBox)
+    monkeypatch.setattr(
+        QInputDialog, "getText", lambda *_a, **_k: ("<b>bold</b> job", True)
+    )
+
+    # Mock the dependencies to reach the save success path.
+    page = SimpleNamespace()
+    page.context = ProcessingContext()
+    page.config = SimpleNamespace(
+        settings=SimpleNamespace(
+            general=SimpleNamespace(working_dir=Path("/working/test"))
+        ),
+        program=SimpleNamespace(current_config="test"),
+    )
+    page._announce_saved_job = lambda name: None  # no-op for this test
+    page._build_job_document = lambda *_: {}
+    page._job_summary = lambda *_: JobSummary()
+    page._default_job_name = lambda: "test"
+    page._on_text_update = lambda *_: None
+
+    # Mock media validation.
+    monkeypatch.setattr(
+        "src.context.processing_context.MediaInputPayload.require_existing_media_paths",
+        lambda *_, **__: None,
+    )
+
+    monkeypatch.setattr(
+        "src.frontend.wizards.process.build_job",
+        lambda **_: SimpleNamespace(
+            name="<b>bold</b> job", job_id="test-id", context={}
+        ),
+    )
+    monkeypatch.setattr(
+        "src.frontend.wizards.process.save_job",
+        lambda *_: Path("/saved/job"),
+    )
+
+    # Drive the success path of _save_job.
+    context = page.context
+    context.media_input.input_path = Path("/test.mkv")
+
+    ProcessPage._save_job(page)  # pyright: ignore[reportArgumentType]
+
+    # The message box should have been created.
+    assert len(captured_boxes) == 1
+    box = captured_boxes[0]
+    assert box.textFormat() == Qt.TextFormat.PlainText
+    assert "<b>bold</b> job" in box.text()

--- a/tests/test_frontend/test_job_save_resume.py
+++ b/tests/test_frontend/test_job_save_resume.py
@@ -57,6 +57,22 @@ def patched_working_dirs(working_dir: Path, monkeypatch: pytest.MonkeyPatch) -> 
     )
 
 
+def _open_dialog(qapp: Any, active_profile: str | None) -> LoadJobDialog:
+    """Construct the picker and wait for its background listing load to land.
+
+    Listing runs on a `_ListingLoader` thread now, so the tree below is empty
+    until that thread's `loaded` signal is delivered -- every test here is
+    about what the picker does with a loaded list, not about the loading
+    itself (that is covered in `test_load_job_dialog.py`), so waiting once
+    here is the fix.
+    """
+    dialog = LoadJobDialog(active_profile)
+    assert dialog._loader is not None
+    dialog._loader.wait(5000)
+    qapp.processEvents()
+    return dialog
+
+
 @pytest.fixture
 def sample_media(tmp_path: Path) -> Path:
     path = tmp_path / "Example.Movie.2024.wav"
@@ -475,7 +491,7 @@ def test_load_dialog_lists_saved_jobs_and_reports_the_choice(
     )
     store.save_job(job, working_dir)
 
-    dialog = LoadJobDialog("config")
+    dialog = _open_dialog(qapp, "config")
     try:
         assert dialog.job_tree.topLevelItemCount() == 1
         item = dialog.job_tree.topLevelItem(0)
@@ -495,7 +511,7 @@ def test_load_dialog_lists_saved_jobs_and_reports_the_choice(
 def test_load_dialog_is_empty_and_inert_without_jobs(
     qapp: Any, patched_working_dirs: None
 ) -> None:
-    dialog = LoadJobDialog("config")
+    dialog = _open_dialog(qapp, "config")
     try:
         assert dialog.job_tree.topLevelItemCount() == 0
         dialog._accept_selection()
@@ -512,7 +528,7 @@ def test_a_job_from_another_config_is_listed_but_not_directly_loadable(
         store.build_job("Other", JobSummary(), {}, config_profile="anime"), working_dir
     )
 
-    dialog = LoadJobDialog("config")
+    dialog = _open_dialog(qapp, "config")
     try:
         assert dialog.job_tree.topLevelItemCount() == 1
         dialog._accept_selection()
@@ -534,7 +550,7 @@ def test_a_job_without_a_recorded_config_stays_loadable(
         store.build_job("Legacy", JobSummary(), {}, config_profile=""), working_dir
     )
 
-    dialog = LoadJobDialog("config")
+    dialog = _open_dialog(qapp, "config")
     try:
         dialog._accept_selection()
         assert dialog.selected_listing is not None
@@ -563,7 +579,7 @@ def test_the_picker_shows_whether_a_job_is_prepared(
 ) -> None:
     _save_listing(working_dir, "ready", prepared=True)
 
-    dialog = LoadJobDialog("config")
+    dialog = _open_dialog(qapp, "config")
     try:
         item = dialog.job_tree.topLevelItem(0)
         assert item is not None
@@ -586,9 +602,12 @@ def test_load_dialog_deletes_the_selected_job(
         QMessageBox, "question", lambda *_a, **_k: QMessageBox.StandardButton.Yes
     )
 
-    dialog = LoadJobDialog("config")
+    dialog = _open_dialog(qapp, "config")
     try:
         dialog._delete_selected()
+        assert dialog._loader is not None
+        dialog._loader.wait(5000)
+        qapp.processEvents()
         assert dialog.job_tree.topLevelItemCount() == 0
         assert store.list_jobs([working_dir]) == []
     finally:

--- a/tests/test_frontend/test_job_save_resume.py
+++ b/tests/test_frontend/test_job_save_resume.py
@@ -28,6 +28,7 @@ from src.backend.jobs import (
 )
 from src.backend.jobs.models import JobSummary
 from src.backend.upload_retry import TrackerRunOutcome
+from src.backend.utils.media_info_utils import clear_full_mi_str_cache
 from src.context.processing_context import ProcessingContext
 from src.enums.image_host import ImageHost, ImageSource
 from src.enums.media_type import MediaType
@@ -42,6 +43,15 @@ from src.frontend.wizards.process import ProcessPage
 from src.frontend.wizards.wizard import MainWindowWizard
 from src.packages.custom_types import ImageUploadFromTo
 from src.payloads.image_hosts import ImagePayloadBase
+
+
+@pytest.fixture(autouse=True)
+def _clear_mi_cache() -> None:
+    # a test that seeds this module-global cache and then fails its own
+    # assertion would otherwise leave the entry behind for the rest of the
+    # session, so clearing it up front rather than trusting the code under
+    # test to do so is what keeps tests independent
+    clear_full_mi_str_cache()
 
 
 @pytest.fixture

--- a/tests/test_frontend/test_job_save_resume.py
+++ b/tests/test_frontend/test_job_save_resume.py
@@ -1033,3 +1033,13 @@ def test_starting_over_drops_mediainfo_cached_by_a_loaded_job(
     MainWindowWizard.reset_wizard(wizard)  # pyright: ignore[reportArgumentType]
 
     assert media_info_utils._FULL_MI_STR_CACHE == {}
+
+
+def test_a_job_name_with_markup_is_escaped_in_the_log(qapp: Any) -> None:
+    written: list[str] = []
+    page = SimpleNamespace(_on_text_update=written.append)
+
+    ProcessPage._announce_saved_job(page, "<b>bold</b> job")  # pyright: ignore[reportArgumentType]
+
+    assert "&lt;b&gt;" in written[0]
+    assert "<b>bold</b> job" not in written[0]

--- a/tests/test_frontend/test_job_save_resume.py
+++ b/tests/test_frontend/test_job_save_resume.py
@@ -864,6 +864,39 @@ def test_a_fully_served_job_asks_nothing(qapp: Any, sample_media: Path) -> None:
     )
 
 
+def test_a_pack_with_a_changed_episode_falls_back_to_hashing(
+    qapp: Any, tmp_path: Path
+) -> None:
+    from src.backend.jobs import fingerprint_files, torrent_content_files
+
+    pack = tmp_path / "Pack.S01"
+    pack.mkdir()
+    (pack / "e01.mkv").write_bytes(b"a")
+    (pack / "e02.mkv").write_bytes(b"bb")
+    job_dir_path = tmp_path / "job"
+    job_dir_path.mkdir()
+    (job_dir_path / "base.torrent").write_bytes(b"torrent")
+
+    context = ProcessingContext()
+    context.media_input.input_path = pack
+    context.media_input.file_list.append(pack / "e01.mkv")
+
+    job = SimpleNamespace(
+        name="pack",
+        context={
+            "base_torrent": {
+                "media": str(pack),
+                "fingerprints": fingerprint_files(torrent_content_files(pack)),
+            }
+        },
+    )
+
+    (pack / "e02.mkv").write_bytes(b"different")
+    MainWindowWizard._attach_base_torrent(SimpleNamespace(), job, job_dir_path, context)  # pyright: ignore[reportArgumentType]
+
+    assert context.shared_data.base_torrent is None
+
+
 # --------------------------------------------------------------------------
 # starting over clears the MediaInfo cache
 # --------------------------------------------------------------------------

--- a/tests/test_frontend/test_job_save_resume.py
+++ b/tests/test_frontend/test_job_save_resume.py
@@ -534,6 +534,14 @@ def test_a_job_from_another_config_is_listed_but_not_directly_loadable(
         dialog._accept_selection()
         assert dialog.selected_listing is None
 
+        # "Only this config" hides the row by default, and `_apply_filter`
+        # deselects whatever it hides -- reveal it and select it explicitly,
+        # the way a user has to before `_accept_with_switch` can act on it.
+        dialog.only_this_config.setChecked(False)
+        item = dialog.job_tree.topLevelItem(0)
+        assert item is not None
+        item.setSelected(True)
+
         dialog._accept_with_switch()
         assert dialog.selected_listing is not None
         assert dialog.selected_listing.config_profile == "anime"

--- a/tests/test_frontend/test_job_save_resume.py
+++ b/tests/test_frontend/test_job_save_resume.py
@@ -1033,7 +1033,7 @@ def test_a_job_name_with_markup_is_escaped_in_the_log(qapp: Any) -> None:
 
 
 def test_a_job_name_with_markup_is_rendered_as_plain_text_in_the_saved_box(
-    qapp: Any, monkeypatch: pytest.MonkeyPatch
+    qapp: Any, working_dir: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """The save confirmation box must show the job name verbatim, not interpret
     markup. Verifies that the box uses PlainText format so angle brackets do
@@ -1087,10 +1087,13 @@ def test_a_job_name_with_markup_is_rendered_as_plain_text_in_the_saved_box(
     # Mock the dependencies to reach the save success path.
     page = SimpleNamespace()
     page.context = ProcessingContext()
+    # A real directory, because `_save_job` really creates one: `build_job` and
+    # `save_job` are mocked below but `job_dir(..., ensure_exists=True)` is not,
+    # and it mkdirs. A hardcoded absolute path here resolves against the current
+    # drive on Windows and quietly writes outside the repo, while on Linux it
+    # raises PermissionError -- green locally, red on CI.
     page.config = SimpleNamespace(
-        settings=SimpleNamespace(
-            general=SimpleNamespace(working_dir=Path("/working/test"))
-        ),
+        settings=SimpleNamespace(general=SimpleNamespace(working_dir=working_dir)),
         program=SimpleNamespace(current_config="test"),
     )
     page._announce_saved_job = lambda name: None  # no-op for this test
@@ -1127,3 +1130,6 @@ def test_a_job_name_with_markup_is_rendered_as_plain_text_in_the_saved_box(
     box = captured_boxes[0]
     assert box.textFormat() == Qt.TextFormat.PlainText
     assert "<b>bold</b> job" in box.text()
+    # Pins the working directory to the fixture: revert it to a hardcoded path
+    # and this fails here rather than only on a Linux runner.
+    assert (working_dir / "jobs" / "test-id").is_dir()

--- a/tests/test_frontend/test_job_save_resume.py
+++ b/tests/test_frontend/test_job_save_resume.py
@@ -33,7 +33,7 @@ from src.enums.wizard import WizardPages
 from src.frontend.custom_widgets import load_job_dialog as load_job_dialog_module
 from src.frontend.custom_widgets.combo_qtree import ComboBoxTreeWidget
 from src.frontend.custom_widgets.load_job_dialog import LoadJobDialog
-from src.frontend.wizards import process as process_module
+from src.frontend.wizards import process as process_module, wizard as wizard_module
 from src.frontend.wizards.process import ProcessPage
 from src.frontend.wizards.wizard import MainWindowWizard
 from src.packages.custom_types import ImageUploadFromTo
@@ -862,3 +862,44 @@ def test_a_fully_served_job_asks_nothing(qapp: Any, sample_media: Path) -> None:
     assert MainWindowWizard._confirm_profile_can_serve_job(
         _wizard_stub(), "Example", context
     )
+
+
+# --------------------------------------------------------------------------
+# starting over clears the MediaInfo cache
+# --------------------------------------------------------------------------
+def test_starting_over_drops_mediainfo_cached_by_a_loaded_job(
+    qapp: Any, sample_media: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A stale dump would be sent to a tracker as if it described the new file."""
+    from src.backend.utils import media_info_utils
+
+    media_info_utils.cache_full_mi_str(sample_media, "dump from the previous job")
+
+    # `reset_wizard` builds a real ProcessingContext from live settings, which
+    # a stand-in has none of; the cache clear is what is under test, not that.
+    monkeypatch.setattr(
+        wizard_module, "create_processing_context", lambda _settings, _plugins: None
+    )
+
+    wizard = SimpleNamespace(
+        config=SimpleNamespace(settings=None, plugin_manager=None),
+        context=None,
+        currentIdChanged=SimpleNamespace(disconnect=lambda: None),
+        _remove_all_pages=lambda: None,
+        _generate_new_pages=lambda: [],
+        _PAGES=[],
+        _insert_plugin_page=lambda: None,
+        _build_wizard_pages=lambda: None,
+        _set_start_page=lambda: None,
+        _connect_current_id_changed=lambda: None,
+        _set_disabled=lambda _value: None,
+        next_button=SimpleNamespace(setText=lambda _text: None),
+        process_button=SimpleNamespace(setText=lambda _text: None),
+        setButtonLayout=lambda _buttons: None,
+        starting_buttons=(),
+        restart=lambda: None,
+    )
+
+    MainWindowWizard.reset_wizard(wizard)  # pyright: ignore[reportArgumentType]
+
+    assert media_info_utils._FULL_MI_STR_CACHE == {}

--- a/tests/test_frontend/test_job_save_resume.py
+++ b/tests/test_frontend/test_job_save_resume.py
@@ -17,10 +17,13 @@ from PySide6.QtWidgets import (
 import pytest
 
 from src.backend.jobs import (
+    MediaFingerprint,
     context_from_dict,
     context_to_dict,
+    fingerprint_files,
     store,
     template_fingerprint,
+    torrent_content_files,
 )
 from src.backend.jobs.models import JobSummary
 from src.backend.upload_retry import TrackerRunOutcome
@@ -867,8 +870,6 @@ def test_a_fully_served_job_asks_nothing(qapp: Any, sample_media: Path) -> None:
 def test_a_pack_with_a_changed_episode_falls_back_to_hashing(
     qapp: Any, tmp_path: Path
 ) -> None:
-    from src.backend.jobs import fingerprint_files, torrent_content_files
-
     pack = tmp_path / "Pack.S01"
     pack.mkdir()
     (pack / "e01.mkv").write_bytes(b"a")
@@ -892,6 +893,102 @@ def test_a_pack_with_a_changed_episode_falls_back_to_hashing(
     )
 
     (pack / "e02.mkv").write_bytes(b"different")
+    MainWindowWizard._attach_base_torrent(SimpleNamespace(), job, job_dir_path, context)  # pyright: ignore[reportArgumentType]
+
+    assert context.shared_data.base_torrent is None
+
+
+def test_an_unchanged_pack_reuses_the_stored_torrent(qapp: Any, tmp_path: Path) -> None:
+    """The positive case: nothing changed, so the clone must actually happen."""
+    pack = tmp_path / "Pack.S01"
+    pack.mkdir()
+    (pack / "e01.mkv").write_bytes(b"a")
+    (pack / "e02.mkv").write_bytes(b"bb")
+    job_dir_path = tmp_path / "job"
+    job_dir_path.mkdir()
+    stored = job_dir_path / "base.torrent"
+    stored.write_bytes(b"torrent")
+
+    context = ProcessingContext()
+    context.media_input.input_path = pack
+    context.media_input.file_list.append(pack / "e01.mkv")
+
+    job = SimpleNamespace(
+        name="pack",
+        context={
+            "base_torrent": {
+                "media": str(pack),
+                "fingerprints": fingerprint_files(torrent_content_files(pack)),
+            }
+        },
+    )
+
+    MainWindowWizard._attach_base_torrent(SimpleNamespace(), job, job_dir_path, context)  # pyright: ignore[reportArgumentType]
+
+    assert context.shared_data.base_torrent == stored
+
+
+def test_a_legacy_single_file_fingerprint_is_honoured(
+    qapp: Any, tmp_path: Path
+) -> None:
+    """A job saved before whole-release fingerprints recorded only the first
+    file -- for a single-file release that is the whole torrent, so it must
+    still be trusted."""
+    media = tmp_path / "movie.mkv"
+    media.write_bytes(b"a")
+    job_dir_path = tmp_path / "job"
+    job_dir_path.mkdir()
+    stored = job_dir_path / "base.torrent"
+    stored.write_bytes(b"torrent")
+
+    context = ProcessingContext()
+    context.media_input.input_path = media
+    context.media_input.file_list.append(media)
+
+    job = SimpleNamespace(
+        name="movie",
+        context={
+            "base_torrent": {
+                "media": str(media),
+                "fingerprint": MediaFingerprint.of(media).to_dict(),
+            }
+        },
+    )
+
+    MainWindowWizard._attach_base_torrent(SimpleNamespace(), job, job_dir_path, context)  # pyright: ignore[reportArgumentType]
+
+    assert context.shared_data.base_torrent == stored
+
+
+def test_a_legacy_fingerprint_does_not_vouch_for_a_directory(
+    qapp: Any, tmp_path: Path
+) -> None:
+    """Guards the `is_dir()` check: a pre-fix job recorded only the first
+    file, which cannot prove the rest of a pack is unchanged even though that
+    first file itself is untouched here."""
+    pack = tmp_path / "Pack.S01"
+    pack.mkdir()
+    first = pack / "e01.mkv"
+    first.write_bytes(b"a")
+    (pack / "e02.mkv").write_bytes(b"bb")
+    job_dir_path = tmp_path / "job"
+    job_dir_path.mkdir()
+    (job_dir_path / "base.torrent").write_bytes(b"torrent")
+
+    context = ProcessingContext()
+    context.media_input.input_path = pack
+    context.media_input.file_list.append(first)
+
+    job = SimpleNamespace(
+        name="pack",
+        context={
+            "base_torrent": {
+                "media": str(pack),
+                "fingerprint": MediaFingerprint.of(first).to_dict(),
+            }
+        },
+    )
+
     MainWindowWizard._attach_base_torrent(SimpleNamespace(), job, job_dir_path, context)  # pyright: ignore[reportArgumentType]
 
     assert context.shared_data.base_torrent is None

--- a/tests/test_frontend/test_job_save_resume.py
+++ b/tests/test_frontend/test_job_save_resume.py
@@ -432,6 +432,31 @@ def test_accepting_the_offer_saves_only_the_deferrable_trackers(
     ]
 
 
+def test_a_deferred_job_only_stores_nfos_for_the_trackers_it_keeps(
+    qapp: Any, sample_media: Path, tmp_path: Path
+) -> None:
+    """A dropped tracker's NFO left in the folder implies the job still covers it."""
+    context = ProcessingContext()
+    _populate(context, sample_media)
+    context.shared_data.tracker_image_hosts[TrackerSelection.HUNO] = ImageUploadFromTo(
+        ImageSource.IMAGES, ImageHost.CHEVERETO_V3
+    )
+    context.shared_data.tracker_release_data = {
+        TrackerSelection.AITHER: {"title": "a", "nfo": "already uploaded"},
+        TrackerSelection.HUNO: {"title": "h", "nfo": "still to go"},
+    }
+
+    page = SimpleNamespace(context=context)
+    page._first_generated_torrent = lambda: None
+    directory = tmp_path / "job"
+    directory.mkdir()
+
+    document = ProcessPage._build_job_document(page, directory, {TrackerSelection.HUNO})
+
+    assert set(document["shared_data"]["tracker_release_data"]) == {"HUNO"}
+    assert {path.name for path in (directory / "nfo").iterdir()} == {"huno.txt"}
+
+
 # --------------------------------------------------------------------------
 # load dialog
 # --------------------------------------------------------------------------

--- a/tests/test_frontend/test_job_save_resume.py
+++ b/tests/test_frontend/test_job_save_resume.py
@@ -1066,6 +1066,7 @@ def test_a_job_name_with_markup_is_rendered_as_plain_text_in_the_saved_box(
             self.text_format = Qt.TextFormat.AutoText
             self.icon_val = None
             self.text_val = ""
+            self.exec_called = False
             captured_boxes.append(self)
 
         def setWindowTitle(self, title: str) -> None:
@@ -1087,6 +1088,7 @@ def test_a_job_name_with_markup_is_rendered_as_plain_text_in_the_saved_box(
             return self.text_val
 
         def exec(self) -> int:
+            self.exec_called = True
             return self.Accepted
 
     monkeypatch.setattr(process_module, "QMessageBox", MockMessageBox)
@@ -1140,6 +1142,10 @@ def test_a_job_name_with_markup_is_rendered_as_plain_text_in_the_saved_box(
     box = captured_boxes[0]
     assert box.textFormat() == Qt.TextFormat.PlainText
     assert "<b>bold</b> job" in box.text()
+    # A regression that stopped displaying the box entirely -- e.g. building
+    # `saved_box` and never calling `.exec()` -- would leave every assertion
+    # above green. This is what catches that.
+    assert box.exec_called is True
     # Pins the working directory to the fixture: revert it to a hardcoded path
     # and this fails here rather than only on a Linux runner.
     assert (working_dir / "jobs" / "test-id").is_dir()

--- a/tests/test_frontend/test_job_save_resume.py
+++ b/tests/test_frontend/test_job_save_resume.py
@@ -1142,6 +1142,10 @@ def test_a_job_name_with_markup_is_rendered_as_plain_text_in_the_saved_box(
     box = captured_boxes[0]
     assert box.textFormat() == Qt.TextFormat.PlainText
     assert "<b>bold</b> job" in box.text()
+    # The rest of the confirmation wording, pinned so a rename silently
+    # reverting "Jobs" (as already happened once on this branch) is caught
+    # here rather than only in the wizard button's tooltip.
+    assert "Use 'Jobs' on the start page to come back to it." in box.text()
     # A regression that stopped displaying the box entirely -- e.g. building
     # `saved_box` and never calling `.exec()` -- would leave every assertion
     # above green. This is what catches that.

--- a/tests/test_frontend/test_job_save_resume.py
+++ b/tests/test_frontend/test_job_save_resume.py
@@ -669,15 +669,15 @@ def test_start_id_plus_restart_jumps_straight_to_the_process_page(qapp: Any) -> 
     assert wizard.currentId() == WizardPages.INPUT_PAGE.value
 
 
-def test_help_button_slot_can_carry_the_load_job_button(qapp: Any) -> None:
-    """All three CustomButton slots are taken, so Load Job rides on HelpButton.
+def test_help_button_slot_can_carry_the_jobs_button(qapp: Any) -> None:
+    """All three CustomButton slots are taken, so Jobs rides on HelpButton.
 
     Guards that a custom button placed in that slot really is shown when the
     layout asks for it, and hidden when a layout omits it.
     """
     wizard = QWizard()
     wizard.setPage(WizardPages.INPUT_PAGE.value, QWizardPage())
-    load_button = QPushButton("Load Job", wizard)
+    load_button = QPushButton("Jobs", wizard)
     wizard.setButton(QWizard.WizardButton.HelpButton, load_button)
     wizard.setOption(QWizard.WizardOption.HaveHelpButton)
     wizard.setButtonLayout(

--- a/tests/test_frontend/test_job_save_resume.py
+++ b/tests/test_frontend/test_job_save_resume.py
@@ -558,47 +558,6 @@ def _save_listing(
     )
 
 
-def test_only_prepared_jobs_on_this_config_can_be_queued(
-    qapp: Any, working_dir: Path, patched_working_dirs: None
-) -> None:
-    """A queue has nobody to answer a prompt, and no business using another
-    config's credentials."""
-    _save_listing(working_dir, "ready", prepared=True)
-    _save_listing(working_dir, "raw", prepared=False)
-    _save_listing(working_dir, "other-config", prepared=True, profile="anime")
-
-    dialog = LoadJobDialog("config")
-    try:
-        dialog.job_tree.selectAll()
-        queueable = [listing.name for listing in dialog.queueable_listings()]
-        assert queueable == ["ready"]
-        # a mixed selection must not silently drop what it cannot run
-        assert not dialog.queue_btn.isEnabled()
-    finally:
-        dialog.deleteLater()
-
-
-def test_selecting_only_prepared_jobs_enables_the_queue(
-    qapp: Any, working_dir: Path, patched_working_dirs: None
-) -> None:
-    _save_listing(working_dir, "ready-one", prepared=True)
-    _save_listing(working_dir, "ready-two", prepared=True)
-
-    dialog = LoadJobDialog("config")
-    try:
-        dialog.job_tree.selectAll()
-        assert dialog.queue_btn.isEnabled()
-
-        dialog._accept_queue()
-        assert {listing.name for listing in dialog.queued_listings} == {
-            "ready-one",
-            "ready-two",
-        }
-        assert dialog.selected_listing is None
-    finally:
-        dialog.deleteLater()
-
-
 def test_the_picker_shows_whether_a_job_is_prepared(
     qapp: Any, working_dir: Path, patched_working_dirs: None
 ) -> None:

--- a/tests/test_frontend/test_load_job_dialog.py
+++ b/tests/test_frontend/test_load_job_dialog.py
@@ -908,6 +908,42 @@ def test_re_clicking_a_queue_row_restores_its_pane(
     assert "queue-job" in dialog.details_lbl.text()
 
 
+def test_a_filter_keystroke_does_not_steal_a_queue_sourced_pane(
+    qapp: Any, working_dir: Path, patched_working_dirs: None
+) -> None:
+    """`_apply_filter` deselects every row it hides, which fires
+    `itemSelectionChanged` for a row that was selected. If that flips the
+    source to "tree" unconditionally, typing in the filter box silently
+    discards a queue-sourced pane the user was looking at -- even though the
+    user never touched the tree or the queue.
+    """
+    _save(working_dir, "row-a", created_at="2026-01-01T00:00:00+00:00")
+    _save(working_dir, "row-b", created_at="2026-06-01T00:00:00+00:00")
+    dialog = _open_dialog(qapp)
+    row_a = dialog.job_tree.findItems("row-a", Qt.MatchFlag.MatchExactly, 0)[0]
+    row_b = dialog.job_tree.findItems("row-b", Qt.MatchFlag.MatchExactly, 0)[0]
+
+    _click_tree_item(dialog, row_b, qapp)
+    dialog._add_to_queue()
+    _click_tree_item(dialog, row_a, qapp)
+    assert dialog._details_source == "tree"
+    assert row_a.isSelected()
+
+    _click_queue_row(dialog, 0, qapp)
+    assert dialog._details_source == "queue"
+    assert "row-b" in dialog.details_lbl.text()
+
+    # row A is still selected in the tree; hiding it must not touch the
+    # source, which the user set by clicking the queue row above
+    QTest.keyClicks(dialog.filter_edit, "row-b")
+    qapp.processEvents()
+
+    assert row_a.isHidden()
+    assert dialog._details_source == "queue"
+    assert "row-b" in dialog.details_lbl.text()
+    assert dialog.open_folder_btn.isEnabled()
+
+
 def test_repeated_refresh_details_calls_skip_describe_entirely(
     qapp: Any,
     working_dir: Path,

--- a/tests/test_frontend/test_load_job_dialog.py
+++ b/tests/test_frontend/test_load_job_dialog.py
@@ -1260,6 +1260,42 @@ def test_a_rename_refreshes_the_cached_details_pane_text(
     assert "<b>old name</b>" not in dialog.details_lbl.text()
 
 
+def test_renaming_a_queued_job_refreshes_its_queue_row_label(
+    qapp: Any,
+    working_dir: Path,
+    patched_working_dirs: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`_add_to_queue` binds the `JobListing` a queue item was queued with
+    once, at add time, and nothing ever re-binds it. `_renumber_queue` builds
+    each row's label from that stored object, so after renaming an
+    already-queued job on disk, the queue row kept the old name -- the tree
+    rebuilds on reload, but `_on_listings_loaded` never touched `queue_list`.
+    Pre-existing, and made visible by T18 letting the user inspect a queue
+    row at all.
+
+    Asserted on the queue row's own text, not the tree's -- the tree already
+    refreshed correctly before this fix, so checking it would not catch a
+    queue row left stale.
+    """
+    _save(working_dir, "old name")
+    dialog = _open_dialog(qapp)
+    dialog.job_tree.setCurrentItem(dialog.job_tree.topLevelItem(0))
+    dialog.job_tree.topLevelItem(0).setSelected(True)
+    dialog._add_to_queue()
+    assert dialog.queue_list.item(0).text() == "1. old name"
+    monkeypatch.setattr(
+        load_job_dialog_module.QInputDialog,
+        "getText",
+        staticmethod(lambda *_a, **_k: ("new name", True)),
+    )
+
+    dialog._rename_selected()
+    _wait_for_load(dialog, qapp)
+
+    assert dialog.queue_list.item(0).text() == "1. new name"
+
+
 def test_cancelling_the_rename_changes_nothing(
     qapp: Any,
     working_dir: Path,

--- a/tests/test_frontend/test_load_job_dialog.py
+++ b/tests/test_frontend/test_load_job_dialog.py
@@ -382,6 +382,23 @@ def test_the_delete_key_is_wired_to_delete(
     assert dialog.delete_btn.shortcut() == Qt.Key.Key_Delete
 
 
+def test_a_job_with_missing_media_is_marked_in_the_list(
+    qapp: Any, working_dir: Path, patched_working_dirs: None, tmp_path: Path
+) -> None:
+    job = store.build_job(
+        "broken",
+        JobSummary(title="Broken", input_path=str(tmp_path / "nope.mkv")),
+        {"shared_data": {}},
+        config_profile="default",
+    )
+    store.save_job(job, working_dir)
+    dialog = LoadJobDialog("default")
+
+    item = dialog.job_tree.topLevelItem(0)
+    assert not item.icon(0).isNull()
+    assert "no longer" in item.toolTip(0)
+
+
 def test_one_failed_delete_does_not_strand_the_rest(
     qapp: Any,
     working_dir: Path,

--- a/tests/test_frontend/test_load_job_dialog.py
+++ b/tests/test_frontend/test_load_job_dialog.py
@@ -77,15 +77,44 @@ def test_the_full_tracker_list_is_available_as_a_tooltip(
     assert "DarkPeers" in dialog.job_tree.topLevelItem(0).toolTip(3)
 
 
-def test_jobs_are_sortable_and_start_newest_first(
+def test_the_list_opens_sorted_newest_first(
     qapp: Any, working_dir: Path, patched_working_dirs: None
 ) -> None:
+    """Assert the sort is configured, not that the rows happen to be in order.
+
+    `list_jobs` already returns newest-first, so checking row 0 proves nothing
+    -- it passes with sorting switched off entirely. The sort indicator is what
+    only `sortByColumn` can set.
+    """
     _save(working_dir, "older", created_at="2026-01-01T00:00:00+00:00")
     _save(working_dir, "newer", created_at="2026-06-01T00:00:00+00:00")
     dialog = LoadJobDialog("default")
 
+    header = dialog.job_tree.header()
     assert dialog.job_tree.isSortingEnabled()
+    assert header.sortIndicatorSection() == 6
+    assert header.sortIndicatorOrder() is Qt.SortOrder.DescendingOrder
     assert dialog.job_tree.topLevelItem(0).text(0) == "newer"
+
+
+def test_the_list_can_be_re_sorted_by_another_column(
+    qapp: Any, working_dir: Path, patched_working_dirs: None
+) -> None:
+    """Proves the widget sorts, rather than that its input arrived sorted.
+
+    Names are chosen so alphabetical order is the reverse of newest-first: only
+    a live sort can put "alpha" above "zulu" here.
+    """
+    _save(working_dir, "zulu", created_at="2026-06-01T00:00:00+00:00")
+    _save(working_dir, "alpha", created_at="2026-01-01T00:00:00+00:00")
+    dialog = LoadJobDialog("default")
+
+    dialog.job_tree.sortByColumn(0, Qt.SortOrder.AscendingOrder)
+
+    assert [
+        dialog.job_tree.topLevelItem(index).text(0)
+        for index in range(dialog.job_tree.topLevelItemCount())
+    ] == ["alpha", "zulu"]
 
 
 def test_the_dialog_can_be_resized_from_its_corner(

--- a/tests/test_frontend/test_load_job_dialog.py
+++ b/tests/test_frontend/test_load_job_dialog.py
@@ -1136,35 +1136,92 @@ def test_closing_mid_load_waits_for_the_loader_before_tearing_down(
     patched_working_dirs: None,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """`done()` exists purely because destroying a running `QThread` aborts
-    the process outright, so what needs proving is that closing the dialog
-    actually blocks until the loader has finished -- not merely that
-    `reject()` did not raise. A real sleep in `run()` (on the loader's own
-    OS thread, so it does not block this test) makes "still running when the
-    user closes the dialog" the case being exercised, rather than a race that
-    happens to resolve one way on a given machine.
+    """`_stop_loader` exists purely because destroying a running `QThread`
+    aborts the process outright, so what needs proving is that closing the
+    dialog actually blocks until the loader has finished -- not merely that
+    `reject()` did not raise, and not only up to some cap.
+
+    The 2.2s sleep here (on the loader's own OS thread, so it does not block
+    this test) is deliberately past the two-second bound an earlier version
+    of `_stop_loader` used: that cap failed in exactly the slow-network-share
+    scan this task exists to get off the GUI thread, since that is precisely
+    the case that runs long. The fix has no cap, and this is what proves it
+    -- a version with `wait(2000)` reinstated fails this test, since the
+    loader would still be asleep for another ~200ms when the assertion runs.
     """
     _save(working_dir, "job")
     original_run = load_job_dialog_module._ListingLoader.run
 
     def slow_run(self: Any) -> None:
-        time.sleep(0.4)
+        time.sleep(2.2)
         original_run(self)
 
     monkeypatch.setattr(load_job_dialog_module._ListingLoader, "run", slow_run)
 
     dialog = LoadJobDialog("default")
-    assert dialog._loader is not None
-    assert dialog._loader.isRunning()
+    loader = dialog._loader
+    assert loader is not None
+    assert loader.isRunning()
 
     dialog.reject()
 
-    # If `done()` merely disconnected the signal and returned without ever
-    # calling `wait()`, the loader would still be mid-sleep here.
-    assert dialog._loader.isRunning() is False
+    # `_stop_loader` clears `dialog._loader` before returning, so the loader
+    # reference captured above -- not `dialog._loader`, which is now `None`
+    # -- is what proves the thread itself finished rather than merely being
+    # detached.
+    assert loader.isRunning() is False
     # And if the disconnect happened after (or not at all), the loader's
     # `loaded` signal -- queued for delivery once the sleep ends -- would
     # still land on a dialog that is closing, repopulating a tree nobody is
     # looking at.
     qapp.processEvents()
     assert dialog.job_tree.topLevelItemCount() == 0
+
+
+def test_calling_load_listings_twice_retires_the_first_loader(
+    qapp: Any,
+    working_dir: Path,
+    patched_working_dirs: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A second `_load_listings()` call while the first is still scanning
+    must retire that first loader, not orphan it. An orphaned loader is still
+    running and still parented to the dialog, but no longer reachable through
+    `self._loader` -- which is exactly the thread `done()` could never wait
+    on, and destroying it later aborts the process.
+
+    Slowing only the first `run()` (via a call counter) guarantees the first
+    loader is still going when the second call arrives, rather than hoping a
+    fast local scan wins a race.
+    """
+    _save(working_dir, "job")
+    original_run = load_job_dialog_module._ListingLoader.run
+    calls = 0
+
+    def slow_first_run(self: Any) -> None:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            time.sleep(0.4)
+        original_run(self)
+
+    monkeypatch.setattr(load_job_dialog_module._ListingLoader, "run", slow_first_run)
+
+    dialog = LoadJobDialog("default")
+    first_loader = dialog._loader
+    assert first_loader is not None
+    assert first_loader.isRunning()
+
+    dialog._load_listings()
+
+    # Retired, not abandoned: if `_load_listings` had merely rebound
+    # `self._loader` to a new instance, `first_loader` would still be
+    # running here.
+    assert first_loader.isRunning() is False
+    assert dialog._loader is not None
+    assert dialog._loader is not first_loader
+
+    _wait_for_load(dialog, qapp)
+
+    assert dialog.job_tree.topLevelItemCount() == 1
+    assert dialog.job_tree.topLevelItem(0).text(0) == "job"

--- a/tests/test_frontend/test_load_job_dialog.py
+++ b/tests/test_frontend/test_load_job_dialog.py
@@ -100,8 +100,17 @@ def test_columns_are_sized_for_what_they_hold(
     header = dialog.job_tree.header()
 
     assert header.sectionResizeMode(0) is QHeaderView.ResizeMode.Stretch
+    assert header.sectionResizeMode(1) is QHeaderView.ResizeMode.Stretch
     assert header.sectionResizeMode(2) is QHeaderView.ResizeMode.ResizeToContents
     assert header.sectionResizeMode(3) is QHeaderView.ResizeMode.Interactive
+    assert header.sectionResizeMode(4) is QHeaderView.ResizeMode.ResizeToContents
+    assert header.sectionResizeMode(5) is QHeaderView.ResizeMode.ResizeToContents
+    assert header.sectionResizeMode(6) is QHeaderView.ResizeMode.ResizeToContents
+    # Trackers (column 3) is the one column seeded with an explicit starting
+    # width rather than left to size itself. The dialog is never shown or
+    # resized in this test, so nothing here would move it off the seeded
+    # value.
+    assert header.sectionSize(3) == 180
     assert dialog.job_tree.textElideMode() is Qt.TextElideMode.ElideRight
 
 

--- a/tests/test_frontend/test_load_job_dialog.py
+++ b/tests/test_frontend/test_load_job_dialog.py
@@ -13,6 +13,7 @@ from typing import Any
 
 from PySide6.QtCore import QItemSelectionModel, Qt
 from PySide6.QtGui import QPalette
+from PySide6.QtTest import QTest
 from PySide6.QtWidgets import QDialogButtonBox, QHeaderView
 import pytest
 import qtawesome as qta
@@ -92,6 +93,36 @@ def _wait_for_load(dialog: LoadJobDialog, qapp: Any) -> None:
     """
     assert dialog._loader is not None
     dialog._loader.wait(5000)
+    qapp.processEvents()
+
+
+def _click_tree_item(dialog: LoadJobDialog, item: Any, qapp: Any) -> None:
+    """Drive a real mouse click on a tree row.
+
+    `itemSelectionChanged`/`currentRowChanged` fire only on an actual
+    selection change, not on every click -- calling `setCurrentItem` or
+    `setSelected` directly exercises exactly that already-working path and
+    would not catch a regression in the click-tracking this simulates. The
+    dialog must be shown first: `visualItemRect` spans every column (this
+    tree has 7), which is wider than the offscreen viewport, so clicking its
+    center can land outside the viewport and hit nothing -- column 0's own
+    visual rect is what is actually visible and clickable.
+    """
+    dialog.show()
+    rect = dialog.job_tree.visualRect(dialog.job_tree.indexFromItem(item, 0))
+    QTest.mouseClick(
+        dialog.job_tree.viewport(), Qt.MouseButton.LeftButton, pos=rect.center()
+    )
+    qapp.processEvents()
+
+
+def _click_queue_row(dialog: LoadJobDialog, row: int, qapp: Any) -> None:
+    """Drive a real mouse click on a queue row -- see `_click_tree_item`."""
+    dialog.show()
+    rect = dialog.queue_list.visualItemRect(dialog.queue_list.item(row))
+    QTest.mouseClick(
+        dialog.queue_list.viewport(), Qt.MouseButton.LeftButton, pos=rect.center()
+    )
     qapp.processEvents()
 
 
@@ -833,6 +864,48 @@ def test_open_folder_acts_on_the_queue_row_while_it_is_the_source(
 
     assert opened == [queue_dir]
     assert opened != [tree_dir]
+
+
+# --------------------------------------------------------------------------
+# T18 fix round 1: click tracking and programmatic-change suppression
+# --------------------------------------------------------------------------
+def test_re_clicking_a_queue_row_restores_its_pane(
+    qapp: Any, working_dir: Path, patched_working_dirs: None
+) -> None:
+    """`currentRowChanged`/`itemSelectionChanged` fire only on an actual
+    change, not on every click -- so re-clicking a queue row that is already
+    `queue_list.currentRow()` emits nothing under selection-only wiring, and
+    the pane silently keeps showing whatever was selected last. With a
+    single-item queue there is no way back to that job short of removing and
+    re-adding it. `itemClicked` fires on every press, including a re-click,
+    which is what this test needs `_click_queue_row`'s real click -- not
+    `setCurrentRow` -- to actually exercise.
+    """
+    _save(working_dir, "tree-job", created_at="2026-01-01T00:00:00+00:00")
+    _save(working_dir, "queue-job", created_at="2026-06-01T00:00:00+00:00")
+    dialog = _open_dialog(qapp)
+    tree_item = dialog.job_tree.findItems("tree-job", Qt.MatchFlag.MatchExactly, 0)[0]
+    queue_source_item = dialog.job_tree.findItems(
+        "queue-job", Qt.MatchFlag.MatchExactly, 0
+    )[0]
+    assert dialog.job_tree.currentItem() is queue_source_item
+
+    dialog._add_to_queue()
+    dialog.job_tree.clearSelection()
+
+    _click_queue_row(dialog, 0, qapp)
+    assert dialog._details_source == "queue"
+    assert "queue-job" in dialog.details_lbl.text()
+
+    _click_tree_item(dialog, tree_item, qapp)
+    assert dialog._details_source == "tree"
+    assert "tree-job" in dialog.details_lbl.text()
+
+    # the same queue row again -- still queue_list.currentRow(), so
+    # currentRowChanged emits nothing; only itemClicked can catch this
+    _click_queue_row(dialog, 0, qapp)
+    assert dialog._details_source == "queue"
+    assert "queue-job" in dialog.details_lbl.text()
 
 
 def test_repeated_refresh_details_calls_skip_describe_entirely(

--- a/tests/test_frontend/test_load_job_dialog.py
+++ b/tests/test_frontend/test_load_job_dialog.py
@@ -294,3 +294,89 @@ def test_the_state_icon_is_chosen_by_the_job_s_own_state(
     assert not ready_icon.isNull()
     assert not draft_icon.isNull()
     assert ready_icon.cacheKey() != draft_icon.cacheKey()
+
+
+def test_delete_removes_every_selected_job(
+    qapp: Any,
+    working_dir: Path,
+    patched_working_dirs: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _save(working_dir, "one")
+    _save(working_dir, "two")
+    dialog = LoadJobDialog("default")
+    dialog.job_tree.selectAll()
+    monkeypatch.setattr(
+        load_job_dialog_module.QMessageBox,
+        "question",
+        lambda *_a, **_k: load_job_dialog_module.QMessageBox.StandardButton.Yes,
+    )
+
+    dialog._delete_selected()
+
+    assert dialog.job_tree.topLevelItemCount() == 0
+    assert list((working_dir / "jobs").iterdir()) == []
+
+
+def test_delete_only_removes_the_selected_job(
+    qapp: Any,
+    working_dir: Path,
+    patched_working_dirs: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The dangerous failure mode here is deleting more than was selected.
+
+    Asserting the selected job's directory is gone would also pass a delete
+    that wipes every saved job on disk -- what actually catches an
+    over-broad delete is checking that the job which was *not* selected is
+    still there.
+    """
+    kept_dir = _save(working_dir, "keep")
+    _save(working_dir, "remove")
+    dialog = LoadJobDialog("default")
+    item = dialog.job_tree.findItems("remove", Qt.MatchFlag.MatchExactly, 0)[0]
+    item.setSelected(True)
+    monkeypatch.setattr(
+        load_job_dialog_module.QMessageBox,
+        "question",
+        lambda *_a, **_k: load_job_dialog_module.QMessageBox.StandardButton.Yes,
+    )
+
+    dialog._delete_selected()
+
+    assert kept_dir.exists()
+    assert [
+        dialog.job_tree.topLevelItem(index).text(0)
+        for index in range(dialog.job_tree.topLevelItemCount())
+    ] == ["keep"]
+
+
+def test_the_delete_confirmation_names_what_it_will_remove(
+    qapp: Any,
+    working_dir: Path,
+    patched_working_dirs: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _save(working_dir, "alpha")
+    _save(working_dir, "beta")
+    dialog = LoadJobDialog("default")
+    dialog.job_tree.selectAll()
+    asked: list[str] = []
+
+    def capture(_parent: Any, _title: str, text: str, *_a: Any, **_k: Any) -> Any:
+        asked.append(text)
+        return load_job_dialog_module.QMessageBox.StandardButton.No
+
+    monkeypatch.setattr(load_job_dialog_module.QMessageBox, "question", capture)
+
+    dialog._delete_selected()
+
+    assert "alpha" in asked[0] and "beta" in asked[0]
+
+
+def test_the_delete_key_is_wired_to_delete(
+    qapp: Any, working_dir: Path, patched_working_dirs: None
+) -> None:
+    dialog = LoadJobDialog("default")
+
+    assert dialog.delete_btn.shortcut() == Qt.Key.Key_Delete

--- a/tests/test_frontend/test_load_job_dialog.py
+++ b/tests/test_frontend/test_load_job_dialog.py
@@ -383,6 +383,31 @@ def test_double_clicking_a_cross_profile_row_offers_the_switch(
     assert dialog.selected_listing is not None
 
 
+def test_double_clicking_a_same_profile_row_just_opens_it(
+    qapp: Any, working_dir: Path, patched_working_dirs: None
+) -> None:
+    """The ordinary case: a double click on a row already on the active
+    profile must accept the dialog and select that job outright, without
+    ever offering the profile switch.
+
+    This matters more than an ordinary coverage gap: the cross-profile
+    branch calls `load_profile()`, which changes persistent global config.
+    Pinning which branch runs is what stops the ordinary case from silently
+    acquiring that side effect.
+    """
+    job_dir = _save(working_dir, "mine")
+    dialog = _open_dialog(qapp)
+    item = dialog.job_tree.topLevelItem(0)
+    dialog.job_tree.setCurrentItem(item)
+
+    dialog._on_double_click(item, 0)
+
+    assert dialog.result() == dialog.DialogCode.Accepted
+    assert dialog.switch_profile_requested is False
+    assert dialog.selected_listing is not None
+    assert dialog.selected_listing.path == job_dir
+
+
 def test_state_column_carries_an_icon(
     qapp: Any, working_dir: Path, patched_working_dirs: None
 ) -> None:

--- a/tests/test_frontend/test_load_job_dialog.py
+++ b/tests/test_frontend/test_load_job_dialog.py
@@ -1859,6 +1859,117 @@ def test_a_failed_delete_leaves_its_queue_entry_in_place(
 
 
 # --------------------------------------------------------------------------
+# T18 fix round 2: queue-management sites left unguarded by round 1
+# --------------------------------------------------------------------------
+def test_removing_a_queued_job_does_not_steal_the_pane_from_the_tree(
+    qapp: Any, working_dir: Path, patched_working_dirs: None
+) -> None:
+    """`_remove_queued` calls `takeItem` on the queue's current row, which
+    fires `currentRowChanged` -- that is queue bookkeeping, not the user
+    picking the queue pane, so it must not set the source. Two jobs are
+    queued so one remains after the removal: the source has to keep
+    describing the tree rather than the fallback in `_details_listing`
+    papering over an empty queue, which would mask this bug.
+    """
+    _save(working_dir, "queued-a", created_at="2026-01-01T00:00:00+00:00")
+    _save(working_dir, "queued-b", created_at="2026-02-01T00:00:00+00:00")
+    _save(working_dir, "tree-job", created_at="2026-06-01T00:00:00+00:00")
+    dialog = _open_dialog(qapp)
+    a_item = dialog.job_tree.findItems("queued-a", Qt.MatchFlag.MatchExactly, 0)[0]
+    b_item = dialog.job_tree.findItems("queued-b", Qt.MatchFlag.MatchExactly, 0)[0]
+    tree_item = dialog.job_tree.findItems("tree-job", Qt.MatchFlag.MatchExactly, 0)[0]
+
+    _click_tree_item(dialog, a_item, qapp)
+    dialog._add_to_queue()
+    _click_tree_item(dialog, b_item, qapp)
+    dialog._add_to_queue()
+
+    _click_queue_row(dialog, 0, qapp)
+    _click_tree_item(dialog, tree_item, qapp)
+    assert dialog._details_source == "tree"
+    assert "tree-job" in dialog.details_lbl.text()
+
+    dialog.queue_remove_btn.click()
+
+    assert dialog._details_source == "tree"
+    assert "tree-job" in dialog.details_lbl.text()
+
+
+def test_moving_a_queued_job_does_not_steal_the_pane_from_the_tree(
+    qapp: Any, working_dir: Path, patched_working_dirs: None
+) -> None:
+    """`_move_queued` calls `takeItem` and `setCurrentRow` on the queue,
+    either of which can fire `currentRowChanged` -- reordering the queue is
+    not the user picking the queue pane.
+    """
+    _save(working_dir, "queued-a", created_at="2026-01-01T00:00:00+00:00")
+    _save(working_dir, "queued-b", created_at="2026-02-01T00:00:00+00:00")
+    _save(working_dir, "tree-job", created_at="2026-06-01T00:00:00+00:00")
+    dialog = _open_dialog(qapp)
+    a_item = dialog.job_tree.findItems("queued-a", Qt.MatchFlag.MatchExactly, 0)[0]
+    b_item = dialog.job_tree.findItems("queued-b", Qt.MatchFlag.MatchExactly, 0)[0]
+    tree_item = dialog.job_tree.findItems("tree-job", Qt.MatchFlag.MatchExactly, 0)[0]
+
+    _click_tree_item(dialog, a_item, qapp)
+    dialog._add_to_queue()
+    _click_tree_item(dialog, b_item, qapp)
+    dialog._add_to_queue()
+
+    _click_queue_row(dialog, 1, qapp)
+    _click_tree_item(dialog, tree_item, qapp)
+    assert dialog._details_source == "tree"
+    assert "tree-job" in dialog.details_lbl.text()
+
+    dialog.queue_up_btn.click()
+
+    assert dialog._details_source == "tree"
+    assert "tree-job" in dialog.details_lbl.text()
+
+
+def test_deleting_a_queued_job_does_not_steal_the_pane_from_the_tree(
+    qapp: Any,
+    working_dir: Path,
+    patched_working_dirs: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`_drop_from_queue` also calls `takeItem` on the queue -- deleting a
+    different job that happens to be queued must not flip the source away
+    from whatever the user was actually looking at in the tree.
+    """
+    _save(working_dir, "queued-a", created_at="2026-01-01T00:00:00+00:00")
+    _save(working_dir, "queued-b", created_at="2026-02-01T00:00:00+00:00")
+    _save(working_dir, "tree-job", created_at="2026-06-01T00:00:00+00:00")
+    dialog = _open_dialog(qapp)
+    a_item = dialog.job_tree.findItems("queued-a", Qt.MatchFlag.MatchExactly, 0)[0]
+    b_item = dialog.job_tree.findItems("queued-b", Qt.MatchFlag.MatchExactly, 0)[0]
+    tree_item = dialog.job_tree.findItems("tree-job", Qt.MatchFlag.MatchExactly, 0)[0]
+
+    _click_tree_item(dialog, a_item, qapp)
+    dialog._add_to_queue()
+    _click_tree_item(dialog, b_item, qapp)
+    dialog._add_to_queue()
+
+    _click_queue_row(dialog, 0, qapp)
+    _click_tree_item(dialog, tree_item, qapp)
+    assert dialog._details_source == "tree"
+
+    dialog.job_tree.clearSelection()
+    a_item.setSelected(True)
+    monkeypatch.setattr(
+        load_job_dialog_module.QMessageBox,
+        "question",
+        lambda *_a, **_k: load_job_dialog_module.QMessageBox.StandardButton.Yes,
+    )
+
+    dialog._delete_selected()
+    _wait_for_load(dialog, qapp)
+
+    assert dialog._details_source == "tree"
+    assert "tree-job" in dialog.details_lbl.text()
+    assert "queued-b" not in dialog.details_lbl.text()
+
+
+# --------------------------------------------------------------------------
 # loading is asynchronous
 # --------------------------------------------------------------------------
 def test_the_list_starts_empty_and_says_it_is_loading(

--- a/tests/test_frontend/test_load_job_dialog.py
+++ b/tests/test_frontend/test_load_job_dialog.py
@@ -399,6 +399,227 @@ def test_a_job_with_missing_media_is_marked_in_the_list(
     assert "no longer" in item.toolTip(0)
 
 
+def test_the_details_pane_describes_the_selected_job(
+    qapp: Any, working_dir: Path, patched_working_dirs: None, tmp_path: Path
+) -> None:
+    media = tmp_path / "Example.2024.mkv"
+    media.write_bytes(b"x" * 20)
+    job = store.build_job(
+        "Example",
+        JobSummary(
+            title="Example",
+            year=2024,
+            media_type="Movie",
+            input_path=str(media),
+            file_count=1,
+            trackers=["Aither"],
+        ),
+        {
+            "shared_data": {
+                "loaded_images": ["a.png", "b.png"],
+                "tracker_image_hosts": {
+                    "AITHER": {
+                        "img_from": "IMAGES",
+                        "img_to": "CHEVERETO_V3",
+                        "img_to_type": "ImageHost",
+                    }
+                },
+            }
+        },
+        config_profile="default",
+    )
+    job.created_at = "2020-01-01T00:00:00+00:00"
+    directory = store.save_job(job, working_dir)
+
+    # A second job the pane must not bleed into. With only one job saved,
+    # assertions on substrings alone would still pass if the pane rendered
+    # nothing at all, or the wrong row's data -- there would be nothing else
+    # to distinguish it from. Pinning it newer than "Example" also makes it
+    # the tree's default (post-sort) row, so a details pane that quietly
+    # ignores the selection and shows row 0 shows this job, not "Example".
+    decoy = store.build_job(
+        "Decoy",
+        JobSummary(title="Decoy", year=2020, trackers=["Huno"]),
+        {
+            "shared_data": {
+                "loaded_images": ["c.png"],
+                "tracker_image_hosts": {
+                    "HUNO": {
+                        "img_from": "IMAGES",
+                        "img_to": "PTPIMG",
+                        "img_to_type": "ImageHost",
+                    }
+                },
+            }
+        },
+        config_profile="default",
+    )
+    decoy.created_at = "2020-06-01T00:00:00+00:00"
+    store.save_job(decoy, working_dir)
+
+    dialog = LoadJobDialog("default")
+    item = dialog.job_tree.findItems("Example", Qt.MatchFlag.MatchExactly, 0)[0]
+    dialog.job_tree.setCurrentItem(item)
+
+    text = dialog.details_lbl.text()
+    assert "Example" in text
+    assert "Aither" in text
+    assert "CHEVERETO_V3" in text
+    assert "2 screenshot" in text
+    assert str(directory) in text
+    # none of the decoy job's own data belongs here
+    assert "Decoy" not in text
+    assert "Huno" not in text
+    assert "PTPIMG" not in text
+    assert "1 screenshot" not in text
+
+
+def test_the_details_pane_is_cleared_when_nothing_is_selected(
+    qapp: Any, working_dir: Path, patched_working_dirs: None
+) -> None:
+    dialog = LoadJobDialog("default")
+
+    assert dialog.details_lbl.text() == ""
+    assert not dialog.open_folder_btn.isEnabled()
+
+
+def test_the_details_pane_clears_once_a_selection_is_lost(
+    qapp: Any, working_dir: Path, patched_working_dirs: None
+) -> None:
+    """The empty-dialog case above can pass on the widgets' own construction
+    defaults alone, without `_refresh_details` ever running -- it does not by
+    itself prove the pane reacts to a selection going away. Populating the
+    pane first, then hiding the selected row via the filter, is what actually
+    exercises that path.
+    """
+    _save(working_dir, "alpha")
+    dialog = LoadJobDialog("default")
+    dialog.job_tree.setCurrentItem(dialog.job_tree.topLevelItem(0))
+    assert dialog.details_lbl.text() != ""
+    assert dialog.open_folder_btn.isEnabled()
+
+    dialog.filter_edit.setText("nothing matches this")
+
+    assert dialog.details_lbl.text() == ""
+    assert not dialog.open_folder_btn.isEnabled()
+
+
+def test_the_details_pane_escapes_html_in_a_job_s_name(
+    qapp: Any, working_dir: Path, patched_working_dirs: None
+) -> None:
+    """Job names are free text from a prompt, and the pane renders rich text.
+
+    A name like this reaching the pane unescaped would inject markup into a
+    QLabel that interprets it -- this plan has already had to fix that same
+    class of bug twice, for the log pane and the save-confirmation box.
+    """
+    _save(working_dir, "<b>evil</b> & friends")
+    dialog = LoadJobDialog("default")
+    dialog.job_tree.setCurrentItem(dialog.job_tree.topLevelItem(0))
+
+    text = dialog.details_lbl.text()
+    assert "<b>evil</b>" not in text
+    assert "&lt;b&gt;evil&lt;/b&gt; &amp; friends" in text
+
+
+def test_a_retired_tracker_name_in_the_document_does_not_crash_the_pane(
+    qapp: Any, working_dir: Path, patched_working_dirs: None
+) -> None:
+    """`tracker_image_hosts` is keyed by enum member name, so a tracker that
+    has since been removed from `TrackerSelection` leaves a name the current
+    build cannot resolve. Falling back to the raw string is what stops that
+    from becoming an unhandled `ValueError` out of `_describe`.
+    """
+    job = store.build_job(
+        "job",
+        JobSummary(title="job"),
+        {
+            "shared_data": {
+                "tracker_image_hosts": {
+                    "RETIRED_TRACKER": {
+                        "img_from": "IMAGES",
+                        "img_to": "CHEVERETO_V3",
+                        "img_to_type": "ImageHost",
+                    }
+                },
+            }
+        },
+        config_profile="default",
+    )
+    store.save_job(job, working_dir)
+    dialog = LoadJobDialog("default")
+    dialog.job_tree.setCurrentItem(dialog.job_tree.topLevelItem(0))
+
+    assert "RETIRED_TRACKER" in dialog.details_lbl.text()
+
+
+def test_an_unreadable_job_does_not_break_the_details_pane(
+    qapp: Any,
+    working_dir: Path,
+    patched_working_dirs: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    directory = store.save_job(
+        store.build_job(
+            "broken", JobSummary(title="Broken"), {}, config_profile="default"
+        ),
+        working_dir,
+    )
+    (directory / store.JOB_DOCUMENT_NAME).write_text("not json", encoding="utf-8")
+    dialog = LoadJobDialog("default")
+
+    # listing skips unreadable jobs, so add the row by hand to exercise the pane
+    from src.backend.jobs.models import JobListing
+
+    listing = JobListing(
+        job_id="x",
+        name="broken",
+        created_at="2026-01-01T00:00:00+00:00",
+        summary=JobSummary(title="Broken"),
+        path=directory,
+        config_profile="default",
+    )
+
+    # The "Broken" title comes straight from the listing passed in, not from
+    # the document -- it would show up even if load_job never ran at all. What
+    # actually proves the corrupt document was read and its failure handled,
+    # rather than this test silently exercising the happy path, is that
+    # load_job's failure got logged.
+    warnings: list[object] = []
+    monkeypatch.setattr(
+        load_job_dialog_module.LOG,
+        "warning",
+        lambda _source, message: warnings.append(message),
+    )
+
+    text = dialog._describe(listing)
+
+    assert "Broken" in text
+    assert warnings
+    assert "not valid JSON" in str(warnings[0])
+
+
+def test_the_open_folder_button_opens_the_selected_job_s_directory(
+    qapp: Any,
+    working_dir: Path,
+    patched_working_dirs: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    directory = _save(working_dir, "job")
+    dialog = LoadJobDialog("default")
+    dialog.job_tree.setCurrentItem(dialog.job_tree.topLevelItem(0))
+    assert dialog.open_folder_btn.isEnabled()
+
+    opened: list[Path] = []
+    monkeypatch.setattr(
+        load_job_dialog_module, "open_explorer", lambda path: opened.append(path)
+    )
+
+    dialog.open_folder_btn.click()
+
+    assert opened == [directory]
+
+
 def test_one_failed_delete_does_not_strand_the_rest(
     qapp: Any,
     working_dir: Path,

--- a/tests/test_frontend/test_load_job_dialog.py
+++ b/tests/test_frontend/test_load_job_dialog.py
@@ -268,3 +268,29 @@ def test_state_column_carries_an_icon(
     dialog = LoadJobDialog("default")
 
     assert not dialog.job_tree.topLevelItem(0).icon(5).isNull()
+
+
+def test_the_state_icon_is_chosen_by_the_job_s_own_state(
+    qapp: Any, working_dir: Path, patched_working_dirs: None
+) -> None:
+    """A non-null icon on one row proves only that *an* icon was set.
+
+    Setting the same icon on every row unconditionally would satisfy that, so
+    what pins the conditional is the two states resolving to different icons.
+    `QIcon.cacheKey()` is equal for references to one icon and differs between
+    distinct ones, which is exactly the distinction needed here.
+    """
+    _save(working_dir, "ready", prepared=True)
+    _save(working_dir, "draft", prepared=False)
+    dialog = LoadJobDialog("default")
+
+    rows = {
+        dialog.job_tree.topLevelItem(index).text(0): dialog.job_tree.topLevelItem(index)
+        for index in range(dialog.job_tree.topLevelItemCount())
+    }
+    ready_icon = rows["ready"].icon(5)
+    draft_icon = rows["draft"].icon(5)
+
+    assert not ready_icon.isNull()
+    assert not draft_icon.isNull()
+    assert ready_icon.cacheKey() != draft_icon.cacheKey()

--- a/tests/test_frontend/test_load_job_dialog.py
+++ b/tests/test_frontend/test_load_job_dialog.py
@@ -5,6 +5,7 @@ tested here is the dialog itself.
 """
 
 from pathlib import Path
+import re
 import time
 from typing import Any
 
@@ -310,6 +311,38 @@ def test_a_mixed_selection_explains_why_the_queue_is_unavailable(
 
     assert not dialog.add_to_queue_btn.isEnabled()
     assert "not prepared" in dialog.status_lbl.text()
+
+
+def test_selection_hint_counts_a_doubly_blocked_job_once(
+    qapp: Any, working_dir: Path, patched_working_dirs: None
+) -> None:
+    """`unprepared` and `other_config` are counted independently, so a job
+    matching both reasons used to be counted in each -- one problem job read
+    as two. The headline now counts blocked jobs once, with the per-reason
+    counts kept only as a breakdown, so no number in the message can exceed
+    the number of jobs actually selected.
+
+    A selection of exactly one such job cannot exercise this: `_selection_hint`
+    special-cases a size-one selection before reaching the reason-counting
+    code below, reporting the profile mismatch instead of the reasons list.
+    Reaching the code under test needs at least one other job alongside it.
+    """
+    _save(working_dir, "problem", prepared=False, profile="anime")
+    _save(working_dir, "fine", prepared=True, profile="default")
+    dialog = _open_dialog(qapp)
+    dialog.only_this_config.setChecked(False)
+    dialog.job_tree.selectAll()
+    selected = dialog._selected_listings()
+    assert len(selected) == 2
+
+    hint = dialog._selection_hint()
+
+    assert hint == (
+        "2 selected; 1 cannot be added to the queue (1 not prepared, "
+        "1 on another config). A queue has nobody to answer a prompt."
+    )
+    for number in re.findall(r"\d+", hint):
+        assert int(number) <= len(selected)
 
 
 def test_a_cross_profile_selection_says_which_config_it_needs(

--- a/tests/test_frontend/test_load_job_dialog.py
+++ b/tests/test_frontend/test_load_job_dialog.py
@@ -4,6 +4,7 @@ The save/resume round trip is covered in `test_job_save_resume.py`; what is
 tested here is the dialog itself.
 """
 
+from datetime import datetime
 from pathlib import Path
 import re
 import time
@@ -1838,3 +1839,36 @@ def test_stop_loader_tolerates_a_loader_whose_c_plus_plus_object_is_gone(
     dialog._stop_loader()
 
     assert dialog._loader is None
+
+
+# --------------------------------------------------------------------------
+# _saved_text: renders the stored UTC timestamp in local time for the
+# "Saved" column and the details pane. Local time is not controllable
+# cross-platform in this test suite (no `time.tzset()` on Windows), so these
+# assertions are written to hold regardless of the runner's zone rather than
+# pinning a literal rendered string.
+# --------------------------------------------------------------------------
+
+
+def test_saved_text_format_is_pinned() -> None:
+    rendered = LoadJobDialog._saved_text("2026-01-01T00:00:00+00:00")
+
+    assert re.fullmatch(r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}", rendered)
+
+
+def test_saved_text_preserves_the_instant() -> None:
+    """Timezone-independent: compares the instant the rendering represents
+    against the instant that went in, not the wall-clock text -- which would
+    only match on a UTC runner. The one-minute tolerance is because the
+    format drops seconds.
+    """
+    raw = "2026-01-01T00:00:00+00:00"
+
+    rendered = LoadJobDialog._saved_text(raw)
+
+    parsed = datetime.strptime(rendered, "%Y-%m-%d %H:%M").astimezone()
+    assert abs((parsed - datetime.fromisoformat(raw)).total_seconds()) < 60
+
+
+def test_saved_text_falls_back_to_the_input_verbatim_when_unparseable() -> None:
+    assert LoadJobDialog._saved_text("not a date") == "not a date"

--- a/tests/test_frontend/test_load_job_dialog.py
+++ b/tests/test_frontend/test_load_job_dialog.py
@@ -394,10 +394,16 @@ def test_one_failed_delete_does_not_strand_the_rest(
     every job after the first failure sitting on disk while the user is told
     only about the one that failed. Nothing else in the suite would notice.
     """
-    fails_dir = _save(working_dir, "unlucky")
-    succeeds_dir = _save(working_dir, "fine")
+    # Explicit timestamps, because the order matters: the failing job must be
+    # processed FIRST for this test to catch a `break` after the failure. Left
+    # to `_save`'s default both land in the same second, and `list_jobs` then
+    # tie-breaks on the random shortuuid directory name -- so the guard would
+    # only catch the mutation on roughly half of runs.
+    fails_dir = _save(working_dir, "unlucky", created_at="2026-06-01T00:00:00+00:00")
+    succeeds_dir = _save(working_dir, "fine", created_at="2026-01-01T00:00:00+00:00")
     dialog = LoadJobDialog("default")
     dialog.job_tree.selectAll()
+    assert dialog.job_tree.topLevelItem(0).text(0) == "unlucky"
 
     real_delete = load_job_dialog_module.delete_job
 

--- a/tests/test_frontend/test_load_job_dialog.py
+++ b/tests/test_frontend/test_load_job_dialog.py
@@ -374,6 +374,14 @@ def test_delete_only_removes_the_selected_job(
     kept_dir = _save(working_dir, "keep")
     _save(working_dir, "remove")
     dialog = _open_dialog(qapp)
+    # `_on_listings_loaded` already leaves row 0 selected via `setCurrentItem`.
+    # Without clearing it first, `setSelected(True)` below only *adds* "remove"
+    # to that selection -- and this test happens to pass regardless, because
+    # both jobs tie on the "Saved" column and "remove" is the one the tie
+    # lands on row 0. That is not something this test states or controls, so
+    # renaming either fixture job would make the tie-break, not the targeting
+    # logic, decide whether it passes.
+    dialog.job_tree.clearSelection()
     item = dialog.job_tree.findItems("remove", Qt.MatchFlag.MatchExactly, 0)[0]
     item.setSelected(True)
     monkeypatch.setattr(

--- a/tests/test_frontend/test_load_job_dialog.py
+++ b/tests/test_frontend/test_load_job_dialog.py
@@ -882,6 +882,43 @@ def test_renaming_rewrites_only_the_name(
     assert dialog.job_tree.topLevelItem(0).text(0) == "new name"
 
 
+def test_a_failed_rename_reports_the_job_by_name(
+    qapp: Any,
+    working_dir: Path,
+    patched_working_dirs: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Delete's failure path names each job it could not remove -- see
+    `test_one_failed_delete_does_not_strand_the_rest`. Rename's used to say
+    only that "job" failed, leaving a user with several jobs open no way to
+    tell which one broke.
+    """
+    _save(working_dir, "old name")
+    dialog = _open_dialog(qapp)
+    dialog.job_tree.setCurrentItem(dialog.job_tree.topLevelItem(0))
+    dialog.job_tree.topLevelItem(0).setSelected(True)
+    monkeypatch.setattr(
+        load_job_dialog_module.QInputDialog,
+        "getText",
+        staticmethod(lambda *_a, **_k: ("new name", True)),
+    )
+
+    def flaky_write(*_a: Any, **_k: Any) -> None:
+        raise load_job_dialog_module.JobStoreError("disk said no")
+
+    monkeypatch.setattr(load_job_dialog_module, "write_job_document", flaky_write)
+    reported: list[str] = []
+    monkeypatch.setattr(
+        load_job_dialog_module.QMessageBox,
+        "critical",
+        lambda _parent, _title, text, *_a, **_k: reported.append(text),
+    )
+
+    dialog._rename_selected()
+
+    assert reported and "old name" in reported[0]
+
+
 def test_a_rename_refreshes_the_cached_details_pane_text(
     qapp: Any,
     working_dir: Path,

--- a/tests/test_frontend/test_load_job_dialog.py
+++ b/tests/test_frontend/test_load_job_dialog.py
@@ -5,6 +5,7 @@ tested here is the dialog itself.
 """
 
 from pathlib import Path
+import time
 from typing import Any
 
 from PySide6.QtCore import QItemSelectionModel, Qt
@@ -55,11 +56,45 @@ def _save(
     return store.save_job(job, working_dir)
 
 
+def _open_dialog(qapp: Any, active_profile: str | None = "default") -> LoadJobDialog:
+    """Construct the dialog and wait for its background listing load to land.
+
+    Listing now happens on a `_ListingLoader` thread, so a dialog fresh out of
+    `__init__` has an empty tree until that thread's `loaded` signal is
+    delivered. Every test below except the three under "loading is
+    asynchronous" is about what happens once the list has arrived, not about
+    the loading itself -- for those, waiting once here is the right fix, not
+    a wait bolted into each test.
+
+    Waiting here also keeps the loader thread from still being alive when the
+    test function returns and the dialog is dropped: destroying a running
+    `QThread` aborts the process outright, and this is the one place where
+    that would be silent since nothing here calls `wait()` afterwards.
+    """
+    dialog = LoadJobDialog(active_profile)
+    _wait_for_load(dialog, qapp)
+    return dialog
+
+
+def _wait_for_load(dialog: LoadJobDialog, qapp: Any) -> None:
+    """Block until the dialog's current loader thread has finished and let
+    its queued `loaded` signal reach `_on_listings_loaded` on this thread.
+
+    Also used after `_delete_selected` / `_rename_selected`, which now kick
+    off a fresh reload asynchronously -- calling it even when a particular
+    action returned early (and so never reloaded) is harmless, since waiting
+    on an already-finished thread returns immediately.
+    """
+    assert dialog._loader is not None
+    dialog._loader.wait(5000)
+    qapp.processEvents()
+
+
 def test_columns_are_sized_for_what_they_hold(
     qapp: Any, working_dir: Path, patched_working_dirs: None
 ) -> None:
     _save(working_dir, "job")
-    dialog = LoadJobDialog("default")
+    dialog = _open_dialog(qapp)
     header = dialog.job_tree.header()
 
     assert header.sectionResizeMode(0) is QHeaderView.ResizeMode.Stretch
@@ -72,7 +107,7 @@ def test_the_full_tracker_list_is_available_as_a_tooltip(
     qapp: Any, working_dir: Path, patched_working_dirs: None
 ) -> None:
     _save(working_dir, "job", trackers=["Aither", "Huno", "LST", "DarkPeers"])
-    dialog = LoadJobDialog("default")
+    dialog = _open_dialog(qapp)
 
     assert "DarkPeers" in dialog.job_tree.topLevelItem(0).toolTip(3)
 
@@ -88,7 +123,7 @@ def test_the_list_opens_sorted_newest_first(
     """
     _save(working_dir, "older", created_at="2026-01-01T00:00:00+00:00")
     _save(working_dir, "newer", created_at="2026-06-01T00:00:00+00:00")
-    dialog = LoadJobDialog("default")
+    dialog = _open_dialog(qapp)
 
     header = dialog.job_tree.header()
     assert dialog.job_tree.isSortingEnabled()
@@ -107,7 +142,7 @@ def test_the_list_can_be_re_sorted_by_another_column(
     """
     _save(working_dir, "zulu", created_at="2026-06-01T00:00:00+00:00")
     _save(working_dir, "alpha", created_at="2026-01-01T00:00:00+00:00")
-    dialog = LoadJobDialog("default")
+    dialog = _open_dialog(qapp)
 
     dialog.job_tree.sortByColumn(0, Qt.SortOrder.AscendingOrder)
 
@@ -120,7 +155,7 @@ def test_the_list_can_be_re_sorted_by_another_column(
 def test_the_dialog_can_be_resized_from_its_corner(
     qapp: Any, working_dir: Path, patched_working_dirs: None
 ) -> None:
-    dialog = LoadJobDialog("default")
+    dialog = _open_dialog(qapp)
 
     assert dialog.isSizeGripEnabled()
 
@@ -128,7 +163,7 @@ def test_the_dialog_can_be_resized_from_its_corner(
 def test_the_info_label_does_not_repeat_the_window_title(
     qapp: Any, working_dir: Path, patched_working_dirs: None
 ) -> None:
-    dialog = LoadJobDialog("default")
+    dialog = _open_dialog(qapp)
 
     assert dialog.windowTitle() == "Saved Jobs"
     assert "<h3" not in dialog.info_lbl.text()
@@ -139,7 +174,7 @@ def test_filtering_matches_name_title_and_tracker(
 ) -> None:
     _save(working_dir, "alpha", title="Alpha Movie", trackers=["Aither"])
     _save(working_dir, "beta", title="Beta Movie", trackers=["Huno"])
-    dialog = LoadJobDialog("default")
+    dialog = _open_dialog(qapp)
 
     dialog.filter_edit.setText("huno")
 
@@ -156,7 +191,7 @@ def test_only_this_config_hides_other_profiles_by_default(
 ) -> None:
     _save(working_dir, "mine", profile="default")
     _save(working_dir, "theirs", profile="anime")
-    dialog = LoadJobDialog("default")
+    dialog = _open_dialog(qapp)
 
     assert dialog.only_this_config.isChecked()
     hidden = {
@@ -171,7 +206,7 @@ def test_unchecking_only_this_config_reveals_other_profiles(
     qapp: Any, working_dir: Path, patched_working_dirs: None
 ) -> None:
     _save(working_dir, "theirs", profile="anime")
-    dialog = LoadJobDialog("default")
+    dialog = _open_dialog(qapp)
 
     dialog.only_this_config.setChecked(False)
 
@@ -183,7 +218,7 @@ def test_hiding_a_row_also_deselects_it(
 ) -> None:
     """A hidden row left selected would silently take part in Load or Delete."""
     _save(working_dir, "alpha")
-    dialog = LoadJobDialog("default")
+    dialog = _open_dialog(qapp)
     dialog.job_tree.topLevelItem(0).setSelected(True)
 
     dialog.filter_edit.setText("nothing matches this")
@@ -205,7 +240,7 @@ def test_a_row_hidden_while_selected_does_not_come_back_selected(
     """
     _save(working_dir, "alpha")
     _save(working_dir, "beta")
-    dialog = LoadJobDialog("default")
+    dialog = _open_dialog(qapp)
     for index in range(dialog.job_tree.topLevelItemCount()):
         dialog.job_tree.topLevelItem(index).setSelected(True)
 
@@ -230,7 +265,7 @@ def test_a_mixed_selection_explains_why_the_queue_is_unavailable(
     """
     _save(working_dir, "ready", prepared=True)
     _save(working_dir, "not-ready", prepared=False)
-    dialog = LoadJobDialog("default")
+    dialog = _open_dialog(qapp)
     dialog.job_tree.selectAll()
 
     assert not dialog.add_to_queue_btn.isEnabled()
@@ -241,7 +276,7 @@ def test_a_cross_profile_selection_says_which_config_it_needs(
     qapp: Any, working_dir: Path, patched_working_dirs: None
 ) -> None:
     _save(working_dir, "theirs", profile="anime")
-    dialog = LoadJobDialog("default")
+    dialog = _open_dialog(qapp)
     dialog.only_this_config.setChecked(False)
     dialog.job_tree.topLevelItem(0).setSelected(True)
     dialog.job_tree.setCurrentItem(dialog.job_tree.topLevelItem(0))
@@ -254,7 +289,7 @@ def test_double_clicking_a_cross_profile_row_offers_the_switch(
 ) -> None:
     """Silently doing nothing is the current behaviour and the worst option."""
     _save(working_dir, "theirs", profile="anime")
-    dialog = LoadJobDialog("default")
+    dialog = _open_dialog(qapp)
     dialog.only_this_config.setChecked(False)
     item = dialog.job_tree.topLevelItem(0)
     dialog.job_tree.setCurrentItem(item)
@@ -269,7 +304,7 @@ def test_state_column_carries_an_icon(
     qapp: Any, working_dir: Path, patched_working_dirs: None
 ) -> None:
     _save(working_dir, "job", prepared=True)
-    dialog = LoadJobDialog("default")
+    dialog = _open_dialog(qapp)
 
     assert not dialog.job_tree.topLevelItem(0).icon(5).isNull()
 
@@ -286,7 +321,7 @@ def test_the_state_icon_is_chosen_by_the_job_s_own_state(
     """
     _save(working_dir, "ready", prepared=True)
     _save(working_dir, "draft", prepared=False)
-    dialog = LoadJobDialog("default")
+    dialog = _open_dialog(qapp)
 
     rows = {
         dialog.job_tree.topLevelItem(index).text(0): dialog.job_tree.topLevelItem(index)
@@ -308,7 +343,7 @@ def test_delete_removes_every_selected_job(
 ) -> None:
     _save(working_dir, "one")
     _save(working_dir, "two")
-    dialog = LoadJobDialog("default")
+    dialog = _open_dialog(qapp)
     dialog.job_tree.selectAll()
     monkeypatch.setattr(
         load_job_dialog_module.QMessageBox,
@@ -317,6 +352,7 @@ def test_delete_removes_every_selected_job(
     )
 
     dialog._delete_selected()
+    _wait_for_load(dialog, qapp)
 
     assert dialog.job_tree.topLevelItemCount() == 0
     assert list((working_dir / "jobs").iterdir()) == []
@@ -337,7 +373,7 @@ def test_delete_only_removes_the_selected_job(
     """
     kept_dir = _save(working_dir, "keep")
     _save(working_dir, "remove")
-    dialog = LoadJobDialog("default")
+    dialog = _open_dialog(qapp)
     item = dialog.job_tree.findItems("remove", Qt.MatchFlag.MatchExactly, 0)[0]
     item.setSelected(True)
     monkeypatch.setattr(
@@ -347,6 +383,7 @@ def test_delete_only_removes_the_selected_job(
     )
 
     dialog._delete_selected()
+    _wait_for_load(dialog, qapp)
 
     assert kept_dir.exists()
     assert [
@@ -363,7 +400,7 @@ def test_the_delete_confirmation_names_what_it_will_remove(
 ) -> None:
     _save(working_dir, "alpha")
     _save(working_dir, "beta")
-    dialog = LoadJobDialog("default")
+    dialog = _open_dialog(qapp)
     dialog.job_tree.selectAll()
     asked: list[str] = []
 
@@ -374,6 +411,7 @@ def test_the_delete_confirmation_names_what_it_will_remove(
     monkeypatch.setattr(load_job_dialog_module.QMessageBox, "question", capture)
 
     dialog._delete_selected()
+    _wait_for_load(dialog, qapp)
 
     assert "alpha" in asked[0] and "beta" in asked[0]
 
@@ -381,7 +419,7 @@ def test_the_delete_confirmation_names_what_it_will_remove(
 def test_the_delete_key_is_wired_to_delete(
     qapp: Any, working_dir: Path, patched_working_dirs: None
 ) -> None:
-    dialog = LoadJobDialog("default")
+    dialog = _open_dialog(qapp)
 
     assert dialog.delete_btn.shortcut() == Qt.Key.Key_Delete
 
@@ -389,7 +427,7 @@ def test_the_delete_key_is_wired_to_delete(
 def test_the_f2_key_is_wired_to_rename(
     qapp: Any, working_dir: Path, patched_working_dirs: None
 ) -> None:
-    dialog = LoadJobDialog("default")
+    dialog = _open_dialog(qapp)
 
     assert dialog.rename_btn.shortcut() == Qt.Key.Key_F2
 
@@ -404,7 +442,7 @@ def test_a_job_with_missing_media_is_marked_in_the_list(
         config_profile="default",
     )
     store.save_job(job, working_dir)
-    dialog = LoadJobDialog("default")
+    dialog = _open_dialog(qapp)
 
     item = dialog.job_tree.topLevelItem(0)
     assert not item.icon(0).isNull()
@@ -469,7 +507,7 @@ def test_the_details_pane_describes_the_selected_job(
     decoy.created_at = "2020-06-01T00:00:00+00:00"
     store.save_job(decoy, working_dir)
 
-    dialog = LoadJobDialog("default")
+    dialog = _open_dialog(qapp)
     item = dialog.job_tree.findItems("Example", Qt.MatchFlag.MatchExactly, 0)[0]
     dialog.job_tree.setCurrentItem(item)
 
@@ -494,7 +532,7 @@ def test_the_details_pane_describes_the_selected_job(
 def test_the_details_pane_is_cleared_when_nothing_is_selected(
     qapp: Any, working_dir: Path, patched_working_dirs: None
 ) -> None:
-    dialog = LoadJobDialog("default")
+    dialog = _open_dialog(qapp)
 
     assert dialog.details_lbl.text() == ""
     assert not dialog.open_folder_btn.isEnabled()
@@ -510,7 +548,7 @@ def test_the_details_pane_clears_once_a_selection_is_lost(
     exercises that path.
     """
     _save(working_dir, "alpha")
-    dialog = LoadJobDialog("default")
+    dialog = _open_dialog(qapp)
     dialog.job_tree.setCurrentItem(dialog.job_tree.topLevelItem(0))
     assert dialog.details_lbl.text() != ""
     assert dialog.open_folder_btn.isEnabled()
@@ -531,7 +569,7 @@ def test_the_details_pane_escapes_html_in_a_job_s_name(
     class of bug twice, for the log pane and the save-confirmation box.
     """
     _save(working_dir, "<b>evil</b> & friends")
-    dialog = LoadJobDialog("default")
+    dialog = _open_dialog(qapp)
     dialog.job_tree.setCurrentItem(dialog.job_tree.topLevelItem(0))
 
     text = dialog.details_lbl.text()
@@ -564,7 +602,7 @@ def test_a_retired_tracker_name_in_the_document_does_not_crash_the_pane(
         config_profile="default",
     )
     store.save_job(job, working_dir)
-    dialog = LoadJobDialog("default")
+    dialog = _open_dialog(qapp)
     dialog.job_tree.setCurrentItem(dialog.job_tree.topLevelItem(0))
 
     assert "RETIRED_TRACKER" in dialog.details_lbl.text()
@@ -583,7 +621,7 @@ def test_an_unreadable_job_does_not_break_the_details_pane(
         working_dir,
     )
     (directory / store.JOB_DOCUMENT_NAME).write_text("not json", encoding="utf-8")
-    dialog = LoadJobDialog("default")
+    dialog = _open_dialog(qapp)
 
     # listing skips unreadable jobs, so add the row by hand to exercise the pane
     from src.backend.jobs.models import JobListing
@@ -623,7 +661,7 @@ def test_the_open_folder_button_opens_the_selected_job_s_directory(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     directory = _save(working_dir, "job")
-    dialog = LoadJobDialog("default")
+    dialog = _open_dialog(qapp)
     dialog.job_tree.setCurrentItem(dialog.job_tree.topLevelItem(0))
     assert dialog.open_folder_btn.isEnabled()
 
@@ -644,7 +682,7 @@ def test_renaming_rewrites_only_the_name(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     directory = _save(working_dir, "old name", trackers=["Aither"])
-    dialog = LoadJobDialog("default")
+    dialog = _open_dialog(qapp)
     dialog.job_tree.setCurrentItem(dialog.job_tree.topLevelItem(0))
     dialog.job_tree.topLevelItem(0).setSelected(True)
     monkeypatch.setattr(
@@ -654,6 +692,7 @@ def test_renaming_rewrites_only_the_name(
     )
 
     dialog._rename_selected()
+    _wait_for_load(dialog, qapp)
 
     reloaded = store.load_job(directory)
     assert reloaded.name == "new name"
@@ -668,7 +707,7 @@ def test_cancelling_the_rename_changes_nothing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     directory = _save(working_dir, "keep me")
-    dialog = LoadJobDialog("default")
+    dialog = _open_dialog(qapp)
     dialog.job_tree.setCurrentItem(dialog.job_tree.topLevelItem(0))
     dialog.job_tree.topLevelItem(0).setSelected(True)
     monkeypatch.setattr(
@@ -678,6 +717,7 @@ def test_cancelling_the_rename_changes_nothing(
     )
 
     dialog._rename_selected()
+    _wait_for_load(dialog, qapp)
 
     assert store.load_job(directory).name == "keep me"
 
@@ -696,7 +736,7 @@ def test_an_empty_new_name_is_refused(
     writes `name: ""` to disk, with nothing failing.
     """
     directory = _save(working_dir, "keep me")
-    dialog = LoadJobDialog("default")
+    dialog = _open_dialog(qapp)
     dialog.job_tree.setCurrentItem(dialog.job_tree.topLevelItem(0))
     dialog.job_tree.topLevelItem(0).setSelected(True)
     monkeypatch.setattr(
@@ -706,6 +746,7 @@ def test_an_empty_new_name_is_refused(
     )
 
     dialog._rename_selected()
+    _wait_for_load(dialog, qapp)
 
     assert store.load_job(directory).name == "keep me"
 
@@ -727,7 +768,7 @@ def test_rename_targets_the_selected_job_not_the_current_row(
     other_dir = _save(
         working_dir, "merely current", created_at="2026-01-01T00:00:00+00:00"
     )
-    dialog = LoadJobDialog("default")
+    dialog = _open_dialog(qapp)
 
     selected_row = dialog.job_tree.topLevelItem(0)
     current_row = dialog.job_tree.topLevelItem(1)
@@ -746,6 +787,7 @@ def test_rename_targets_the_selected_job_not_the_current_row(
     )
 
     dialog._rename_selected()
+    _wait_for_load(dialog, qapp)
 
     assert store.load_job(keep_dir).name == "renamed"
     assert store.load_job(other_dir).name == "merely current"
@@ -756,7 +798,7 @@ def test_rename_is_only_available_for_one_job(
 ) -> None:
     _save(working_dir, "one")
     _save(working_dir, "two")
-    dialog = LoadJobDialog("default")
+    dialog = _open_dialog(qapp)
     dialog.job_tree.selectAll()
 
     assert not dialog.rename_btn.isEnabled()
@@ -781,7 +823,7 @@ def test_one_failed_delete_does_not_strand_the_rest(
     # only catch the mutation on roughly half of runs.
     fails_dir = _save(working_dir, "unlucky", created_at="2026-06-01T00:00:00+00:00")
     succeeds_dir = _save(working_dir, "fine", created_at="2026-01-01T00:00:00+00:00")
-    dialog = LoadJobDialog("default")
+    dialog = _open_dialog(qapp)
     dialog.job_tree.selectAll()
     assert dialog.job_tree.topLevelItem(0).text(0) == "unlucky"
 
@@ -806,6 +848,7 @@ def test_one_failed_delete_does_not_strand_the_rest(
     )
 
     dialog._delete_selected()
+    _wait_for_load(dialog, qapp)
 
     assert fails_dir.exists()
     assert not succeeds_dir.exists()
@@ -820,7 +863,7 @@ def test_only_a_runnable_job_can_be_added_to_the_queue(
 ) -> None:
     _save(working_dir, "ready", prepared=True)
     _save(working_dir, "not-ready", prepared=False)
-    dialog = LoadJobDialog("default")
+    dialog = _open_dialog(qapp)
     dialog.job_tree.selectAll()
 
     assert not dialog.add_to_queue_btn.isEnabled()
@@ -837,7 +880,7 @@ def test_only_prepared_jobs_on_this_config_can_be_added_to_the_queue(
     _save(working_dir, "ready", prepared=True, profile="config")
     _save(working_dir, "raw", prepared=False, profile="config")
     _save(working_dir, "other-config", prepared=True, profile="anime")
-    dialog = LoadJobDialog("config")
+    dialog = _open_dialog(qapp, "config")
     dialog.only_this_config.setChecked(False)
     dialog.job_tree.selectAll()
 
@@ -860,7 +903,7 @@ def test_adding_jobs_builds_a_queue_in_click_order(
     """
     _save(working_dir, "first", created_at="2026-01-01T00:00:00+00:00")
     _save(working_dir, "second", created_at="2026-06-01T00:00:00+00:00")
-    dialog = LoadJobDialog("default")
+    dialog = _open_dialog(qapp)
     # `_load_listings` leaves row 0 selected as the initial current item;
     # clear it so only the row picked below is selected on the first add.
     dialog.job_tree.clearSelection()
@@ -881,7 +924,7 @@ def test_a_job_cannot_be_queued_twice(
     qapp: Any, working_dir: Path, patched_working_dirs: None
 ) -> None:
     _save(working_dir, "once")
-    dialog = LoadJobDialog("default")
+    dialog = _open_dialog(qapp)
     dialog.job_tree.topLevelItem(0).setSelected(True)
 
     dialog._add_to_queue()
@@ -902,7 +945,7 @@ def test_a_queued_job_can_be_moved_up(
     """
     _save(working_dir, "a", created_at="2026-01-01T00:00:00+00:00")
     _save(working_dir, "b", created_at="2026-06-01T00:00:00+00:00")
-    dialog = LoadJobDialog("default")
+    dialog = _open_dialog(qapp)
     dialog.job_tree.topLevelItem(0).setSelected(True)
     dialog._add_to_queue()
     dialog.job_tree.clearSelection()
@@ -920,7 +963,7 @@ def test_removing_from_the_queue_leaves_the_job_saved(
     qapp: Any, working_dir: Path, patched_working_dirs: None
 ) -> None:
     directory = _save(working_dir, "keep")
-    dialog = LoadJobDialog("default")
+    dialog = _open_dialog(qapp)
     dialog.job_tree.topLevelItem(0).setSelected(True)
     dialog._add_to_queue()
     dialog.queue_list.setCurrentRow(0)
@@ -935,7 +978,7 @@ def test_run_queue_needs_a_queue(
     qapp: Any, working_dir: Path, patched_working_dirs: None
 ) -> None:
     _save(working_dir, "ready")
-    dialog = LoadJobDialog("default")
+    dialog = _open_dialog(qapp)
 
     assert not dialog.queue_btn.isEnabled()
 
@@ -950,7 +993,7 @@ def test_adding_prepared_jobs_enables_the_queue_and_accept_queue_reports_them(
 ) -> None:
     _save(working_dir, "ready-one", prepared=True, profile="config")
     _save(working_dir, "ready-two", prepared=True, profile="config")
-    dialog = LoadJobDialog("config")
+    dialog = _open_dialog(qapp, "config")
     dialog.job_tree.selectAll()
 
     dialog._add_to_queue()
@@ -978,7 +1021,7 @@ def test_deleting_a_queued_job_takes_it_out_of_the_queue(
     """
     _save(working_dir, "doomed", created_at="2026-01-01T00:00:00+00:00")
     _save(working_dir, "survivor", created_at="2026-06-01T00:00:00+00:00")
-    dialog = LoadJobDialog("default")
+    dialog = _open_dialog(qapp)
     dialog.job_tree.selectAll()
     dialog._add_to_queue()
     doomed_item = dialog.job_tree.findItems("doomed", Qt.MatchFlag.MatchExactly, 0)[0]
@@ -991,6 +1034,7 @@ def test_deleting_a_queued_job_takes_it_out_of_the_queue(
     )
 
     dialog._delete_selected()
+    _wait_for_load(dialog, qapp)
 
     assert dialog.queue_list.count() == 1
     assert [listing.name for listing in dialog.queueable_listings()] == ["survivor"]
@@ -1010,7 +1054,7 @@ def test_a_failed_delete_leaves_its_queue_entry_in_place(
     """
     stuck_dir = _save(working_dir, "stuck", created_at="2026-01-01T00:00:00+00:00")
     _save(working_dir, "goes", created_at="2026-06-01T00:00:00+00:00")
-    dialog = LoadJobDialog("default")
+    dialog = _open_dialog(qapp)
     dialog.job_tree.selectAll()
     dialog._add_to_queue()
 
@@ -1035,6 +1079,92 @@ def test_a_failed_delete_leaves_its_queue_entry_in_place(
     )
 
     dialog._delete_selected()
+    _wait_for_load(dialog, qapp)
 
     assert [listing.name for listing in dialog.queueable_listings()] == ["stuck"]
     assert reported and "stuck" in reported[0]
+
+
+# --------------------------------------------------------------------------
+# loading is asynchronous
+# --------------------------------------------------------------------------
+def test_the_list_starts_empty_and_says_it_is_loading(
+    qapp: Any, working_dir: Path, patched_working_dirs: None
+) -> None:
+    """Constructing the dialog must not block on `list_jobs` -- that call is
+    what stalls visibly on a network share, so the tree has to start empty
+    with a placeholder rather than already populated.
+    """
+    _save(working_dir, "job")
+    dialog = LoadJobDialog("default")
+
+    assert dialog.job_tree.topLevelItemCount() == 0
+    assert "Loading" in dialog.empty_lbl.text()
+    assert dialog.empty_lbl.isVisible() or not dialog.isVisible()
+
+    # Nothing above depends on this: it only lets the loader thread `__init__`
+    # started finish before `dialog` goes out of scope. Destroying a `QThread`
+    # while it is still running aborts the process, not just this test.
+    _wait_for_load(dialog, qapp)
+
+
+def test_listings_populate_the_tree_when_they_arrive(
+    qapp: Any, working_dir: Path, patched_working_dirs: None
+) -> None:
+    _save(working_dir, "job")
+    dialog = LoadJobDialog("default")
+
+    _wait_for_load(dialog, qapp)
+
+    assert dialog.job_tree.topLevelItemCount() == 1
+    assert dialog.job_tree.topLevelItem(0).text(0) == "job"
+
+
+def test_an_empty_working_directory_reports_no_jobs(
+    qapp: Any, working_dir: Path, patched_working_dirs: None
+) -> None:
+    dialog = LoadJobDialog("default")
+
+    _wait_for_load(dialog, qapp)
+
+    assert "No saved jobs yet" in dialog.empty_lbl.text()
+
+
+def test_closing_mid_load_waits_for_the_loader_before_tearing_down(
+    qapp: Any,
+    working_dir: Path,
+    patched_working_dirs: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`done()` exists purely because destroying a running `QThread` aborts
+    the process outright, so what needs proving is that closing the dialog
+    actually blocks until the loader has finished -- not merely that
+    `reject()` did not raise. A real sleep in `run()` (on the loader's own
+    OS thread, so it does not block this test) makes "still running when the
+    user closes the dialog" the case being exercised, rather than a race that
+    happens to resolve one way on a given machine.
+    """
+    _save(working_dir, "job")
+    original_run = load_job_dialog_module._ListingLoader.run
+
+    def slow_run(self: Any) -> None:
+        time.sleep(0.4)
+        original_run(self)
+
+    monkeypatch.setattr(load_job_dialog_module._ListingLoader, "run", slow_run)
+
+    dialog = LoadJobDialog("default")
+    assert dialog._loader is not None
+    assert dialog._loader.isRunning()
+
+    dialog.reject()
+
+    # If `done()` merely disconnected the signal and returned without ever
+    # calling `wait()`, the loader would still be mid-sleep here.
+    assert dialog._loader.isRunning() is False
+    # And if the disconnect happened after (or not at all), the loader's
+    # `loaded` signal -- queued for delivery once the sleep ends -- would
+    # still land on a dialog that is closing, repopulating a tree nobody is
+    # looking at.
+    qapp.processEvents()
+    assert dialog.job_tree.topLevelItemCount() == 0

--- a/tests/test_frontend/test_load_job_dialog.py
+++ b/tests/test_frontend/test_load_job_dialog.py
@@ -994,3 +994,47 @@ def test_deleting_a_queued_job_takes_it_out_of_the_queue(
 
     assert dialog.queue_list.count() == 1
     assert [listing.name for listing in dialog.queueable_listings()] == ["survivor"]
+
+
+def test_a_failed_delete_leaves_its_queue_entry_in_place(
+    qapp: Any,
+    working_dir: Path,
+    patched_working_dirs: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A delete that raises must not also drop its queue entry -- the job is
+    untouched on disk and still perfectly runnable, so losing its queue
+    position would be an undisclosed side effect of an operation that never
+    happened. Only the job whose delete actually succeeded should leave the
+    queue.
+    """
+    stuck_dir = _save(working_dir, "stuck", created_at="2026-01-01T00:00:00+00:00")
+    _save(working_dir, "goes", created_at="2026-06-01T00:00:00+00:00")
+    dialog = LoadJobDialog("default")
+    dialog.job_tree.selectAll()
+    dialog._add_to_queue()
+
+    real_delete = load_job_dialog_module.delete_job
+
+    def flaky(path: Path) -> None:
+        if path == stuck_dir:
+            raise load_job_dialog_module.JobStoreError("disk said no")
+        real_delete(path)
+
+    reported: list[str] = []
+    monkeypatch.setattr(load_job_dialog_module, "delete_job", flaky)
+    monkeypatch.setattr(
+        load_job_dialog_module.QMessageBox,
+        "question",
+        lambda *_a, **_k: load_job_dialog_module.QMessageBox.StandardButton.Yes,
+    )
+    monkeypatch.setattr(
+        load_job_dialog_module.QMessageBox,
+        "critical",
+        lambda _parent, _title, text, *_a, **_k: reported.append(text),
+    )
+
+    dialog._delete_selected()
+
+    assert [listing.name for listing in dialog.queueable_listings()] == ["stuck"]
+    assert reported and "stuck" in reported[0]

--- a/tests/test_frontend/test_load_job_dialog.py
+++ b/tests/test_frontend/test_load_job_dialog.py
@@ -382,6 +382,14 @@ def test_the_delete_key_is_wired_to_delete(
     assert dialog.delete_btn.shortcut() == Qt.Key.Key_Delete
 
 
+def test_the_f2_key_is_wired_to_rename(
+    qapp: Any, working_dir: Path, patched_working_dirs: None
+) -> None:
+    dialog = LoadJobDialog("default")
+
+    assert dialog.rename_btn.shortcut() == Qt.Key.Key_F2
+
+
 def test_a_job_with_missing_media_is_marked_in_the_list(
     qapp: Any, working_dir: Path, patched_working_dirs: None, tmp_path: Path
 ) -> None:
@@ -623,6 +631,62 @@ def test_the_open_folder_button_opens_the_selected_job_s_directory(
     dialog.open_folder_btn.click()
 
     assert opened == [directory]
+
+
+def test_renaming_rewrites_only_the_name(
+    qapp: Any,
+    working_dir: Path,
+    patched_working_dirs: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    directory = _save(working_dir, "old name", trackers=["Aither"])
+    dialog = LoadJobDialog("default")
+    dialog.job_tree.setCurrentItem(dialog.job_tree.topLevelItem(0))
+    dialog.job_tree.topLevelItem(0).setSelected(True)
+    monkeypatch.setattr(
+        load_job_dialog_module.QInputDialog,
+        "getText",
+        staticmethod(lambda *_a, **_k: ("new name", True)),
+    )
+
+    dialog._rename_selected()
+
+    reloaded = store.load_job(directory)
+    assert reloaded.name == "new name"
+    assert reloaded.summary.trackers == ["Aither"]
+    assert dialog.job_tree.topLevelItem(0).text(0) == "new name"
+
+
+def test_cancelling_the_rename_changes_nothing(
+    qapp: Any,
+    working_dir: Path,
+    patched_working_dirs: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    directory = _save(working_dir, "keep me")
+    dialog = LoadJobDialog("default")
+    dialog.job_tree.setCurrentItem(dialog.job_tree.topLevelItem(0))
+    dialog.job_tree.topLevelItem(0).setSelected(True)
+    monkeypatch.setattr(
+        load_job_dialog_module.QInputDialog,
+        "getText",
+        staticmethod(lambda *_a, **_k: ("", False)),
+    )
+
+    dialog._rename_selected()
+
+    assert store.load_job(directory).name == "keep me"
+
+
+def test_rename_is_only_available_for_one_job(
+    qapp: Any, working_dir: Path, patched_working_dirs: None
+) -> None:
+    _save(working_dir, "one")
+    _save(working_dir, "two")
+    dialog = LoadJobDialog("default")
+    dialog.job_tree.selectAll()
+
+    assert not dialog.rename_btn.isEnabled()
 
 
 def test_one_failed_delete_does_not_strand_the_rest(

--- a/tests/test_frontend/test_load_job_dialog.py
+++ b/tests/test_frontend/test_load_job_dialog.py
@@ -120,12 +120,24 @@ def test_the_list_opens_sorted_newest_first(
     `list_jobs` already returns newest-first, so checking row 0 proves nothing
     -- it passes with sorting switched off entirely. The sort indicator is what
     only `sortByColumn` can set.
+
+    Checked again after a reload (triggered the same way delete and rename
+    trigger one) because the flag and indicator are set by the populate path
+    on every call, not only by dialog construction.
     """
     _save(working_dir, "older", created_at="2026-01-01T00:00:00+00:00")
     _save(working_dir, "newer", created_at="2026-06-01T00:00:00+00:00")
     dialog = _open_dialog(qapp)
 
     header = dialog.job_tree.header()
+    assert dialog.job_tree.isSortingEnabled()
+    assert header.sortIndicatorSection() == 6
+    assert header.sortIndicatorOrder() is Qt.SortOrder.DescendingOrder
+    assert dialog.job_tree.topLevelItem(0).text(0) == "newer"
+
+    dialog._load_listings()
+    _wait_for_load(dialog, qapp)
+
     assert dialog.job_tree.isSortingEnabled()
     assert header.sortIndicatorSection() == 6
     assert header.sortIndicatorOrder() is Qt.SortOrder.DescendingOrder

--- a/tests/test_frontend/test_load_job_dialog.py
+++ b/tests/test_frontend/test_load_job_dialog.py
@@ -1047,6 +1047,42 @@ def test_accept_with_switch_targets_the_selected_job_not_the_current_row(
     assert dialog.selected_listing.config_profile == "config-a"
 
 
+def test_selection_hint_names_the_selected_job_not_the_current_row(
+    qapp: Any, working_dir: Path, patched_working_dirs: None
+) -> None:
+    """Same divergence as rename -- see
+    `test_rename_targets_the_selected_job_not_the_current_row`. The hint is
+    display-only, but it still has to describe the row that is actually
+    highlighted, not whatever `currentItem()` last landed on.
+    """
+    _save(working_dir, "selected", created_at="2026-06-01T00:00:00+00:00")
+    _save(
+        working_dir,
+        "merely current",
+        profile="other",
+        created_at="2026-01-01T00:00:00+00:00",
+    )
+    dialog = _open_dialog(qapp)
+    dialog.only_this_config.setChecked(False)
+
+    selected_row = dialog.job_tree.topLevelItem(0)
+    current_row = dialog.job_tree.topLevelItem(1)
+    assert selected_row.text(0) == "selected"
+    selected_row.setSelected(True)
+    dialog.job_tree.setCurrentItem(
+        current_row, 0, QItemSelectionModel.SelectionFlag.NoUpdate
+    )
+    assert dialog.job_tree.currentItem() is current_row
+    assert [item.text(0) for item in dialog.job_tree.selectedItems()] == ["selected"]
+
+    # "selected" matches the active profile and is prepared, so the hint says
+    # it is ready. The merely-current row is on another config -- if the hint
+    # named it instead, this would talk about switching profiles, not loading.
+    assert (
+        dialog._selection_hint() == "'selected' is ready to load or add to the queue."
+    )
+
+
 def test_rename_is_only_available_for_one_job(
     qapp: Any, working_dir: Path, patched_working_dirs: None
 ) -> None:

--- a/tests/test_frontend/test_load_job_dialog.py
+++ b/tests/test_frontend/test_load_job_dialog.py
@@ -259,3 +259,12 @@ def test_double_clicking_a_cross_profile_row_offers_the_switch(
 
     assert dialog.switch_profile_requested is True
     assert dialog.selected_listing is not None
+
+
+def test_state_column_carries_an_icon(
+    qapp: Any, working_dir: Path, patched_working_dirs: None
+) -> None:
+    _save(working_dir, "job", prepared=True)
+    dialog = LoadJobDialog("default")
+
+    assert not dialog.job_tree.topLevelItem(0).icon(5).isNull()

--- a/tests/test_frontend/test_load_job_dialog.py
+++ b/tests/test_frontend/test_load_job_dialog.py
@@ -944,6 +944,48 @@ def test_a_filter_keystroke_does_not_steal_a_queue_sourced_pane(
     assert dialog.open_folder_btn.isEnabled()
 
 
+def test_the_pane_falls_back_to_the_tree_job_once_its_queue_row_is_gone(
+    qapp: Any, working_dir: Path, patched_working_dirs: None
+) -> None:
+    """Removing the queue row the pane is describing empties
+    `queue_list.currentItem()` out from under a queue-sourced pane -- a
+    different widget's action, not the user switching away. A pane that goes
+    blank because of it reads as a glitch; falling back to the tree's own
+    listing always leaves something sensible on screen.
+
+    Not part of the brief's required A/B/E tests, but added because a
+    mutation check against the pre-existing suite (reverting the fallback to
+    a bare `return None`) showed nothing in the suite caught it -- the
+    brief's claim that C is "covered by the existing suite" did not hold
+    empirically, unlike D's tree-branch behaviour, which a mutation check
+    confirmed really is already covered.
+    """
+    _save(working_dir, "tree-job", created_at="2026-01-01T00:00:00+00:00")
+    _save(working_dir, "queue-job", created_at="2026-06-01T00:00:00+00:00")
+    dialog = _open_dialog(qapp)
+    tree_item = dialog.job_tree.findItems("tree-job", Qt.MatchFlag.MatchExactly, 0)[0]
+    queue_source_item = dialog.job_tree.findItems(
+        "queue-job", Qt.MatchFlag.MatchExactly, 0
+    )[0]
+
+    dialog.job_tree.clearSelection()
+    queue_source_item.setSelected(True)
+    dialog._add_to_queue()
+    queue_source_item.setSelected(False)
+    dialog.job_tree.setCurrentItem(tree_item)
+    tree_item.setSelected(True)
+
+    dialog.queue_list.setCurrentRow(0)
+    assert dialog._details_source == "queue"
+    assert "queue-job" in dialog.details_lbl.text()
+
+    dialog._remove_queued()
+
+    assert dialog.details_lbl.text() != ""
+    assert "tree-job" in dialog.details_lbl.text()
+    assert "queue-job" not in dialog.details_lbl.text()
+
+
 def test_repeated_refresh_details_calls_skip_describe_entirely(
     qapp: Any,
     working_dir: Path,

--- a/tests/test_frontend/test_load_job_dialog.py
+++ b/tests/test_frontend/test_load_job_dialog.py
@@ -189,3 +189,33 @@ def test_hiding_a_row_also_deselects_it(
     dialog.filter_edit.setText("nothing matches this")
 
     assert dialog._selected_listings() == []
+
+
+def test_a_row_hidden_while_selected_does_not_come_back_selected(
+    qapp: Any, working_dir: Path, patched_working_dirs: None
+) -> None:
+    """Clearing a filter must not resurrect a selection the user cannot see.
+
+    This is what the explicit `setSelected(False)` is actually for, and it is
+    the only thing that exercises it. `selectedItems()` already skips hidden
+    rows, so while the filter is on, hiding alone is enough -- but
+    `isSelected()` survives hiding, so without the deselect the row reappears
+    already selected once the filter clears, a selection the user never made
+    and never saw happen.
+    """
+    _save(working_dir, "alpha")
+    _save(working_dir, "beta")
+    dialog = LoadJobDialog("default")
+    for index in range(dialog.job_tree.topLevelItemCount()):
+        dialog.job_tree.topLevelItem(index).setSelected(True)
+
+    dialog.filter_edit.setText("alpha")
+    dialog.filter_edit.setText("")
+
+    rows = [
+        dialog.job_tree.topLevelItem(index)
+        for index in range(dialog.job_tree.topLevelItemCount())
+    ]
+    assert all(not row.isHidden() for row in rows)
+    # "beta" was hidden and so deselected; "alpha" never was, so it stays
+    assert sorted(row.text(0) for row in rows if row.isSelected()) == ["alpha"]

--- a/tests/test_frontend/test_load_job_dialog.py
+++ b/tests/test_frontend/test_load_job_dialog.py
@@ -11,8 +11,10 @@ from types import SimpleNamespace
 from typing import Any
 
 from PySide6.QtCore import QItemSelectionModel, Qt
+from PySide6.QtGui import QPalette
 from PySide6.QtWidgets import QDialogButtonBox, QHeaderView
 import pytest
+import qtawesome as qta
 
 from src.backend.jobs import store
 from src.backend.jobs.models import JobSummary
@@ -420,27 +422,38 @@ def test_state_column_carries_an_icon(
 def test_the_state_icon_is_chosen_by_the_job_s_own_state(
     qapp: Any, working_dir: Path, patched_working_dirs: None
 ) -> None:
-    """A non-null icon on one row proves only that *an* icon was set.
+    """A non-null icon on one row proves only that *an* icon was set, and the
+    two icons merely differing from each other proves only that they are not
+    identical -- both a "same icon for every row" bug and a "states swapped"
+    bug would be missed by that alone: a swap still leaves two distinct,
+    non-null icons, just attached to the wrong rows.
 
-    Setting the same icon on every row unconditionally would satisfy that, so
-    what pins the conditional is the two states resolving to different icons.
-    `QIcon.cacheKey()` is equal for references to one icon and differs between
-    distinct ones, which is exactly the distinction needed here.
+    `qtawesome` caches by (icon name, color), so calling `qta.icon()` here
+    with production's exact name and color reproduces the same `QIcon`
+    `cacheKey()` -- verified empirically, not assumed -- which is what lets
+    each row's icon be checked against the specific icon it should hold,
+    not just against its sibling.
+
+    Rows are collected into a dict keyed by name rather than read by
+    position: newly-saved jobs can tie on `created_at` to the second, and the
+    listing's tie-break sorts by job id, a random `shortuuid` -- so which row
+    lands at index 0 is not deterministic between runs.
     """
     _save(working_dir, "ready", prepared=True)
     _save(working_dir, "draft", prepared=False)
     dialog = _open_dialog(qapp)
 
-    rows = {
-        dialog.job_tree.topLevelItem(index).text(0): dialog.job_tree.topLevelItem(index)
-        for index in range(dialog.job_tree.topLevelItemCount())
-    }
-    ready_icon = rows["ready"].icon(5)
-    draft_icon = rows["draft"].icon(5)
+    rows = {}
+    for index in range(dialog.job_tree.topLevelItemCount()):
+        item = dialog.job_tree.topLevelItem(index)
+        rows[item.text(0)] = item
 
-    assert not ready_icon.isNull()
-    assert not draft_icon.isNull()
-    assert ready_icon.cacheKey() != draft_icon.cacheKey()
+    icon_color = dialog.palette().color(QPalette.ColorRole.WindowText).name()
+    prepared_icon = qta.icon("mdi6.package-variant-closed", color=icon_color)
+    needs_input_icon = qta.icon("mdi6.pencil-outline", color=icon_color)
+
+    assert rows["ready"].icon(5).cacheKey() == prepared_icon.cacheKey()
+    assert rows["draft"].icon(5).cacheKey() == needs_input_icon.cacheKey()
 
 
 def test_delete_removes_every_selected_job(

--- a/tests/test_frontend/test_load_job_dialog.py
+++ b/tests/test_frontend/test_load_job_dialog.py
@@ -219,3 +219,43 @@ def test_a_row_hidden_while_selected_does_not_come_back_selected(
     assert all(not row.isHidden() for row in rows)
     # "beta" was hidden and so deselected; "alpha" never was, so it stays
     assert sorted(row.text(0) for row in rows if row.isSelected()) == ["alpha"]
+
+
+def test_a_mixed_selection_explains_why_the_queue_is_unavailable(
+    qapp: Any, working_dir: Path, patched_working_dirs: None
+) -> None:
+    _save(working_dir, "ready", prepared=True)
+    _save(working_dir, "not-ready", prepared=False)
+    dialog = LoadJobDialog("default")
+    dialog.job_tree.selectAll()
+
+    assert not dialog.queue_btn.isEnabled()
+    assert "not prepared" in dialog.status_lbl.text()
+
+
+def test_a_cross_profile_selection_says_which_config_it_needs(
+    qapp: Any, working_dir: Path, patched_working_dirs: None
+) -> None:
+    _save(working_dir, "theirs", profile="anime")
+    dialog = LoadJobDialog("default")
+    dialog.only_this_config.setChecked(False)
+    dialog.job_tree.topLevelItem(0).setSelected(True)
+    dialog.job_tree.setCurrentItem(dialog.job_tree.topLevelItem(0))
+
+    assert "anime" in dialog.status_lbl.text()
+
+
+def test_double_clicking_a_cross_profile_row_offers_the_switch(
+    qapp: Any, working_dir: Path, patched_working_dirs: None
+) -> None:
+    """Silently doing nothing is the current behaviour and the worst option."""
+    _save(working_dir, "theirs", profile="anime")
+    dialog = LoadJobDialog("default")
+    dialog.only_this_config.setChecked(False)
+    item = dialog.job_tree.topLevelItem(0)
+    dialog.job_tree.setCurrentItem(item)
+
+    dialog._on_double_click(item, 0)
+
+    assert dialog.switch_profile_requested is True
+    assert dialog.selected_listing is not None

--- a/tests/test_frontend/test_load_job_dialog.py
+++ b/tests/test_frontend/test_load_job_dialog.py
@@ -7,7 +7,7 @@ tested here is the dialog itself.
 from pathlib import Path
 from typing import Any
 
-from PySide6.QtCore import Qt
+from PySide6.QtCore import QItemSelectionModel, Qt
 from PySide6.QtWidgets import QHeaderView
 import pytest
 
@@ -676,6 +676,75 @@ def test_cancelling_the_rename_changes_nothing(
     dialog._rename_selected()
 
     assert store.load_job(directory).name == "keep me"
+
+
+def test_an_empty_new_name_is_refused(
+    qapp: Any,
+    working_dir: Path,
+    patched_working_dirs: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Accepting the prompt with a blank field must not blank the job's name.
+
+    The guard is `not accepted or not name.strip()`. The cancel test only ever
+    supplies `accepted=False`, so it cannot tell the two halves apart -- narrow
+    the guard to `if not accepted` and a user who clicks OK on an empty field
+    writes `name: ""` to disk, with nothing failing.
+    """
+    directory = _save(working_dir, "keep me")
+    dialog = LoadJobDialog("default")
+    dialog.job_tree.setCurrentItem(dialog.job_tree.topLevelItem(0))
+    dialog.job_tree.topLevelItem(0).setSelected(True)
+    monkeypatch.setattr(
+        load_job_dialog_module.QInputDialog,
+        "getText",
+        staticmethod(lambda *_a, **_k: ("   ", True)),
+    )
+
+    dialog._rename_selected()
+
+    assert store.load_job(directory).name == "keep me"
+
+
+def test_rename_targets_the_selected_job_not_the_current_row(
+    qapp: Any,
+    working_dir: Path,
+    patched_working_dirs: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`currentItem()` can point at a row that is not selected.
+
+    Ctrl+clicking a second row and ctrl+clicking it again leaves the current
+    item there while the first row stays the only selection. Targeting the
+    current row would rename the wrong job on disk while the right one is
+    still highlighted.
+    """
+    keep_dir = _save(working_dir, "selected", created_at="2026-06-01T00:00:00+00:00")
+    other_dir = _save(
+        working_dir, "merely current", created_at="2026-01-01T00:00:00+00:00"
+    )
+    dialog = LoadJobDialog("default")
+
+    selected_row = dialog.job_tree.topLevelItem(0)
+    current_row = dialog.job_tree.topLevelItem(1)
+    assert selected_row.text(0) == "selected"
+    selected_row.setSelected(True)
+    dialog.job_tree.setCurrentItem(
+        current_row, 0, QItemSelectionModel.SelectionFlag.NoUpdate
+    )
+    assert dialog.job_tree.currentItem() is current_row
+    assert [item.text(0) for item in dialog.job_tree.selectedItems()] == ["selected"]
+
+    monkeypatch.setattr(
+        load_job_dialog_module.QInputDialog,
+        "getText",
+        staticmethod(lambda *_a, **_k: ("renamed", True)),
+    )
+
+    dialog._rename_selected()
+
+    assert store.load_job(keep_dir).name == "renamed"
+    assert store.load_job(other_dir).name == "merely current"
 
 
 def test_rename_is_only_available_for_one_job(

--- a/tests/test_frontend/test_load_job_dialog.py
+++ b/tests/test_frontend/test_load_job_dialog.py
@@ -464,7 +464,12 @@ def test_the_details_pane_describes_the_selected_job(
     text = dialog.details_lbl.text()
     assert "Example" in text
     assert "Aither" in text
-    assert "CHEVERETO_V3" in text
+    # Both halves of the tracker row are stored as enum member names and both
+    # must be resolved for display -- checking only the tracker leaves the
+    # destination free to render as the raw "CHEVERETO_V3" beside a
+    # humanised "Aither".
+    assert "Chevereto v3" in text
+    assert "CHEVERETO_V3" not in text
     assert "2 screenshot" in text
     assert str(directory) in text
     # none of the decoy job's own data belongs here

--- a/tests/test_frontend/test_load_job_dialog.py
+++ b/tests/test_frontend/test_load_job_dialog.py
@@ -1969,6 +1969,47 @@ def test_deleting_a_queued_job_does_not_steal_the_pane_from_the_tree(
     assert "queued-b" not in dialog.details_lbl.text()
 
 
+def test_reloading_while_the_queue_is_the_source_does_not_steal_the_pane(
+    qapp: Any,
+    working_dir: Path,
+    patched_working_dirs: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`_load_listings` clears the tree synchronously, before the async
+    reload it kicks off even produces anything to show -- that clear is what
+    actually flips the source first during a real rename/delete reload, not
+    `_on_listings_loaded`'s own (already-empty-by-then) clear. Disclosed as
+    untested in the T18 fix round 1 report; this closes that gap.
+
+    Also pins the rebound queue listing's rendered text, not just the
+    source: renaming keeps the same path, and a stale `_details_cache` entry
+    or `_last_described_path` left over from a button-state refresh that ran
+    mid-reload (while the tree was empty and the queue not yet rebound)
+    would otherwise go on showing the pre-rename name even after the source
+    correctly stayed "queue".
+    """
+    _save(working_dir, "queued-job")
+    dialog = _open_dialog(qapp)
+    item = dialog.job_tree.topLevelItem(0)
+    _click_tree_item(dialog, item, qapp)
+    dialog._add_to_queue()
+
+    _click_queue_row(dialog, 0, qapp)
+    assert dialog._details_source == "queue"
+    assert "queued-job" in dialog.details_lbl.text()
+
+    monkeypatch.setattr(
+        load_job_dialog_module.QInputDialog,
+        "getText",
+        staticmethod(lambda *_a, **_k: ("renamed-job", True)),
+    )
+    dialog._rename_selected()
+    _wait_for_load(dialog, qapp)
+
+    assert dialog._details_source == "queue"
+    assert "renamed-job" in dialog.details_lbl.text()
+
+
 # --------------------------------------------------------------------------
 # loading is asynchronous
 # --------------------------------------------------------------------------

--- a/tests/test_frontend/test_load_job_dialog.py
+++ b/tests/test_frontend/test_load_job_dialog.py
@@ -559,6 +559,107 @@ def test_the_details_pane_clears_once_a_selection_is_lost(
     assert not dialog.open_folder_btn.isEnabled()
 
 
+def test_refreshing_details_for_the_same_listing_does_not_re_read_the_document(
+    qapp: Any,
+    working_dir: Path,
+    patched_working_dirs: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`_describe` parses the job document and walks its folder -- the same
+    read this branch already moved off-thread for `list_jobs`, so repeating it
+    on every keystroke or on an unrelated selection change would undo that.
+
+    `queue_list.currentRowChanged` feeds the same `_update_button_state` ->
+    `_refresh_details` chain the tree's own selection does, so moving the
+    queue selection alone -- with the tree's current item unchanged -- has to
+    be a no-op here too, not just a direct repeated call.
+    """
+    _save(working_dir, "job")
+    dialog = _open_dialog(qapp)
+    dialog.job_tree.setCurrentItem(dialog.job_tree.topLevelItem(0))
+    dialog.job_tree.topLevelItem(0).setSelected(True)
+    dialog._add_to_queue()
+    assert dialog.details_lbl.text() != ""
+
+    calls: list[Path] = []
+    real_load_job = load_job_dialog_module.load_job
+
+    def counting_load_job(path: Path) -> Any:
+        calls.append(path)
+        return real_load_job(path)
+
+    monkeypatch.setattr(load_job_dialog_module, "load_job", counting_load_job)
+
+    dialog._refresh_details()
+    dialog.queue_list.setCurrentRow(0)
+
+    assert calls == []
+
+
+def test_repeated_refresh_details_calls_skip_describe_entirely(
+    qapp: Any,
+    working_dir: Path,
+    patched_working_dirs: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`_describe`'s own memoisation would hide a missing skip here -- a
+    second call would still avoid re-reading the document by hitting the
+    cache. What the early return in `_refresh_details` buys beyond that is
+    not calling `_describe` (and re-stat'ing `is_dir()`) at all when the
+    listing to show has not changed, so this spies on `_describe` itself
+    rather than on what it reads.
+    """
+    _save(working_dir, "job")
+    dialog = _open_dialog(qapp)
+    dialog.job_tree.setCurrentItem(dialog.job_tree.topLevelItem(0))
+    assert dialog.details_lbl.text() != ""
+
+    calls: list[Any] = []
+    real_describe = dialog._describe
+
+    def counting_describe(listing: Any) -> str:
+        calls.append(listing)
+        return real_describe(listing)
+
+    monkeypatch.setattr(dialog, "_describe", counting_describe)
+
+    dialog._refresh_details()
+
+    assert calls == []
+
+
+def test_switching_back_to_a_previously_described_job_does_not_re_read_it(
+    qapp: Any,
+    working_dir: Path,
+    patched_working_dirs: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The skip in `_refresh_details` only covers a listing unchanged since
+    the last call -- switching away and back is a change each time, so it is
+    `_describe`'s own memoisation, not the skip, that has to catch this.
+    """
+    _save(working_dir, "alpha", created_at="2026-01-01T00:00:00+00:00")
+    _save(working_dir, "beta", created_at="2026-06-01T00:00:00+00:00")
+    dialog = _open_dialog(qapp)
+    alpha_item = dialog.job_tree.findItems("alpha", Qt.MatchFlag.MatchExactly, 0)[0]
+    beta_item = dialog.job_tree.findItems("beta", Qt.MatchFlag.MatchExactly, 0)[0]
+    dialog.job_tree.setCurrentItem(alpha_item)
+    dialog.job_tree.setCurrentItem(beta_item)
+
+    calls: list[Path] = []
+    real_load_job = load_job_dialog_module.load_job
+
+    def counting_load_job(path: Path) -> Any:
+        calls.append(path)
+        return real_load_job(path)
+
+    monkeypatch.setattr(load_job_dialog_module, "load_job", counting_load_job)
+
+    dialog.job_tree.setCurrentItem(alpha_item)
+
+    assert calls == []
+
+
 def test_the_details_pane_escapes_html_in_a_job_s_name(
     qapp: Any, working_dir: Path, patched_working_dirs: None
 ) -> None:
@@ -698,6 +799,38 @@ def test_renaming_rewrites_only_the_name(
     assert reloaded.name == "new name"
     assert reloaded.summary.trackers == ["Aither"]
     assert dialog.job_tree.topLevelItem(0).text(0) == "new name"
+
+
+def test_a_rename_refreshes_the_cached_details_pane_text(
+    qapp: Any,
+    working_dir: Path,
+    patched_working_dirs: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The details cache is keyed by path, and a rename keeps the same path --
+    so a cache entry (or a "nothing changed" skip) left over from before the
+    reload would go on showing the pre-rename name even though the row itself
+    updated. Both are cleared in `_load_listings` for exactly this reason.
+    """
+    # A distinct title, so the pane's bolded name header -- what the cache is
+    # actually keyed on and what rename actually changes -- is unambiguous
+    # against the "Title" row it also shows, which rename leaves untouched.
+    _save(working_dir, "old name", title="Some Movie")
+    dialog = _open_dialog(qapp)
+    dialog.job_tree.setCurrentItem(dialog.job_tree.topLevelItem(0))
+    dialog.job_tree.topLevelItem(0).setSelected(True)
+    assert "<b>old name</b>" in dialog.details_lbl.text()
+    monkeypatch.setattr(
+        load_job_dialog_module.QInputDialog,
+        "getText",
+        staticmethod(lambda *_a, **_k: ("new name", True)),
+    )
+
+    dialog._rename_selected()
+    _wait_for_load(dialog, qapp)
+
+    assert "<b>new name</b>" in dialog.details_lbl.text()
+    assert "<b>old name</b>" not in dialog.details_lbl.text()
 
 
 def test_cancelling_the_rename_changes_nothing(

--- a/tests/test_frontend/test_load_job_dialog.py
+++ b/tests/test_frontend/test_load_job_dialog.py
@@ -380,3 +380,47 @@ def test_the_delete_key_is_wired_to_delete(
     dialog = LoadJobDialog("default")
 
     assert dialog.delete_btn.shortcut() == Qt.Key.Key_Delete
+
+
+def test_one_failed_delete_does_not_strand_the_rest(
+    qapp: Any,
+    working_dir: Path,
+    patched_working_dirs: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Continuing past a failure is this method's whole point.
+
+    An accidental `break`, or the `try` drifting outside the loop, would leave
+    every job after the first failure sitting on disk while the user is told
+    only about the one that failed. Nothing else in the suite would notice.
+    """
+    fails_dir = _save(working_dir, "unlucky")
+    succeeds_dir = _save(working_dir, "fine")
+    dialog = LoadJobDialog("default")
+    dialog.job_tree.selectAll()
+
+    real_delete = load_job_dialog_module.delete_job
+
+    def flaky(path: Path) -> None:
+        if path == fails_dir:
+            raise load_job_dialog_module.JobStoreError("disk said no")
+        real_delete(path)
+
+    reported: list[str] = []
+    monkeypatch.setattr(load_job_dialog_module, "delete_job", flaky)
+    monkeypatch.setattr(
+        load_job_dialog_module.QMessageBox,
+        "question",
+        lambda *_a, **_k: load_job_dialog_module.QMessageBox.StandardButton.Yes,
+    )
+    monkeypatch.setattr(
+        load_job_dialog_module.QMessageBox,
+        "critical",
+        lambda _parent, _title, text, *_a, **_k: reported.append(text),
+    )
+
+    dialog._delete_selected()
+
+    assert fails_dir.exists()
+    assert not succeeds_dir.exists()
+    assert reported and "unlucky" in reported[0]

--- a/tests/test_frontend/test_load_job_dialog.py
+++ b/tests/test_frontend/test_load_job_dialog.py
@@ -1,0 +1,105 @@
+"""Coverage for the saved-job picker's presentation and actions.
+
+The save/resume round trip is covered in `test_job_save_resume.py`; what is
+tested here is the dialog itself.
+"""
+
+from pathlib import Path
+from typing import Any
+
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QHeaderView
+import pytest
+
+from src.backend.jobs import store
+from src.backend.jobs.models import JobSummary
+from src.frontend.custom_widgets import load_job_dialog as load_job_dialog_module
+from src.frontend.custom_widgets.load_job_dialog import LoadJobDialog
+
+
+@pytest.fixture
+def working_dir(tmp_path: Path) -> Path:
+    return tmp_path / "nfoforge"
+
+
+@pytest.fixture
+def patched_working_dirs(working_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        load_job_dialog_module, "unique_working_dirs", lambda: [working_dir]
+    )
+
+
+def _save(
+    working_dir: Path,
+    name: str,
+    *,
+    profile: str = "default",
+    prepared: bool = True,
+    trackers: list[str] | None = None,
+    title: str | None = None,
+    created_at: str | None = None,
+) -> Path:
+    context: dict[str, Any] = {"shared_data": {}}
+    if prepared:
+        context["shared_data"]["tracker_release_data"] = {
+            "AITHER": {"title": "t", "nfo": "body"}
+        }
+    job = store.build_job(
+        name,
+        JobSummary(title=title or name, year=2024, trackers=trackers or ["Aither"]),
+        context,
+        config_profile=profile,
+    )
+    if created_at:
+        job.created_at = created_at
+    return store.save_job(job, working_dir)
+
+
+def test_columns_are_sized_for_what_they_hold(
+    qapp: Any, working_dir: Path, patched_working_dirs: None
+) -> None:
+    _save(working_dir, "job")
+    dialog = LoadJobDialog("default")
+    header = dialog.job_tree.header()
+
+    assert header.sectionResizeMode(0) is QHeaderView.ResizeMode.Stretch
+    assert header.sectionResizeMode(2) is QHeaderView.ResizeMode.ResizeToContents
+    assert header.sectionResizeMode(3) is QHeaderView.ResizeMode.Interactive
+    assert dialog.job_tree.textElideMode() is Qt.TextElideMode.ElideRight
+
+
+def test_the_full_tracker_list_is_available_as_a_tooltip(
+    qapp: Any, working_dir: Path, patched_working_dirs: None
+) -> None:
+    _save(working_dir, "job", trackers=["Aither", "Huno", "LST", "DarkPeers"])
+    dialog = LoadJobDialog("default")
+
+    assert "DarkPeers" in dialog.job_tree.topLevelItem(0).toolTip(3)
+
+
+def test_jobs_are_sortable_and_start_newest_first(
+    qapp: Any, working_dir: Path, patched_working_dirs: None
+) -> None:
+    _save(working_dir, "older", created_at="2026-01-01T00:00:00+00:00")
+    _save(working_dir, "newer", created_at="2026-06-01T00:00:00+00:00")
+    dialog = LoadJobDialog("default")
+
+    assert dialog.job_tree.isSortingEnabled()
+    assert dialog.job_tree.topLevelItem(0).text(0) == "newer"
+
+
+def test_the_dialog_can_be_resized_from_its_corner(
+    qapp: Any, working_dir: Path, patched_working_dirs: None
+) -> None:
+    dialog = LoadJobDialog("default")
+
+    assert dialog.isSizeGripEnabled()
+
+
+def test_the_info_label_does_not_repeat_the_window_title(
+    qapp: Any, working_dir: Path, patched_working_dirs: None
+) -> None:
+    dialog = LoadJobDialog("default")
+
+    assert dialog.windowTitle() == "Saved Jobs"
+    assert "<h3" not in dialog.info_lbl.text()

--- a/tests/test_frontend/test_load_job_dialog.py
+++ b/tests/test_frontend/test_load_job_dialog.py
@@ -7,6 +7,7 @@ tested here is the dialog itself.
 from pathlib import Path
 import re
 import time
+from types import SimpleNamespace
 from typing import Any
 
 from PySide6.QtCore import QItemSelectionModel, Qt
@@ -1762,3 +1763,31 @@ def test_calling_load_listings_twice_retires_the_first_loader(
 
     assert dialog.job_tree.topLevelItemCount() == 1
     assert dialog.job_tree.topLevelItem(0).text(0) == "job"
+
+
+def test_stop_loader_tolerates_a_loader_whose_c_plus_plus_object_is_gone(
+    qapp: Any, working_dir: Path, patched_working_dirs: None
+) -> None:
+    """`wait()` on a `QThread` whose underlying C++ object is already
+    destroyed raises `RuntimeError`, which is exactly the post-condition
+    `_stop_loader` wants -- no live thread left to wait for -- so it has to
+    be tolerated rather than propagate out of dialog close.
+
+    Not reachable through the real `_ListingLoader` today, and there is no
+    safe way to actually destroy a live `QThread`'s C++ object from Python to
+    reproduce it -- doing so aborts the process rather than raising. A stub
+    whose `wait()` raises `RuntimeError` stands in for that case instead.
+    """
+    dialog = _open_dialog(qapp)
+
+    def raise_runtime_error() -> None:
+        raise RuntimeError("Internal C++ object already deleted.")
+
+    dialog._loader = SimpleNamespace(  # pyright: ignore[reportAttributeAccessIssue]
+        loaded=SimpleNamespace(disconnect=lambda *_a, **_k: None),
+        wait=raise_runtime_error,
+    )
+
+    dialog._stop_loader()
+
+    assert dialog._loader is None

--- a/tests/test_frontend/test_load_job_dialog.py
+++ b/tests/test_frontend/test_load_job_dialog.py
@@ -198,6 +198,34 @@ def test_filtering_matches_name_title_and_tracker(
     assert visible == ["beta"]
 
 
+def test_filtering_matches_input_name(
+    qapp: Any, working_dir: Path, patched_working_dirs: None
+) -> None:
+    """The placeholder promises filtering by file works, so `_apply_filter`'s
+    haystack has to actually include `input_name` -- a filter that only
+    searched `name`, `title` and `trackers` would leave that promise broken
+    for a user filtering by the source filename.
+    """
+    job = store.build_job(
+        "job",
+        JobSummary(
+            title="Some Title",
+            trackers=["Aither"],
+            input_name="Distinctive.Source.File.mkv",
+        ),
+        {"shared_data": {}},
+        config_profile="default",
+    )
+    store.save_job(job, working_dir)
+    dialog = _open_dialog(qapp)
+
+    assert "file" in dialog.filter_edit.placeholderText().casefold()
+
+    dialog.filter_edit.setText("distinctive.source.file")
+
+    assert not dialog.job_tree.topLevelItem(0).isHidden()
+
+
 def test_only_this_config_hides_other_profiles_by_default(
     qapp: Any, working_dir: Path, patched_working_dirs: None
 ) -> None:

--- a/tests/test_frontend/test_load_job_dialog.py
+++ b/tests/test_frontend/test_load_job_dialog.py
@@ -9,7 +9,7 @@ import time
 from typing import Any
 
 from PySide6.QtCore import QItemSelectionModel, Qt
-from PySide6.QtWidgets import QHeaderView
+from PySide6.QtWidgets import QDialogButtonBox, QHeaderView
 import pytest
 
 from src.backend.jobs import store
@@ -791,6 +791,119 @@ def test_rename_targets_the_selected_job_not_the_current_row(
 
     assert store.load_job(keep_dir).name == "renamed"
     assert store.load_job(other_dir).name == "merely current"
+
+
+def test_button_state_reflects_the_selected_job_not_the_current_row(
+    qapp: Any, working_dir: Path, patched_working_dirs: None
+) -> None:
+    """Same divergence as rename -- see
+    `test_rename_targets_the_selected_job_not_the_current_row`. Enablement and
+    the actions it gates have to agree on the same job, or a button that looks
+    correctly enabled ends up acting on a row the user did not pick.
+    """
+    _save(working_dir, "selected", created_at="2026-06-01T00:00:00+00:00")
+    _save(
+        working_dir,
+        "merely current",
+        profile="other",
+        created_at="2026-01-01T00:00:00+00:00",
+    )
+    dialog = _open_dialog(qapp)
+    dialog.only_this_config.setChecked(False)
+
+    selected_row = dialog.job_tree.topLevelItem(0)
+    current_row = dialog.job_tree.topLevelItem(1)
+    assert selected_row.text(0) == "selected"
+    selected_row.setSelected(True)
+    dialog.job_tree.setCurrentItem(
+        current_row, 0, QItemSelectionModel.SelectionFlag.NoUpdate
+    )
+    assert dialog.job_tree.currentItem() is current_row
+    assert [item.text(0) for item in dialog.job_tree.selectedItems()] == ["selected"]
+
+    dialog._update_button_state()
+
+    # "selected" matches the active profile: Load has to be enabled and
+    # Switch has to stay off, even though the merely-current row is the one
+    # that would need a switch.
+    open_button = dialog.button_box.button(QDialogButtonBox.StandardButton.Open)
+    assert open_button is not None
+    assert open_button.isEnabled()
+    assert not dialog.switch_btn.isEnabled()
+
+
+def test_accept_selection_targets_the_selected_job_not_the_current_row(
+    qapp: Any, working_dir: Path, patched_working_dirs: None
+) -> None:
+    """Same divergence as rename -- see
+    `test_rename_targets_the_selected_job_not_the_current_row` -- but worse: a
+    listing loaded here lands on the process page, where the next action is
+    Process. Loading the wrong release would upload it to a tracker.
+    """
+    selected_dir = _save(
+        working_dir, "selected", created_at="2026-06-01T00:00:00+00:00"
+    )
+    other_dir = _save(
+        working_dir, "merely current", created_at="2026-01-01T00:00:00+00:00"
+    )
+    dialog = _open_dialog(qapp)
+
+    selected_row = dialog.job_tree.topLevelItem(0)
+    current_row = dialog.job_tree.topLevelItem(1)
+    assert selected_row.text(0) == "selected"
+    selected_row.setSelected(True)
+    dialog.job_tree.setCurrentItem(
+        current_row, 0, QItemSelectionModel.SelectionFlag.NoUpdate
+    )
+    assert dialog.job_tree.currentItem() is current_row
+    assert [item.text(0) for item in dialog.job_tree.selectedItems()] == ["selected"]
+
+    dialog._accept_selection()
+
+    assert dialog.selected_listing is not None
+    assert dialog.selected_listing.path == selected_dir
+    assert dialog.selected_listing.path != other_dir
+
+
+def test_accept_with_switch_targets_the_selected_job_not_the_current_row(
+    qapp: Any, working_dir: Path, patched_working_dirs: None
+) -> None:
+    """Same divergence again, worse still: this drives `_switch_config_profile`,
+    which calls `config.load_profile()` and emits `settings_refresh` --
+    switching the active config, with its credentials and templates, on the
+    strength of a row the user did not select.
+    """
+    selected_dir = _save(
+        working_dir,
+        "selected",
+        profile="config-a",
+        created_at="2026-06-01T00:00:00+00:00",
+    )
+    _save(
+        working_dir,
+        "merely current",
+        profile="config-b",
+        created_at="2026-01-01T00:00:00+00:00",
+    )
+    dialog = _open_dialog(qapp)
+    dialog.only_this_config.setChecked(False)
+
+    selected_row = dialog.job_tree.topLevelItem(0)
+    current_row = dialog.job_tree.topLevelItem(1)
+    assert selected_row.text(0) == "selected"
+    selected_row.setSelected(True)
+    dialog.job_tree.setCurrentItem(
+        current_row, 0, QItemSelectionModel.SelectionFlag.NoUpdate
+    )
+    assert dialog.job_tree.currentItem() is current_row
+    assert [item.text(0) for item in dialog.job_tree.selectedItems()] == ["selected"]
+
+    dialog._accept_with_switch()
+
+    assert dialog.switch_profile_requested is True
+    assert dialog.selected_listing is not None
+    assert dialog.selected_listing.path == selected_dir
+    assert dialog.selected_listing.config_profile == "config-a"
 
 
 def test_rename_is_only_available_for_one_job(

--- a/tests/test_frontend/test_load_job_dialog.py
+++ b/tests/test_frontend/test_load_job_dialog.py
@@ -132,3 +132,60 @@ def test_the_info_label_does_not_repeat_the_window_title(
 
     assert dialog.windowTitle() == "Saved Jobs"
     assert "<h3" not in dialog.info_lbl.text()
+
+
+def test_filtering_matches_name_title_and_tracker(
+    qapp: Any, working_dir: Path, patched_working_dirs: None
+) -> None:
+    _save(working_dir, "alpha", title="Alpha Movie", trackers=["Aither"])
+    _save(working_dir, "beta", title="Beta Movie", trackers=["Huno"])
+    dialog = LoadJobDialog("default")
+
+    dialog.filter_edit.setText("huno")
+
+    visible = [
+        dialog.job_tree.topLevelItem(i).text(0)
+        for i in range(dialog.job_tree.topLevelItemCount())
+        if not dialog.job_tree.topLevelItem(i).isHidden()
+    ]
+    assert visible == ["beta"]
+
+
+def test_only_this_config_hides_other_profiles_by_default(
+    qapp: Any, working_dir: Path, patched_working_dirs: None
+) -> None:
+    _save(working_dir, "mine", profile="default")
+    _save(working_dir, "theirs", profile="anime")
+    dialog = LoadJobDialog("default")
+
+    assert dialog.only_this_config.isChecked()
+    hidden = {
+        dialog.job_tree.topLevelItem(i).text(0)
+        for i in range(dialog.job_tree.topLevelItemCount())
+        if dialog.job_tree.topLevelItem(i).isHidden()
+    }
+    assert hidden == {"theirs"}
+
+
+def test_unchecking_only_this_config_reveals_other_profiles(
+    qapp: Any, working_dir: Path, patched_working_dirs: None
+) -> None:
+    _save(working_dir, "theirs", profile="anime")
+    dialog = LoadJobDialog("default")
+
+    dialog.only_this_config.setChecked(False)
+
+    assert not dialog.job_tree.topLevelItem(0).isHidden()
+
+
+def test_hiding_a_row_also_deselects_it(
+    qapp: Any, working_dir: Path, patched_working_dirs: None
+) -> None:
+    """A hidden row left selected would silently take part in Load or Delete."""
+    _save(working_dir, "alpha")
+    dialog = LoadJobDialog("default")
+    dialog.job_tree.topLevelItem(0).setSelected(True)
+
+    dialog.filter_edit.setText("nothing matches this")
+
+    assert dialog._selected_listings() == []

--- a/tests/test_frontend/test_load_job_dialog.py
+++ b/tests/test_frontend/test_load_job_dialog.py
@@ -1006,6 +1006,34 @@ def test_accept_selection_targets_the_selected_job_not_the_current_row(
     assert dialog.selected_listing.path != other_dir
 
 
+def test_accept_selection_refuses_a_selected_cross_profile_job(
+    qapp: Any, working_dir: Path, patched_working_dirs: None
+) -> None:
+    """The profile guard in `_accept_selection`, reached rather than assumed.
+
+    With `only_this_config` checked -- its default -- a cross-profile row is
+    hidden and deselected by `_apply_filter`, so `_selected_listings()` is
+    empty and `_accept_selection` returns on `len(selected) != 1` before ever
+    reaching the `matches_profile` check below it. Revealing and selecting
+    the row is what it actually takes for a user to get a cross-profile job
+    selected in the first place, so that is what reaches the guard this test
+    means to cover.
+    """
+    _save(working_dir, "theirs", profile="anime")
+    dialog = _open_dialog(qapp)
+    dialog.only_this_config.setChecked(False)
+    item = dialog.job_tree.topLevelItem(0)
+    item.setSelected(True)
+    # Confirm the selection actually landed, so a regression back to the
+    # hidden-and-deselected state fails loudly here instead of the assertion
+    # below passing for the wrong reason.
+    assert len(dialog._selected_listings()) == 1
+
+    dialog._accept_selection()
+
+    assert dialog.selected_listing is None
+
+
 def test_accept_with_switch_targets_the_selected_job_not_the_current_row(
     qapp: Any, working_dir: Path, patched_working_dirs: None
 ) -> None:

--- a/tests/test_frontend/test_load_job_dialog.py
+++ b/tests/test_frontend/test_load_job_dialog.py
@@ -677,6 +677,115 @@ def test_refreshing_details_for_the_same_listing_does_not_re_read_the_document(
     assert calls == []
 
 
+def test_selecting_a_queue_row_describes_that_job(
+    qapp: Any, working_dir: Path, patched_working_dirs: None
+) -> None:
+    """Clicking a queue row must describe the queued job, not whatever the
+    tree's own selection still points at -- the two panes used to share one
+    detail view, driven only by the tree's current item, so selecting a
+    queued job told the user nothing about it.
+
+    The tree selection is left on a *different* job throughout, so this
+    cannot pass by the pane coincidentally still showing the right thing.
+    """
+    _save(working_dir, "tree-job", created_at="2026-06-01T00:00:00+00:00")
+    _save(working_dir, "queue-job", created_at="2026-01-01T00:00:00+00:00")
+    dialog = _open_dialog(qapp)
+    tree_item = dialog.job_tree.findItems("tree-job", Qt.MatchFlag.MatchExactly, 0)[0]
+    queue_source_item = dialog.job_tree.findItems(
+        "queue-job", Qt.MatchFlag.MatchExactly, 0
+    )[0]
+
+    # Queue "queue-job" without disturbing the eventual tree selection.
+    dialog.job_tree.clearSelection()
+    queue_source_item.setSelected(True)
+    dialog._add_to_queue()
+    queue_source_item.setSelected(False)
+
+    # Leave the tree selected on "tree-job" -- the pane must not describe this.
+    dialog.job_tree.setCurrentItem(tree_item)
+    tree_item.setSelected(True)
+    assert "tree-job" in dialog.details_lbl.text()
+    assert "queue-job" not in dialog.details_lbl.text()
+
+    dialog.queue_list.setCurrentRow(0)
+
+    assert "queue-job" in dialog.details_lbl.text()
+    assert "tree-job" not in dialog.details_lbl.text()
+
+
+def test_changing_the_tree_selection_after_a_queue_row_describes_the_tree_job_again(
+    qapp: Any, working_dir: Path, patched_working_dirs: None
+) -> None:
+    """Once a queue row has taken over the pane, the tree's own selection has
+    to be able to take it back -- the pane describes whichever pane the user
+    last interacted with, not permanently whichever was clicked first.
+    """
+    _save(working_dir, "tree-job", created_at="2026-06-01T00:00:00+00:00")
+    _save(working_dir, "queue-job", created_at="2026-01-01T00:00:00+00:00")
+    dialog = _open_dialog(qapp)
+    tree_item = dialog.job_tree.findItems("tree-job", Qt.MatchFlag.MatchExactly, 0)[0]
+    queue_source_item = dialog.job_tree.findItems(
+        "queue-job", Qt.MatchFlag.MatchExactly, 0
+    )[0]
+
+    dialog.job_tree.clearSelection()
+    queue_source_item.setSelected(True)
+    dialog._add_to_queue()
+    queue_source_item.setSelected(False)
+    dialog.job_tree.setCurrentItem(tree_item)
+    tree_item.setSelected(True)
+
+    dialog.queue_list.setCurrentRow(0)
+    assert "queue-job" in dialog.details_lbl.text()
+
+    # Re-select the tree's row -- a real change to the tree's selection, not
+    # a repeat of a call that would already be a no-op.
+    tree_item.setSelected(False)
+    tree_item.setSelected(True)
+
+    assert "tree-job" in dialog.details_lbl.text()
+    assert "queue-job" not in dialog.details_lbl.text()
+
+
+def test_open_folder_acts_on_the_queue_row_while_it_is_the_source(
+    qapp: Any,
+    working_dir: Path,
+    patched_working_dirs: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Open Folder has to follow the same source as the details pane it sits
+    under -- otherwise the pane can describe a queued job while the button
+    opens a different one, lying about what it acts on.
+    """
+    tree_dir = _save(working_dir, "tree-job", created_at="2026-06-01T00:00:00+00:00")
+    queue_dir = _save(working_dir, "queue-job", created_at="2026-01-01T00:00:00+00:00")
+    dialog = _open_dialog(qapp)
+    tree_item = dialog.job_tree.findItems("tree-job", Qt.MatchFlag.MatchExactly, 0)[0]
+    queue_source_item = dialog.job_tree.findItems(
+        "queue-job", Qt.MatchFlag.MatchExactly, 0
+    )[0]
+
+    dialog.job_tree.clearSelection()
+    queue_source_item.setSelected(True)
+    dialog._add_to_queue()
+    queue_source_item.setSelected(False)
+    dialog.job_tree.setCurrentItem(tree_item)
+    tree_item.setSelected(True)
+
+    dialog.queue_list.setCurrentRow(0)
+
+    opened: list[Path] = []
+    monkeypatch.setattr(
+        load_job_dialog_module, "open_explorer", lambda path: opened.append(path)
+    )
+
+    dialog.open_folder_btn.click()
+
+    assert opened == [queue_dir]
+    assert opened != [tree_dir]
+
+
 def test_repeated_refresh_details_calls_skip_describe_entirely(
     qapp: Any,
     working_dir: Path,

--- a/tests/test_frontend/test_load_job_dialog.py
+++ b/tests/test_frontend/test_load_job_dialog.py
@@ -224,12 +224,16 @@ def test_a_row_hidden_while_selected_does_not_come_back_selected(
 def test_a_mixed_selection_explains_why_the_queue_is_unavailable(
     qapp: Any, working_dir: Path, patched_working_dirs: None
 ) -> None:
+    """`queue_btn` now reflects the queue list, not the selection -- it would
+    be disabled here regardless, since nothing has been added yet. What a
+    mixed selection actually still gates is whether it can be *added*.
+    """
     _save(working_dir, "ready", prepared=True)
     _save(working_dir, "not-ready", prepared=False)
     dialog = LoadJobDialog("default")
     dialog.job_tree.selectAll()
 
-    assert not dialog.queue_btn.isEnabled()
+    assert not dialog.add_to_queue_btn.isEnabled()
     assert "not prepared" in dialog.status_lbl.text()
 
 
@@ -806,3 +810,187 @@ def test_one_failed_delete_does_not_strand_the_rest(
     assert fails_dir.exists()
     assert not succeeds_dir.exists()
     assert reported and "unlucky" in reported[0]
+
+
+# --------------------------------------------------------------------------
+# the queue: an explicit, ordered list beside the tree
+# --------------------------------------------------------------------------
+def test_only_a_runnable_job_can_be_added_to_the_queue(
+    qapp: Any, working_dir: Path, patched_working_dirs: None
+) -> None:
+    _save(working_dir, "ready", prepared=True)
+    _save(working_dir, "not-ready", prepared=False)
+    dialog = LoadJobDialog("default")
+    dialog.job_tree.selectAll()
+
+    assert not dialog.add_to_queue_btn.isEnabled()
+
+
+def test_only_prepared_jobs_on_this_config_can_be_added_to_the_queue(
+    qapp: Any, working_dir: Path, patched_working_dirs: None
+) -> None:
+    """A queue has nobody to answer a prompt, and no business using another
+    config's credentials -- even calling `_add_to_queue` directly against a
+    mixed selection (the button itself would be disabled first) must not let
+    either kind in.
+    """
+    _save(working_dir, "ready", prepared=True, profile="config")
+    _save(working_dir, "raw", prepared=False, profile="config")
+    _save(working_dir, "other-config", prepared=True, profile="anime")
+    dialog = LoadJobDialog("config")
+    dialog.only_this_config.setChecked(False)
+    dialog.job_tree.selectAll()
+
+    dialog._add_to_queue()
+
+    assert [listing.name for listing in dialog.queueable_listings()] == ["ready"]
+
+
+def test_adding_jobs_builds_a_queue_in_click_order(
+    qapp: Any, working_dir: Path, patched_working_dirs: None
+) -> None:
+    """Queue order must come from when each job was added, not from the
+    tree's row order -- otherwise this would pass even if `_add_to_queue`
+    silently re-sorted the queue to match the tree on every call.
+
+    Newest-first sorting puts "second" at row 0 and "first" at row 1. Adding
+    "first" (row 1) before "second" (row 0) makes the click order the exact
+    reverse of the tree's display order, so only a queue that actually
+    tracks add order -- not display order -- produces this sequence.
+    """
+    _save(working_dir, "first", created_at="2026-01-01T00:00:00+00:00")
+    _save(working_dir, "second", created_at="2026-06-01T00:00:00+00:00")
+    dialog = LoadJobDialog("default")
+    # `_load_listings` leaves row 0 selected as the initial current item;
+    # clear it so only the row picked below is selected on the first add.
+    dialog.job_tree.clearSelection()
+
+    dialog.job_tree.topLevelItem(1).setSelected(True)
+    dialog._add_to_queue()
+    dialog.job_tree.clearSelection()
+    dialog.job_tree.topLevelItem(0).setSelected(True)
+    dialog._add_to_queue()
+
+    assert [listing.name for listing in dialog.queueable_listings()] == [
+        "first",
+        "second",
+    ]
+
+
+def test_a_job_cannot_be_queued_twice(
+    qapp: Any, working_dir: Path, patched_working_dirs: None
+) -> None:
+    _save(working_dir, "once")
+    dialog = LoadJobDialog("default")
+    dialog.job_tree.topLevelItem(0).setSelected(True)
+
+    dialog._add_to_queue()
+    dialog._add_to_queue()
+
+    assert dialog.queue_list.count() == 1
+
+
+def test_a_queued_job_can_be_moved_up(
+    qapp: Any, working_dir: Path, patched_working_dirs: None
+) -> None:
+    """Asserts the resulting sequence, not merely that the current row moved.
+
+    "a" and "b" are queued in tree row order ("b" first, since newest-first
+    sorting puts it at row 0), giving a starting queue of ["b", "a"]. Moving
+    "a" up must produce ["a", "b"] -- which matches neither that add order
+    nor the tree's display order, so it cannot pass by coincidence.
+    """
+    _save(working_dir, "a", created_at="2026-01-01T00:00:00+00:00")
+    _save(working_dir, "b", created_at="2026-06-01T00:00:00+00:00")
+    dialog = LoadJobDialog("default")
+    dialog.job_tree.topLevelItem(0).setSelected(True)
+    dialog._add_to_queue()
+    dialog.job_tree.clearSelection()
+    dialog.job_tree.topLevelItem(1).setSelected(True)
+    dialog._add_to_queue()
+    dialog.queue_list.setCurrentRow(1)
+
+    dialog._move_queued(-1)
+
+    assert dialog.queue_list.currentRow() == 0
+    assert [listing.name for listing in dialog.queueable_listings()] == ["a", "b"]
+
+
+def test_removing_from_the_queue_leaves_the_job_saved(
+    qapp: Any, working_dir: Path, patched_working_dirs: None
+) -> None:
+    directory = _save(working_dir, "keep")
+    dialog = LoadJobDialog("default")
+    dialog.job_tree.topLevelItem(0).setSelected(True)
+    dialog._add_to_queue()
+    dialog.queue_list.setCurrentRow(0)
+
+    dialog._remove_queued()
+
+    assert dialog.queue_list.count() == 0
+    assert directory.exists()
+
+
+def test_run_queue_needs_a_queue(
+    qapp: Any, working_dir: Path, patched_working_dirs: None
+) -> None:
+    _save(working_dir, "ready")
+    dialog = LoadJobDialog("default")
+
+    assert not dialog.queue_btn.isEnabled()
+
+    dialog.job_tree.topLevelItem(0).setSelected(True)
+    dialog._add_to_queue()
+
+    assert dialog.queue_btn.isEnabled()
+
+
+def test_adding_prepared_jobs_enables_the_queue_and_accept_queue_reports_them(
+    qapp: Any, working_dir: Path, patched_working_dirs: None
+) -> None:
+    _save(working_dir, "ready-one", prepared=True, profile="config")
+    _save(working_dir, "ready-two", prepared=True, profile="config")
+    dialog = LoadJobDialog("config")
+    dialog.job_tree.selectAll()
+
+    dialog._add_to_queue()
+
+    assert dialog.queue_btn.isEnabled()
+
+    dialog._accept_queue()
+
+    assert {listing.name for listing in dialog.queued_listings} == {
+        "ready-one",
+        "ready-two",
+    }
+    assert dialog.selected_listing is None
+
+
+def test_deleting_a_queued_job_takes_it_out_of_the_queue(
+    qapp: Any,
+    working_dir: Path,
+    patched_working_dirs: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Asserts the queue shrank AND that an unrelated queued job survived --
+    otherwise this would still pass a `_drop_from_queue` that emptied the
+    whole queue on any delete, rather than only the deleted job's entry.
+    """
+    _save(working_dir, "doomed", created_at="2026-01-01T00:00:00+00:00")
+    _save(working_dir, "survivor", created_at="2026-06-01T00:00:00+00:00")
+    dialog = LoadJobDialog("default")
+    dialog.job_tree.selectAll()
+    dialog._add_to_queue()
+    doomed_item = dialog.job_tree.findItems("doomed", Qt.MatchFlag.MatchExactly, 0)[0]
+    dialog.job_tree.clearSelection()
+    doomed_item.setSelected(True)
+    monkeypatch.setattr(
+        load_job_dialog_module.QMessageBox,
+        "question",
+        lambda *_a, **_k: load_job_dialog_module.QMessageBox.StandardButton.Yes,
+    )
+
+    dialog._delete_selected()
+
+    assert dialog.queue_list.count() == 1
+    assert [listing.name for listing in dialog.queueable_listings()] == ["survivor"]

--- a/tests/test_frontend/test_process_page_retry.py
+++ b/tests/test_frontend/test_process_page_retry.py
@@ -3,7 +3,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from PySide6.QtCore import QObject, QThread, QTimer, Signal, Slot
-from PySide6.QtWidgets import QMessageBox, QWidget
+from PySide6.QtWidgets import QMessageBox, QTextBrowser, QWidget
 import pytest
 
 from src.backend.upload_retry import (
@@ -160,6 +160,24 @@ def test_retry_is_relabelled_when_the_tracker_may_have_the_torrent(responses) ->
         ProcessPage._on_upload_retry_signal(QWidget(), _failure(server_accepted=True))
 
     assert responses == [UploadRetryAction.RETRY]
+
+
+def test_replacing_the_last_line_scrubs_secrets_too(qapp) -> None:
+    """`_on_text_update` scrubs before inserting; its replace-last-line twin
+    did not, even though the same plugin-reachable channel
+    (`UploadReporter.replace_last_line`, fed from `ProcessBackEnd`) writes
+    through it. The gap was the log *pane* specifically -- the logger itself
+    already scrubs centrally before anything reaches disk.
+    """
+    stub = SimpleNamespace(text_widget=QTextBrowser())
+
+    ProcessPage._on_text_update_replace_last_line(
+        stub,
+        "<span>done: https://tracker.example/"
+        "deadbeefdeadbeefdeadbeefdeadbeef/announce</span>",
+    )
+
+    assert "deadbeefdeadbeefdeadbeefdeadbeef" not in stub.text_widget.toPlainText()
 
 
 def test_cancel_hides_the_process_button() -> None:

--- a/tests/test_frontend/test_wizard.py
+++ b/tests/test_frontend/test_wizard.py
@@ -99,6 +99,39 @@ def test_open_load_job_dialog_frees_the_dialog_when_the_user_cancels(
     assert _FakeLoadJobDialog.instances[0].delete_later_called is True
 
 
+def test_the_jobs_button_tooltip_explains_what_it_opens(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The "Jobs" button repurposes the wizard's unused HelpButton slot (see
+    the comment above it in production), so nothing about its label says
+    what it does -- the tooltip is the only explanation the user gets. Pinned
+    so a rename silently reverting the wording, as already happened once on
+    this branch, is caught here.
+
+    Page construction and processing-context setup are heavy and unrelated
+    to the button itself, so they are stubbed to let a real
+    `MainWindowWizard` come up far enough to build its buttons.
+    """
+    monkeypatch.setattr(
+        wizard_module,
+        "create_processing_context",
+        lambda *_a, **_k: SimpleNamespace(),
+    )
+    monkeypatch.setattr(MainWindowWizard, "_generate_new_pages", lambda self: [])
+    monkeypatch.setattr(MainWindowWizard, "_insert_plugin_page", lambda self: None)
+    monkeypatch.setattr(MainWindowWizard, "_build_wizard_pages", lambda self: None)
+    monkeypatch.setattr(MainWindowWizard, "_set_start_page", lambda self: None)
+    config = SimpleNamespace(
+        settings=SimpleNamespace(), plugin_manager=SimpleNamespace()
+    )
+
+    wizard = MainWindowWizard(config, None)  # pyright: ignore[reportArgumentType]
+
+    assert wizard.load_job_button.toolTip() == (
+        "Browse saved jobs: load one to process it, or queue several"
+    )
+
+
 def test_open_load_job_dialog_frees_the_dialog_after_accepting_a_queue(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_frontend/test_wizard.py
+++ b/tests/test_frontend/test_wizard.py
@@ -1,5 +1,10 @@
-from PySide6.QtWidgets import QWizard, QWizardPage
+from types import SimpleNamespace
+from typing import Any
 
+from PySide6.QtWidgets import QDialog, QWizard, QWizardPage
+import pytest
+
+import src.frontend.wizards.wizard as wizard_module
 from src.frontend.wizards.wizard import MainWindowWizard
 
 
@@ -43,3 +48,87 @@ def test_remove_all_pages_schedules_deletion_and_detaches_pages() -> None:
     # ... and each removed page scheduled for deletion rather than left
     # dangling with live connections.
     assert all(page.delete_later_called for page in pages)
+
+
+class _FakeLoadJobDialog:
+    """Stands in for `LoadJobDialog`, whose own `.exec()` would block on a
+    real modal loop. Records `deleteLater()` so a leak -- a parented dialog
+    surviving as a hidden child of the wizard -- is observable without
+    needing to construct the real dialog's tree, details pane and loader.
+    """
+
+    instances: list["_FakeLoadJobDialog"] = []
+
+    def __init__(self, *_args: Any, **_kwargs: Any) -> None:
+        self.delete_later_called = False
+        self.queued_listings: list[Any] = []
+        self.selected_listing: Any = None
+        self._result = QDialog.DialogCode.Rejected
+        _FakeLoadJobDialog.instances.append(self)
+
+    def exec(self) -> int:
+        return int(self._result)
+
+    def deleteLater(self) -> None:
+        self.delete_later_called = True
+
+
+@pytest.fixture(autouse=True)
+def _reset_fake_dialog_instances() -> None:
+    _FakeLoadJobDialog.instances = []
+
+
+def test_open_load_job_dialog_frees_the_dialog_when_the_user_cancels(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Parenting `dialog` to the wizard (`LoadJobDialog(..., self)`) makes it
+    survive as a hidden child for the wizard's life without `deleteLater()` --
+    the same leak `queue_dialog` a few lines below is already guarded against,
+    worse here since this dialog carries a listing tree, a details pane and
+    one retired `_ListingLoader` per reload.
+    """
+    wizard = QWizard()
+    wizard.config = SimpleNamespace(  # pyright: ignore[reportAttributeAccessIssue]
+        program=SimpleNamespace(current_config="default")
+    )
+    monkeypatch.setattr(wizard_module, "LoadJobDialog", _FakeLoadJobDialog)
+
+    MainWindowWizard.open_load_job_dialog(wizard)
+
+    assert len(_FakeLoadJobDialog.instances) == 1
+    assert _FakeLoadJobDialog.instances[0].delete_later_called is True
+
+
+def test_open_load_job_dialog_frees_the_dialog_after_accepting_a_queue(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The leak is not limited to the cancel path -- every accepted run
+    (queue or single job) has to schedule the same cleanup."""
+    wizard = QWizard()
+    wizard.config = SimpleNamespace(  # pyright: ignore[reportAttributeAccessIssue]
+        program=SimpleNamespace(current_config="default")
+    )
+
+    class _AcceptedQueueDialog(_FakeLoadJobDialog):
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            super().__init__(*args, **kwargs)
+            self._result = QDialog.DialogCode.Accepted
+            self.queued_listings = [SimpleNamespace(path="does-not-matter")]
+
+    class _FakeQueueDialog:
+        def __init__(self, *_args: Any, **_kwargs: Any) -> None:
+            self.delete_later_called = False
+
+        def start(self) -> None: ...
+        def exec(self) -> None: ...
+
+        def deleteLater(self) -> None:
+            self.delete_later_called = True
+
+    monkeypatch.setattr(wizard_module, "LoadJobDialog", _AcceptedQueueDialog)
+    monkeypatch.setattr(wizard_module, "JobQueueDialog", _FakeQueueDialog)
+
+    MainWindowWizard.open_load_job_dialog(wizard)
+
+    assert len(_FakeLoadJobDialog.instances) == 1
+    assert _FakeLoadJobDialog.instances[0].delete_later_called is True


### PR DESCRIPTION
Follow-up to the job system: closes correctness gaps in saving, resuming and
queueing jobs, and rebuilds the saved-job picker.

## Queue correctness

- **A queued job no longer re-uploads itself.** After a job runs, its files are
  reconciled with what actually happened: a tracker whose upload provably
  landed is removed from the job, and a job with nothing left is deleted.
  Anything else — never attempted, skipped, failed, disabled in config, or an
  upload nobody can account for — stays. Previously an uploaded job survived
  intact, so running the queue twice uploaded everything twice.
- **The queue has its own window.** It used to borrow the process page, which
  left it invisible (nothing navigated there), uncancellable, and sharing
  per-run state. It now shows each job with its trackers underneath, and can
  be stopped between jobs. A finished job collapses to one line; one with a
  problem stays open on the tracker that explains why.

## Saving and resuming

- A deferred job keeps the titles and NFOs from its run, including overview
  edits, and the prompt says so — it previously claimed the opposite.
- The base torrent is only reused when every file it covers is unchanged.
  Before, only the first file was checked, so editing one episode of a pack
  cloned a torrent whose piece hashes no longer matched its content.
- Cached MediaInfo dumps are dropped when the wizard restarts, so a new run
  cannot inherit a dump describing a previous encode.
- Metadata-provider payloads are filtered for serialisability, so one odd
  value costs that field rather than the whole save.
- Job names are escaped before reaching the log pane, and the save
  confirmation renders as plain text.
- The clean-up size scan survives a file or directory vanishing mid-walk.

## The saved-job picker

The start-page button is now **Jobs** and opens **Saved Jobs**:

- Filter by name, title or tracker; sort by any column; other configs hidden
  by default but one checkbox away.
- A details pane showing a job's trackers and image hosts, screenshot count,
  media path and disk usage.
- Jobs whose source media has moved are flagged and cannot be processed.
- Rename (F2), multi-select delete, and an explicit ordered queue list
  replacing "whatever happens to be selected".
- Disabled actions explain themselves instead of going grey silently.
- The listing scan runs off the GUI thread.

## Documentation

`using-the-wizard.md` gains a saved-jobs section covering jobs, config
profiles and the queue. Several CHANGELOG claims that no longer matched the
code have been corrected.

## Testing

1465 passing (up from 1348), with `ruff check`, `ruff format --check` and
`basedpyright` clean at every commit.
