### PR TITLE
fix: BeyondHD title component order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- **BeyondHD release titles order their components differently.** Three changes, to BeyondHD alone:
+  - A Blu-ray, UHD Blu-ray or DVD source leads its resolution -- "BluRay 1080p" rather than "1080p BluRay". A WEB-DL is unaffected and still reads "2160p AMZN WEB-DL", which keeps the service abbreviation against WEB-DL.
+  - Frame size, cut and localization are stated in that order immediately ahead of the source: "IMAX Directors Cut Subbed REPACK UHD BluRay 2160p". The frame size and the cut previously came the other way round.
+  - A subbed or dubbed release is marked as one. BeyondHD had no localization component at all, so the claim was detected and shown on the rename page but never reached the title. It is the only tracker that states Subbed: Aither, LST and ReelFliX suppress it.
+
 ## [1.1.9] - 2026-08-26
 
 ### Added

--- a/src/backend/process.py
+++ b/src/backend/process.py
@@ -2891,6 +2891,12 @@ class ProcessBackEnd:
         produces is contiguous -- the mapper sorts guessit's list and keeps
         first and last -- so the range is exact rather than approximate for
         everything but a hand-built non-contiguous mapping.
+
+        `is_dvd` and `is_optical_source` both read the source override, so
+        an entry ordering its components by source cannot disagree with the
+        source the `{source}` token prints beside them. A source that is
+        absent or unrecognised leaves both false, which is the answer that
+        changes no tracker's order.
         """
         overrides = context.shared_data.dynamic_data.get("override_tokens") or {}
         media_info = None
@@ -2914,6 +2920,7 @@ class ProcessBackEnd:
             is_remux=bool(overrides.get("remux")),
             is_disc=False,
             is_dvd="dvd" in source,
+            is_optical_source="dvd" in source or "bluray" in source,
             resolution=resolution,
             hdr_identity=resolve_hdr_identity(media_info),
             season=release_info.season,

--- a/src/backend/trackers/media_support.py
+++ b/src/backend/trackers/media_support.py
@@ -80,6 +80,6 @@ UNIT3D_TRACKERS: frozenset[TrackerSelection] = frozenset(
 )
 
 # Whether a tracker's upload has a release-name field at all is a title rule,
-# so it lives on that tracker's entry -- see `accepts_a_release_name` in
-# `title_rules.py`. It used to be a frozenset here, beside the media-type
-# support tables, which answer a different question.
+# so it lives on that tracker's entry rather than here beside the media-type
+# support tables, which answer a different question -- see
+# `accepts_a_release_name` in `title_rules.py`.

--- a/src/backend/trackers/title_render.py
+++ b/src/backend/trackers/title_render.py
@@ -1,13 +1,12 @@
 """Render a release title through a tracker's entry.
 
