### PR TITLE
fix: collect plugin API modules in frozen builds

### DIFF
--- a/build.py
+++ b/build.py
@@ -10,6 +10,21 @@ from stdlib_list import stdlib_list
 
 from src.backend.utils.get_os_executable_ext import get_executable_string_by_os
 
+# Modules that exist for external plugins to import rather than for NfoForge's
+# own use. Nothing here imports them, so PyInstaller's walk from the entry
+# script never reaches them and they are left out of the frozen build -- which
+# a plugin discovers only as `No module named ...` once a user runs a release,
+# since running from source resolves them off the filesystem regardless.
+#
+# The build cannot infer this set for itself: plugins are copied in after the
+# freeze, are not present on the build machine, and may be compiled, so their
+# imports are beyond static analysis. Naming them here stands in for the import
+# edge PyInstaller has no way to see.
+PLUGIN_API_MODULES: list[str] = [
+    # `WizardPluginBase`, which a wizard plugin subclasses
+    "src.plugins.plugin_wizard_base",
+]
+
 
 def get_std_lib() -> list:
     """Return all standard library modules removing 'this' and 'antigravity'"""
@@ -17,6 +32,19 @@ def get_std_lib() -> list:
     standard_lib.remove("this")
     standard_lib.remove("antigravity")
     return standard_lib
+
+
+def spec_hiddenimports(include_std_lib: bool) -> list[str]:
+    """Modules to name in the spec that PyInstaller's own walk would not find.
+
+    The plugin API is always included. The standard library is per-build, and
+    the plugin API must not be gated on that choice: a build without the
+    standard library is still a build external plugins load into.
+    """
+    hiddenimports: list[str] = list(PLUGIN_API_MODULES)
+    if include_std_lib:
+        hiddenimports += get_std_lib()
+    return hiddenimports
 
 
 def modify_spec_file(spec_file_path: Path, hiddenimports: list):
@@ -183,10 +211,8 @@ def build_app(folder_name: str, include_std_lib: bool, debug: bool = False):
     # modify the generated spec file
     spec_file_path = pyinstaller_folder / "NfoForge.spec"
 
-    # add standard lib to bundle if needed
-    if include_std_lib:
-        hiddenimports = get_std_lib()
-        modify_spec_file(spec_file_path, hiddenimports)
+    # name the modules PyInstaller's own import walk cannot reach
+    modify_spec_file(spec_file_path, spec_hiddenimports(include_std_lib))
 
     # modify the generated spec file to include two executables
     modify_spec_file_for_dual_exe(spec_file_path)

--- a/tests/test_plugins/test_plugin_api_bundling.py
+++ b/tests/test_plugins/test_plugin_api_bundling.py
@@ -1,0 +1,78 @@
+"""Plugin-facing modules must be declared for the frozen build to collect them.
+
+PyInstaller assembles its module list by walking imports from the entry script,
+so a module nothing in NfoForge imports is never reached and does not enter the
+bundle. Most of `src.plugins` rides along because the loader and manager import
+it for their own work, but a module written purely for external plugins to
+subclass or call has no internal importer by design. It drops out of every
+release while continuing to work when NfoForge runs from source, and the plugin
+that imports it then fails with `No module named ...` for the user alone.
+
+The build cannot discover these for itself. Plugins are copied in after the
+freeze, are not present on the build machine, and may be compiled, which puts
+their imports beyond static analysis. `build.PLUGIN_API_MODULES` is the
+declaration that stands in for the missing import edge, and this keeps it
+honest: every module in the plugin package is either reached by host code or
+named there, and none may be quietly neither.
+"""
+
+import ast
+from pathlib import Path
+
+from build import PLUGIN_API_MODULES, spec_hiddenimports
+from tests.repo_paths import REPO_ROOT
+
+HOST_SOURCE = REPO_ROOT / "src"
+PLUGIN_PACKAGE = HOST_SOURCE / "plugins"
+
+
+def dotted_name(module: Path) -> str:
+    """The importable name of a source file, e.g. `src.plugins.api`."""
+    return ".".join(module.relative_to(REPO_ROOT).with_suffix("").parts)
+
+
+def imported_names(module: Path) -> set[str]:
+    """Every dotted name a source file imports.
+
+    `from x.y import z` contributes both `x.y` and `x.y.z`, because that syntax
+    cannot be told apart from an attribute import without resolving it. The
+    extra name is harmless: these are only ever looked up, never trusted to be
+    modules.
+    """
+    names: set[str] = set()
+    for node in ast.walk(ast.parse(module.read_text(encoding="utf-8"))):
+        if isinstance(node, ast.Import):
+            names.update(alias.name for alias in node.names)
+        # a relative import addresses the importing package, not this one
+        elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+            names.add(node.module)
+            names.update(f"{node.module}.{alias.name}" for alias in node.names)
+    return names
+
+
+def test_every_plugin_module_is_either_imported_by_nfoforge_or_declared() -> None:
+    imported_by_host: set[str] = set()
+    for source in HOST_SOURCE.rglob("*.py"):
+        imported_by_host |= imported_names(source)
+
+    undeclared = sorted(
+        name
+        for module in PLUGIN_PACKAGE.glob("*.py")
+        if (name := dotted_name(module)) not in imported_by_host
+        and name not in PLUGIN_API_MODULES
+    )
+
+    assert not undeclared, (
+        "these modules in src/plugins are imported by no NfoForge code, so "
+        "PyInstaller will not collect them and any plugin importing one will "
+        "fail to load in a release build. Add them to build.PLUGIN_API_MODULES "
+        f"if they exist for plugins, or remove them if they are dead: {undeclared}"
+    )
+
+
+def test_declared_modules_are_collected_without_the_standard_library() -> None:
+    # the stdlib is opt-in per build, and the plugin API must not be gated on
+    # that unrelated choice
+    hiddenimports = spec_hiddenimports(include_std_lib=False)
+
+    assert set(PLUGIN_API_MODULES) <= set(hiddenimports)


