### PR TITLE
fix: strip local state from the runtime a build ships

### DIFF
--- a/build.py
+++ b/build.py
@@ -26,6 +26,57 @@ PLUGIN_API_MODULES: list[str] = [
 ]
 
 
+# Directories in the bundled runtime that hold nothing but local state. The
+# runtime is seeded from `runtime/` on the build machine rather than from a
+# clean template, so each of these arrives holding whatever that machine
+# accumulated. They are cleared wholesale rather than by file extension: the
+# old patterns matched NfoForge's own `.toml` and `.log` names, which let a
+# plugin's JSON credentials and a rotated `.log.1` reach a build.
+#
+# `docs` is deliberately absent. It is untracked like these are, but the build
+# generates it, so clearing it would ship a release with no documentation.
+LOCAL_STATE_DIRS = ("apps", "cookies", "logs", "templates", "user_packages")
+
+# Under `config`, everything is the user's own except these two, which are the
+# packaged defaults a release starts from.
+PACKAGED_CONFIG_DIRS = ("audio_conventions", "defaults")
+
+
+def _clear_directory(directory: Path) -> None:
+    """Empty a directory, leaving it in place, if it is there at all."""
+    if not directory.is_dir():
+        return
+    for item in directory.iterdir():
+        if item.is_dir():
+            shutil.rmtree(item, ignore_errors=True)
+        else:
+            item.unlink(missing_ok=True)
+
+
+def strip_local_state(bundled_runtime: Path) -> None:
+    """Remove the build machine's own data from the runtime a release ships.
+
+    Credentials, saved configuration, logs and cookies all live under the
+    runtime directory this build copies verbatim, so without this a release
+    carries whatever the maintainer's install happened to hold.
+    """
+    for name in LOCAL_STATE_DIRS:
+        _clear_directory(bundled_runtime / name)
+
+    config = bundled_runtime / "config"
+    if config.is_dir():
+        for item in config.iterdir():
+            if item.name in PACKAGED_CONFIG_DIRS:
+                continue
+            if item.is_dir():
+                shutil.rmtree(item, ignore_errors=True)
+            else:
+                item.unlink(missing_ok=True)
+
+    # local plugin installs, which are not part of a release
+    shutil.rmtree(bundled_runtime / "plugins", ignore_errors=True)
+
+
 def get_std_lib() -> list:
     """Return all standard library modules removing 'this' and 'antigravity'"""
     standard_lib = stdlib_list()
@@ -282,32 +333,7 @@ def build_app(folder_name: str, include_std_lib: bool, debug: bool = False):
     )
 
     # remove dev files
-    bundled_runtime = Path(exe_path.parent / "bundle" / "runtime")
-
-    # remove all config files from config directory
-    for cfg_file in Path(bundled_runtime / "config").rglob("*.toml"):
-        if not str(cfg_file.parent).endswith("defaults"):
-            cfg_file.unlink(missing_ok=True)
-
-    # remove templates
-    for template_file in Path(bundled_runtime / "templates").glob("*.txt"):
-        template_file.unlink(missing_ok=True)
-
-    # remove user packages
-    user_packages = bundled_runtime / "user_packages"
-    if user_packages.exists():
-        shutil.rmtree(bundled_runtime / "user_packages", ignore_errors=True)
-
-    # remove logs
-    for log_file in Path(bundled_runtime / "logs").glob("*.log"):
-        log_file.unlink(missing_ok=True)
-
-    # remove cookies
-    for cookie_file in Path(bundled_runtime / "cookies").glob("*.pkl"):
-        cookie_file.unlink(missing_ok=True)
-
-    # remove plugins folder
-    shutil.rmtree(bundled_runtime / "plugins", ignore_errors=True)
+    strip_local_state(Path(exe_path.parent / "bundle" / "runtime"))
 
     # Return a success message
     return success