-Two stages, replacing the four rewriting layers that grew up separately:
-compose from the entry (or the user's global template when it has none),
-then normalise from the entry. This module is the normalisation half.
+Two stages: compose from the entry (or the user's global template when it
+has none), then normalise from the entry. This module is the normalisation
+half.
 
 Normalisation always applies, whether or not the entry composes, so the
-seven trackers with no layout of their own still get their separator,
-colon and vocabulary imposed on the user's house style -- which is exactly
-what they do today through their own `generate_release_title`.
+seven trackers with no layout of their own still get their separator, colon
+and vocabulary imposed on the user's house style.
 """
 
 from __future__ import annotations
@@ -47,20 +46,18 @@ _TAG_SEPARATOR_LOOKBEHIND = r"(?<!-)"
 # that way) is untouched.
 _TRAILING_TAG_GAP = re.compile(r"\s+-(\S+)$")
 
-# BeyondHD's DD exception, carried over verbatim from the uploader's
-# own rule so the spelling cannot drift from what it enforced.
+# BeyondHD's DD exception: "DD5.1" closed up, where "DDP 5.1" stays spaced.
 _DD_CHANNELS = re.compile(r"\bDD\s+(\d\.[01])")
 
-# How NfoForge already spells each identity, mirroring
-# `{video_dynamic_range_type}`. Four of the eight are not written the way the
-# identity is named -- HDR10 is "HDR", HDR10+ is "HDR10Plus", and the two
-# Dolby Vision composites follow -- so the identity name is not usable as a
-# default. That token is what every packaged tracker template uses, so this
-# is what every tracker has been receiving; Aither's published "REMUX HDR
-# HEVC" and LST's "REMUX DV HDR HEVC" both show it.
+# How NfoForge spells each identity, mirroring `{video_dynamic_range_type}`.
+# Four of the eight are not written the way the identity is named -- HDR10 is
+# "HDR", HDR10+ is "HDR10Plus", and the two Dolby Vision composites follow --
+# so the identity name is not usable as a default. These spellings are what
+# trackers expect: Aither's published "REMUX HDR HEVC" and LST's "REMUX DV
+# HDR HEVC" both show it.
 #
-# It is also the vocabulary the per-tracker overrides are written against:
-# the three trackers publishing "HDR10+" map it from "HDR10Plus".
+# They are also what an entry's vocabulary is written against: the three
+# trackers publishing "HDR10+" map it from "HDR10Plus".
 _DEFAULT_SPELLINGS: Mapping[HdrType, str] = MappingProxyType(
     {
         "SDR": "SDR",

--- a/src/backend/trackers/title_rules.py
+++ b/src/backend/trackers/title_rules.py
@@ -7,15 +7,15 @@ setting that enforcement would override anyway.
 One entry per tracker, with no inheritance between them. Two entries that
 are currently identical stay written out separately: a tracker changing its
 rules must not require unpicking a shared abstraction, and must not be able
-to alter another tracker by accident. That is not a hypothetical -- the
-shipped config's worst defect was a template copied between two trackers
-whose published rules differ, which propagated an error into a tracker that
-never shared those rules. `test_no_two_entries_share_an_object` pins it.
+to alter another tracker by accident. Sharing one object between two
+trackers gives both of them whichever set of rules was written first, and
+two trackers are only identical until one of them publishes a change.
+`test_no_two_entries_share_an_object` pins it.
 
 An entry has two sections. Normalisation always applies. Composition is
 optional -- nine entries have none. Seven of those render the user's global
-title template, which is exactly what they do today; the remaining two
-render no title at all, having no release name field to put one in.
+title template; the remaining two render no title at all, having no release
+name field to put one in.
 
 A tracker rule never reaches a filename. Every rule lives in an entry, never
 in a token handler: handlers are shared, and `file_name_mode` selects only
@@ -267,10 +267,10 @@ def _is_series(release: ReleaseProperties) -> bool:
 # the entry's vocabulary rather than by a token that refuses to render it.
 _DUB = ("{audio_language_dual}", "{localization|unless(audio_language_dual)}")
 
-# Components carry no `:opt= :` prefix. The shipped templates needed one to
-# avoid a double space where a token did not resolve; normalisation closes
-# that gap for every entry now, so the plain form is enough and reads as the
-# published rules are written.
+# Components are plain tokens, carrying no `:opt= :` separator prefix.
+# Normalisation closes the gap an unresolved token leaves, for every entry,
+# so a component does not have to carry its own separator -- which lets the
+# list read the way the published rules are written.
 
 # Every entry is constructed inline. Two that read alike are still two
 # objects, so editing one cannot reach the other.
@@ -448,10 +448,9 @@ TITLE_RULES: Mapping[TrackerSelection, TrackerTitleEntry] = MappingProxyType(
                 omit=(OmitRule(when=_is_series, components=("{release_year}",)),),
             ),
         ),
-        # ReelFliX. Its shipped template was a near copy of BeyondHD's,
-        # but its published rules match LST and Aither -- so every remux was
-        # emitting audio before video where its rules require video first.
-        # That defect is why entries do not share objects.
+        # ReelFliX. Its published rules match LST and Aither rather than
+        # BeyondHD's, which is easy to get backwards given how alike the
+        # four read: video goes ahead of audio on a remux.
         TrackerSelection.REELFLIX: TrackerTitleEntry(
             normalisation=Normalisation(
                 colon=ColonReplace.KEEP,
@@ -503,7 +502,7 @@ TITLE_RULES: Mapping[TrackerSelection, TrackerTitleEntry] = MappingProxyType(
                 ),
             ),
         ),
-        # BeyondHD. Six differences from the shipped template:
+        # BeyondHD. Six rules that set it apart from the other three:
         #
         # - audio is {audio_codec} plus channels, giving "DDP Atmos 5.1" as
         #   BeyondHD requires, not the "DDP 5.1 Atmos" the other three want.
@@ -570,31 +569,27 @@ TITLE_RULES: Mapping[TrackerSelection, TrackerTitleEntry] = MappingProxyType(
                 omit=(OmitRule(when=_is_series, components=("{release_year}",)),),
             ),
         ),
-        # The four below are transcribed from the shipped config rather than
-        # from published rules, none having been gathered for them. What the
-        # config says is copied rather than improved -- {edition} rather than
-        # {cut}, undivided {audio_codec}, dash colon handling and the
-        # over-1080 SDR form all stand.
+        # No published rules have been gathered for the four below, so their
+        # layout is assumed rather than checked: {edition} rather than {cut},
+        # undivided {audio_codec}, dash colon handling and the over-1080 SDR
+        # form. Hold an entry here more loosely than the four above, and
+        # replace it outright if that tracker's rules are ever gathered.
         #
-        # Two things do not come from the config, because the config had
-        # nothing to say about either.
+        # Two things are not assumed.
         #
-        # Their shipped overrides cover films only, so a series on these
-        # trackers used to render the user's global template. An entry has no
-        # media-type split, so the composition now serves both, with the
-        # designator supplying the season and episode and an episode title
-        # beside it. Aither names the episode from its published examples;
-        # only LST, ReelFliX and BeyondHD are known to leave it out.
+        # An entry has no media-type split, so one composition serves films
+        # and series alike, the designator supplying the season and episode
+        # and an episode title sitting beside it. Aither names the episode
+        # from its published examples; only LST, ReelFliX and BeyondHD are
+        # known to leave it out.
         #
-        # The title is {title_exact}, where the config said {title_clean}.
-        # Clean answers to the user's `title_clean_rules`, which ship
-        # aggressive: they unidecode, drop apostrophes and flatten every
-        # non-alphanumeric to a space, so "Amelie's Cafe: Fire & Ice" reached
-        # these four as "Amelies Cafe Fire and Ice" and reached the four with
-        # gathered rules intact. Nothing published asks for that, a tracker
-        # rule that varies with a user setting is not a rule, and the split
-        # tracked which entries were transcribed rather than anything about
-        # the trackers. The episode title matches at the same tier.
+        # The title is {title_exact} rather than {title_clean}. Clean answers
+        # to the user's `title_clean_rules`, which ship aggressive: they
+        # unidecode, drop apostrophes and flatten every non-alphanumeric to a
+        # space, so "Amelie's Cafe: Fire & Ice" would reach these four as
+        # "Amelies Cafe Fire and Ice" while reaching the other four intact.
+        # A tracker rule that varies with a user setting is not a rule. The
+        # episode title matches at the same tier.
         TrackerSelection.DARK_PEERS: TrackerTitleEntry(
             normalisation=Normalisation(
                 colon=ColonReplace.REPLACE_WITH_DASH,
@@ -701,10 +696,9 @@ TITLE_RULES: Mapping[TrackerSelection, TrackerTitleEntry] = MappingProxyType(
 def accepts_a_release_name(tracker: TrackerSelection) -> bool:
     """Whether an upload to `tracker` carries a release name at all.
 
-    Was a frozenset beside the media-type support tables, which answers a
-    different question. A tracker's title rules are one object now, and
-    "there is no title" is one of them, so the answer comes from the entry
-    rather than from a list that has to be kept in step with it.
+    A tracker's title rules are one object, and "there is no title" is one
+    of them, so the answer comes from the entry rather than from a separate
+    list that would have to be kept in step with it.
 
     This is the accessor for a caller holding only a `TrackerSelection`.
     The renderer and `resolve_tracker_title` have the entry in hand already

--- a/src/backend/trackers/title_rules.py
+++ b/src/backend/trackers/title_rules.py
@@ -114,13 +114,25 @@ class ReleaseProperties:
     earns its place from a checked tracker -- `is_remux` and `is_disc` from
     the remux order swap and BeyondHD's dynamic range baseline, `is_dvd`
     from BeyondHD's DVD order and the LST and ReelFliX omit rules,
+    `is_optical_source` from BeyondHD's source-before-resolution rule,
     `resolution` and `hdr_identity` from every dynamic range rule, and
     `season`/`episodes` from the designator.
+
+    `is_optical_source` is not `is_disc`. It says the release came off
+    optical media -- Blu-ray, UHD Blu-ray or DVD -- however it was encoded,
+    where `is_disc` says the upload *is* a full disc. An encode from a
+    Blu-ray is the first and not the second.
+
+    It is a positive test for optical media rather than a negative one for
+    web, so a release whose source could not be determined keeps the order
+    every tracker used before this rule existed instead of being named as a
+    disc on a guess.
     """
 
     is_remux: bool = False
     is_disc: bool = False
     is_dvd: bool = False
+    is_optical_source: bool = False
     resolution: int = 1080
     hdr_identity: HdrType = "SDR"
     season: int | None = None
@@ -236,6 +248,10 @@ def _is_disc_or_remux(release: ReleaseProperties) -> bool:
 
 def _is_dvd(release: ReleaseProperties) -> bool:
     return release.is_dvd
+
+
+def _is_optical_source(release: ReleaseProperties) -> bool:
+    return release.is_optical_source
 
 
 def _is_dvd_remux(release: ReleaseProperties) -> bool:
@@ -487,8 +503,7 @@ TITLE_RULES: Mapping[TrackerSelection, TrackerTitleEntry] = MappingProxyType(
                 ),
             ),
         ),
-        # BeyondHD. Four differences from the shipped template, all from its
-        # published rules:
+        # BeyondHD. Six differences from the shipped template:
         #
         # - audio is {audio_codec} plus channels, giving "DDP Atmos 5.1" as
         #   BeyondHD requires, not the "DDP 5.1 Atmos" the other three want.
@@ -496,6 +511,17 @@ TITLE_RULES: Mapping[TrackerSelection, TrackerTitleEntry] = MappingProxyType(
         # - HYBRID sits against REMUX, since BeyondHD requires them adjacent.
         # - the DVD order is "MPEG-2 DD2.0", so the codec leads there
         #   where audio leads everywhere else.
+        # - an optical source leads its resolution -- "BluRay 1080p", "UHD
+        #   BluRay 2160p", "DVD 480p" -- where the other three write the
+        #   resolution first. Web keeps the resolution first, so a WEB-DL
+        #   still reads "2160p AMZN WEB-DL" with the service against WEB-DL
+        #   as every tracker requiring one wants it.
+        # - frame size, cut and localization are stated in that order ahead
+        #   of the source run: "IMAX Directors Cut Subbed REPACK UHD BluRay
+        #   2160p", or "... REPACK 2160p AMZN WEB-DL" off optical. The other
+        #   three order the first two the opposite way and suppress Subbed
+        #   through their vocabulary, so BeyondHD is the only entry that
+        #   states a subbed release at all.
         TrackerSelection.BEYOND_HD: TrackerTitleEntry(
             normalisation=Normalisation(
                 colon=ColonReplace.KEEP,
@@ -507,12 +533,19 @@ TITLE_RULES: Mapping[TrackerSelection, TrackerTitleEntry] = MappingProxyType(
                     "{title_exact}",
                     "{release_year}",
                     Designator.SIMPLE,
-                    "{cut}",
                     "{frame_size}",
+                    "{cut}",
+                    "{localization}",
                     "{re_release}",
-                    "{resolution}",
-                    "{streaming_service}",
-                    "{source}",
+                    ConditionalOrder(
+                        when=_is_optical_source,
+                        then=("{source}", "{resolution}"),
+                        otherwise=(
+                            "{resolution}",
+                            "{streaming_service}",
+                            "{source}",
+                        ),
+                    ),
                     "{hybrid}",
                     "{remux}",
                     ConditionalOrder(

--- a/src/backend/trackers/utils.py
+++ b/src/backend/trackers/utils.py
@@ -55,9 +55,9 @@ DISC_TITLE_REGEX = regex.compile(
 _CHANNEL_LAYOUT_REGEX = re.compile(r"(?<!\d)[1-9]\.[01](?:\.[0-9])?(?!\d)")
 _CHANNEL_LAYOUT_SENTINEL = "\x00"
 # A video codec's internal period is the same casualty as a channel layout:
-# nothing in the string distinguishes it from a separator. `H.264` shipped as
-# `H 264` to every tracker that spaces its titles, including one whose own
-# published example spells it `H.264`.
+# nothing in the string distinguishes it from a separator. Unprotected,
+# `H.264` reaches every tracker that spaces its titles as `H 264` -- including
+# one whose own published example spells it `H.264`.
 #
 # The left boundary excludes an alphanumeric rather than requiring whitespace,
 # because both title forms reach here: a composed title is space-separated,
@@ -79,8 +79,9 @@ def strip_title_dots(release_title: str) -> str:
 
     Both are protected before the periods are stripped rather than
     reconstructed afterwards. Reconstruction requires knowing every codec that can
-    precede the channels, and anything the list missed (AAC, Opus, LPCM, an Atmos
-    suffix between the codec and the channels, ...) silently shipped as "5 1".
+    precede the channels, and anything such a list missed (AAC, Opus, LPCM, an
+    Atmos suffix between the codec and the channels, ...) would silently become
+    "5 1".
     """
     name = _CHANNEL_LAYOUT_REGEX.sub(
         lambda match: match.group(0).replace(".", _CHANNEL_LAYOUT_SENTINEL),

--- a/tests/test_backend/test_tracker_naming_rules.py
+++ b/tests/test_backend/test_tracker_naming_rules.py
@@ -21,7 +21,11 @@ The rules being pinned, quoted as saved:
 - ReelFliX ........ the same remux/encode split as Aither and LST, video
                     ahead of audio on a remux; blank tag preferred over a
                     NOGROUP placeholder
-- BeyondHD ........ remux/encode/web-dl with no tag must end "-NOGROUP"
+- BeyondHD ........ remux/encode/web-dl with no tag must end "-NOGROUP";
+                    an optical source leads its resolution ("BluRay 1080p"),
+                    while web keeps "2160p AMZN WEB-DL"; frame size, cut and
+                    localization are stated in that order ahead of the source
+                    ("IMAX Directors Cut Subbed REPACK UHD BluRay 2160p")
 
 Known gaps, deliberately not asserted because NfoForge has no token for them.
 Each needs a new token rather than an edit to an entry:
@@ -82,6 +86,13 @@ REMUX_NAME = "Movie.Name.2026.REPACK.UHD.BluRay.2160p.TrueHD.Atmos.7.1.DV.HEVC.R
 ENCODE_NAME = "Movie.Name.2026.1080p.BluRay.TrueHD.Atmos.7.1.DV.HEVC.x265-SomeGroup.mkv"
 WEB_NAME = (
     "Movie.Name.2026.2160p.AMZN.WEB-DL.TrueHD.Atmos.7.1.DV.HEVC.H.265-SomeGroup.mkv"
+)
+# Carries all three of the components BeyondHD states ahead of its source,
+# which the other three trackers order differently and one of which they do
+# not state at all.
+CLAIMED_NAME = (
+    "Movie.Name.2026.IMAX.Directors.Cut.Subbed.REPACK.UHD.BluRay.2160p."
+    "TrueHD.Atmos.7.1.DV.HEVC.REMUX-SomeGroup.mkv"
 )
 
 
@@ -223,6 +234,7 @@ def _render(
     release = ReleaseProperties(
         is_remux=bool(overrides.get("remux")),
         is_dvd="dvd" in source.lower(),
+        is_optical_source="dvd" in source.lower() or "bluray" in source.lower(),
         resolution=height,
         hdr_identity=resolve_hdr_identity(media_info),
         season=season,
@@ -473,6 +485,78 @@ def test_beyondhd_glues_dd_to_its_channel_layout(
     ddp = _render(TrackerSelection.BEYOND_HD, WEB_NAME, "WEB-DL")
     assert "DDP 7.1" in ddp
     assert "DDP7.1" not in ddp
+
+
+@pytest.mark.parametrize(
+    ("name", "source", "expected"),
+    [
+        (ENCODE_NAME, "BluRay", "BluRay 2160p"),
+        (REMUX_NAME, "UHD BluRay", "UHD BluRay 2160p"),
+        (ENCODE_NAME, "DVD", "DVD 2160p"),
+        (WEB_NAME, "WEB-DL", "2160p AMZN WEB-DL"),
+    ],
+    ids=["encode", "remux", "dvd", "web"],
+)
+def test_beyondhd_leads_an_optical_source_with_the_source(
+    name: str, source: str, expected: str
+) -> None:
+    """BeyondHD writes "BluRay 1080p" where the other three write "1080p
+    BluRay". Web is the exception: the resolution still comes first, which
+    keeps the service abbreviation against WEB-DL where every tracker
+    asking for one wants it.
+
+    The DVD row pairs a source with the fixture's own 2160p, which no real
+    release does. What it pins is the branch rather than the pairing -- a
+    DVD is optical, so it leads on the same rule as the two Blu-ray shapes
+    rather than by way of the codec-first order it separately triggers.
+    """
+    assert expected in _render(TrackerSelection.BEYOND_HD, name, source)
+
+
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        ("UHD BluRay", "IMAX Directors Cut Subbed REPACK UHD BluRay 2160p"),
+        ("WEB-DL", "IMAX Directors Cut Subbed REPACK 2160p AMZN WEB-DL"),
+    ],
+    ids=["optical", "web"],
+)
+def test_beyondhd_states_frame_size_cut_and_localization_before_the_source(
+    source: str, expected: str
+) -> None:
+    """Frame size, cut and localization, in that order, against the source.
+
+    The group travels with the source under the same optical rule, so a
+    WEB-DL reads the same up to the point where the resolution and source
+    swap places. REPACK keeps its own position between the group and the
+    source rather than moving with either.
+
+    The service is supplied rather than detected because the name carries
+    none, and it is supplied for both rows: the optical branch has no
+    `{streaming_service}` component, so an explicit choice cannot put one in
+    a Blu-ray title.
+    """
+    rendered = _render(
+        TrackerSelection.BEYOND_HD, CLAIMED_NAME, source, streaming_service="AMZN"
+    )
+
+    assert f"Movie Name 2026 {expected} " in rendered
+
+
+@pytest.mark.parametrize("tracker", REMUX_AUDIO_LAST)
+def test_the_other_three_order_the_cut_first_and_state_no_subbed(
+    tracker: TrackerSelection,
+) -> None:
+    """The control, so the BeyondHD test above is about BeyondHD.
+
+    Aither, LST and ReelFliX write the cut ahead of the frame size, and
+    their vocabulary maps "Subbed" to nothing -- so a subbed release is
+    named as one on BeyondHD alone.
+    """
+    rendered = _render(tracker, CLAIMED_NAME, "UHD BluRay")
+
+    assert "Directors Cut IMAX" in rendered
+    assert "Subbed" not in rendered
 
 
 @pytest.mark.parametrize("tracker", ALL_FOUR)
@@ -803,16 +887,15 @@ def test_a_non_web_release_carries_no_streaming_service(
     source change into a BluRay title."""
     rendered = _render(tracker, WEB_NAME, "BluRay")
 
-    # BeyondHD puts Atmos with the codec and the channels after it,
-    # where the other three spell it the other way round.
-    audio = (
-        "TrueHD Atmos 7.1"
-        if tracker is TrackerSelection.BEYOND_HD
-        else "TrueHD 7.1 Atmos"
-    )
+    # Two spellings BeyondHD does not share with the other three: an
+    # optical source leads its resolution, and Atmos goes with the codec
+    # rather than after the channels.
+    beyond_hd = tracker is TrackerSelection.BEYOND_HD
+    quality = "BluRay 2160p" if beyond_hd else "2160p BluRay"
+    audio = "TrueHD Atmos 7.1" if beyond_hd else "TrueHD 7.1 Atmos"
 
     assert "AMZN" not in rendered
-    assert rendered == (f"Movie Name 2026 2160p BluRay {audio} DV HDR x265-SomeGroup")
+    assert rendered == (f"Movie Name 2026 {quality} {audio} DV HDR x265-SomeGroup")
 
 
 @pytest.mark.parametrize("tracker", ALL_FOUR)


### PR DESCRIPTION
BeyondHD now leads an optical source with its source -- "BluRay 1080p" rather than "1080p BluRay" -- with DVD and UHD Blu-ray following the same rule; a WEB-DL is unaffected. Frame size, cut and localization are stated in that order immediately ahead of the source and travel with it: the first two were ordered the other way round, and there was no localization component at all, so a subbed or dubbed release was detected and shown on the rename page but never named in the title. The ordering condition is a new `ReleaseProperties` field that tests positively for optical media, so a release whose source cannot be determined keeps the order it had rather than being named as a disc on a guess. New parametrised tests pin both orderings, with a control asserting the other three trackers are unchanged. A third commit rewrites comments across the trackers package that described rules by diffing them against the removed per-tracker title config -- comments only, no behaviour change.