### PR TITLE
ci: avoid duplicate quality runs on push+pull_request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,17 @@ name: CI
 
 on:
   push:
+    branches:
+      - main
+      - dev
   pull_request:
 
 permissions:
   contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   quality:


### PR DESCRIPTION
The quality job had no branch filter on either trigger, so pushing a commit to a branch with an open PR fired both push and pull_request events, running the identical job twice. Scope push to main/dev only so feature branches (always used via PR) get a single run from the pull_request event, and add a concurrency group to cancel stale runs when a PR gets rapid follow-up commits.