### PR DESCRIPTION
## Problem

A compiled external plugin that loads fine when NfoForge runs from source fails in a release build:

> No module named 'src.plugins.plugin_wizard_base'

PyInstaller assembles its module list by walking imports from the entry script. `src/plugins/plugin_wizard_base.py` exists only for external plugins to subclass, so no NfoForge code imports it, the walk never reaches it, and it is left out of the bundle. Running from source resolves it off the filesystem regardless, so the gap appears only in a release.

Of the five modules in `src/plugins/`, it is the only one with no internal importer, and the only one absent from the shipped exe:

| module | NfoForge modules importing it | in the exe |
| --- | --- | --- |
| `api` | 12 | present |
| `manager` | 3 | present |
| `loader` | 1 | present |
| `plugin_prompt_dialog` | 1 | present |
| `plugin_wizard_base` | 0 | absent |

`api` survives only because `loader.py` imports it for its own `isinstance` check.

The build cannot discover this for itself: plugins are copied in after the freeze, are not present on the build machine, and may be compiled, so their imports are beyond static analysis.

## Change

- `PLUGIN_API_MODULES` in `build.py` names the modules that exist for plugins rather than for NfoForge's own use, and the build adds them to the spec's `hiddenimports`.
- Hidden imports were previously applied only when `include_std_lib` was set, which left the plugin API gated on an unrelated per-build choice. They are now applied either way; the standard library stays opt-in exactly as before.
- A test asserts every module in `src/plugins/` is either imported by NfoForge or declared in that list, so the next plugin-facing module cannot go missing silently.

## Verification

- `ruff check`, `ruff format --check` and `basedpyright` all clean
- Full suite: 2348 passed, 2 skipped
- Guard proven: with the list emptied it fails naming `src.plugins.plugin_wizard_base`; populated, it passes
- Generated spec confirmed to receive `hiddenimports=['src.plugins.plugin_wizard_base']`, and `include_std_lib=True` still yields the full standard library list plus it

## Open question, deliberately not settled here

There are currently two candidates for "the wizard base a plugin subclasses":

- `WizardPluginBase` -- named and docstringed for plugins, lives in `src/plugins/`, undocumented, and overrides only `__init__` to forward its arguments unchanged
- `BaseWizardPage` -- what `PluginDefinition.wizard_page` is actually typed as, and imported in `api.py` only under `TYPE_CHECKING`, so plugins cannot obtain it from `src.plugins.api` at runtime

This PR treats `WizardPluginBase` as public and ships it, which is the smaller change and needs no API decision. If you would rather retire it in favour of `BaseWizardPage` re-exported from `src.plugins.api`, the list simply loses an entry and the test keeps holding either way.