--- a/tests/test_build_runtime.py
+++ b/tests/test_build_runtime.py
@@ -1,0 +1,93 @@
+"""A release must not carry the maintainer's own data out of their checkout.
+
+The bundled runtime is seeded from `runtime/` as it exists on the build
+machine, not from a clean template, so it arrives holding whatever that
+machine accumulated: saved credentials and config under `config/`, a log
+history, cookies. Stripping it by file extension is what let a plugin's JSON
+credentials and a rotated `.log.1` reach a build, since the patterns were
+written around NfoForge's own `.toml` and `.log` names.
+
+CI is unaffected either way -- a fresh checkout has none of this, as
+`.gitignore` keeps it all untracked -- which is exactly why a local build is
+the one that leaks and the one nobody checks.
+"""
+
+from pathlib import Path
+
+from build import strip_local_state
+
+# Files a maintainer's checkout accumulates that must never reach a release.
+# A plugin's saved credential and a rotated log are the two that really
+# shipped: one survived because the config sweep only matched `*.toml`, the
+# other because the log sweep only matched `*.log`.
+LOCAL_STATE = (
+    "config/plugins/example_plugin_auth.json",
+    "config/plugins/example_plugin.toml",
+    "config/user/user_config.toml",
+    "config/program/program_conf.toml",
+    "logs/nfoforge.log",
+    "logs/nfoforge.log.1",
+    "logs/crash.log",
+    "cookies/session.pkl",
+    "cookies/session.dat",
+    "templates/my_template.txt",
+    "templates/my_template.jinja",
+    "user_packages/mypkg/module.py",
+    "plugins/some_plugin/plugin.py",
+)
+
+# What a release genuinely needs, sitting in the same tree. `docs/` is
+# gitignored like the local state above, but the build generates it, so
+# "drop everything untracked" would silently ship a release with no docs.
+SHIPPED = (
+    "config/defaults/default_config.toml",
+    "config/defaults/default_program_conf.toml",
+    "config/audio_conventions/default.json",
+    "docs/index.html",
+    "fonts/Roboto/Roboto-Regular.ttf",
+    "images/NfoForge_logo.png",
+)
+
+
+def build_runtime(root: Path) -> Path:
+    """A bundled runtime holding both local state and what a release needs."""
+    for relative in LOCAL_STATE + SHIPPED:
+        path = root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("x", encoding="utf-8")
+    return root
+
+
+def test_local_state_does_not_survive_into_a_release(tmp_path) -> None:
+    runtime = build_runtime(tmp_path / "runtime")
+
+    strip_local_state(runtime)
+
+    survivors = sorted(
+        relative for relative in LOCAL_STATE if (runtime / relative).exists()
+    )
+    assert not survivors, (
+        f"these carry the build machine's own data into a release: {survivors}"
+    )
+
+
+def test_packaged_defaults_and_generated_docs_survive(tmp_path) -> None:
+    # the same sweep that removes local state must leave a working release
+    runtime = build_runtime(tmp_path / "runtime")
+
+    strip_local_state(runtime)
+
+    missing = sorted(
+        relative for relative in SHIPPED if not (runtime / relative).exists()
+    )
+    assert not missing, f"a release needs these and the sweep removed them: {missing}"
+
+
+def test_a_runtime_missing_the_optional_directories_is_not_an_error(tmp_path) -> None:
+    # not every checkout has run the app, so these may never have been created
+    runtime = tmp_path / "runtime"
+    (runtime / "config" / "defaults").mkdir(parents=True)
+
+    strip_local_state(runtime)
+
+    assert (runtime / "config" / "defaults").is_dir()


### PR DESCRIPTION
## Problem

The bundled runtime is copied from `runtime/` on the build machine rather than from a clean template:

```
f"--add-data={dev_runtime}:runtime",   # dev_runtime = project_root / "runtime"
```

The cleanup that followed matched by **file extension** -- `*.toml` under config, `*.log` under logs, `*.pkl` under cookies, `*.txt` under templates. Those patterns describe NfoForge's own file names, so anything written in another format stayed put.

Two things that really shipped in a local build here:

- **A plugin's saved credentials.** The config sweep matched `*.toml`, but a plugin storing its auth as JSON left a live credential in `bundle/runtime/config/plugins/`. Its neighbouring `.toml` files were correctly removed, which makes this easy to miss.
- **A rotated log.** `logs/*.log` never matches `nfoforge_....log.1`, so 20 MB of the maintainer's own log history shipped, dating back over a year.

`shutil.rmtree(bundled_runtime / "plugins")` is also easy to misread as covering the first case. It removes `runtime/plugins`, which is a different path from `runtime/config/plugins`.

## Not a CI problem

Releases built by `release.yml` were never affected. All of this is gitignored (`runtime/config/*`, `runtime/logs/`, `runtime/cookies/`, `runtime/templates/`), so a fresh checkout has none of it and the runner collects nothing.

That is precisely what makes it worth fixing: it only bites local builds, and it fails silently. Anyone building locally to test a change ships their own credentials, with nothing in the output to indicate it.

## Change

`strip_local_state()` clears those directories wholesale rather than by extension, keeping only the packaged defaults under `config` (`defaults/`, `audio_conventions/`).

`docs` is deliberately left alone. It is untracked like the rest, but the build generates it, so a naive "drop everything untracked" would ship a release with no documentation. That distinction is called out in the code and pinned by a test.

One small behaviour change worth noting: `user_packages` is now emptied rather than removed outright, matching how `logs`, `cookies` and `templates` are handled. `plugins` is still removed entirely, as before.

## Verification

Three tests build a runtime holding both local state and the files a release needs, then assert local state is gone and the packaged defaults, generated docs and fonts survive.

Non-vacuous: run the previous extension-based cleanup against the same fixture and four files survive, including both real-world cases.

```
config/plugins/example_plugin_auth.json
cookies/session.dat
logs/nfoforge.log.1
templates/my_template.jinja
```

- `ruff check .`, `ruff format --check`, `basedpyright` all clean
- Full suite: 2351 passed, 2 skipped
