### PR TITLE
fix: tracker title component order and season pack designator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- **BeyondHD release titles order their components differently.** Three changes, to BeyondHD alone:
+  - A Blu-ray, UHD Blu-ray or DVD source leads its resolution -- "BluRay 1080p" rather than "1080p BluRay". A WEB-DL is unaffected.
+  - Frame size, cut and localization are stated in that order immediately ahead of the source: "IMAX Directors Cut Subbed REPACK UHD BluRay 2160p". The frame size and the cut previously came the other way round.
+  - A subbed or dubbed release is marked as one. BeyondHD had no localization component at all, so the claim was detected and shown on the rename page but never reached the title. It is the only tracker that states Subbed: Aither, LST and ReelFliX suppress it.
+
 ## [1.1.9] - 2026-08-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
   - Frame size, cut and localization are stated in that order immediately ahead of the source: "IMAX Directors Cut Subbed REPACK UHD BluRay 2160p". The frame size and the cut previously came the other way round.
   - A subbed or dubbed release is marked as one. BeyondHD had no localization component at all, so the claim was detected and shown on the rename page but never reached the title. It is the only tracker that states Subbed: Aither, LST and ReelFliX suppress it.
 
+### Fixed
+
+- A season pack is named after its season on every tracker with hardcoded title rules -- "Show S01 BluRay ..." rather than "Show S01E01-05 BluRay ...". A pack maps every episode it contains, and the title was reading those mappings as an episode range, so it disagreed with the filename beside it and with the season/episode values sent to the tracker.
+
 ## [1.1.9] - 2026-08-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ### Fixed
 
-- A season pack is named after its season on every tracker with hardcoded title rules -- "Show S01 BluRay ..." rather than "Show S01E01-05 BluRay ...". A pack maps every episode it contains, and the title was reading those mappings as an episode range, so it disagreed with the filename beside it and with the season/episode values sent to the tracker.
+- A season pack is named after its season on every tracker with hardcoded title rules -- "Show S01 BluRay ..." rather than "Show S01E01-05 BluRay ...". A pack maps every episode it contains, and the title was reading those mappings as an episode range, so it disagreed with the filename beside it and with the season/episode values sent to the tracker. Only a release covering every episode TVDB lists for the season is named this way: a partial pack keeps its episode range rather than claiming a season it does not contain, as does a release whose season TVDB cannot list.
 
 ## [1.1.9] - 2026-08-26
 

--- a/src/backend/process.py
+++ b/src/backend/process.py
@@ -2891,6 +2891,12 @@ class ProcessBackEnd:
         produces is contiguous -- the mapper sorts guessit's list and keeps
         first and last -- so the range is exact rather than approximate for
         everything but a hand-built non-contiguous mapping.
+
+        `is_dvd` and `is_optical_source` both read the source override, so
+        an entry ordering its components by source cannot disagree with the
+        source the `{source}` token prints beside them. A source that is
+        absent or unrecognised leaves both false, which is the answer that
+        changes no tracker's order.
         """
         overrides = context.shared_data.dynamic_data.get("override_tokens") or {}
         media_info = None
@@ -2914,6 +2920,7 @@ class ProcessBackEnd:
             is_remux=bool(overrides.get("remux")),
             is_disc=False,
             is_dvd="dvd" in source,
+            is_optical_source="dvd" in source or "bluray" in source,
             resolution=resolution,
             hdr_identity=resolve_hdr_identity(media_info),
             season=release_info.season,

--- a/src/backend/process.py
+++ b/src/backend/process.py
@@ -2887,7 +2887,12 @@ class ProcessBackEnd:
         picker and the only_if/unless filters all resolve from it, so a
         composition keyed off it cannot disagree with what is printed.
 
-        `episodes` is derived from the span's ends. Every span NfoForge
+        `episodes` is derived from the span's ends, and only where the
+        release is a span. A pack maps every file it contains, so its ends
+        are exactly as populated as a span's and `is_pack` is the only thing
+        telling the two apart -- a pack that kept them is designated
+        "S01E01-05" where `display_tag` and the `{episode_number}` token
+        kwarg, which both read that flag, say "S01". Every span NfoForge
         produces is contiguous -- the mapper sorts guessit's list and keeps
         first and last -- so the range is exact rather than approximate for
         everything but a hand-built non-contiguous mapping.
@@ -2912,7 +2917,7 @@ class ProcessBackEnd:
 
         source = str(overrides.get("source", "")).lower()
         episodes: tuple[int, ...] = ()
-        if release_info.episode_start is not None:
+        if release_info.episode_start is not None and not release_info.is_pack:
             end = release_info.episode_end or release_info.episode_start
             episodes = tuple(range(release_info.episode_start, end + 1))
 

--- a/src/backend/process.py
+++ b/src/backend/process.py
@@ -111,6 +111,7 @@ from src.backend.utils.images import (
     get_parity_images_to_str,
 )
 from src.backend.utils.token_utils import get_prompt_tokens
+from src.backend.utils.tvdb_episodes import season_episode_numbers
 from src.config.config import ConfigManager
 from src.config.tv_tokens import get_tvr_title_token
 from src.context.processing_context import ProcessingContext
@@ -2888,14 +2889,10 @@ class ProcessBackEnd:
         composition keyed off it cannot disagree with what is printed.
 
         `episodes` is derived from the span's ends, and only where the
-        release is a span. A pack maps every file it contains, so its ends
-        are exactly as populated as a span's and `is_pack` is the only thing
-        telling the two apart -- a pack that kept them is designated
-        "S01E01-05" where `display_tag` and the `{episode_number}` token
-        kwarg, which both read that flag, say "S01". Every span NfoForge
-        produces is contiguous -- the mapper sorts guessit's list and keeps
-        first and last -- so the range is exact rather than approximate for
-        everything but a hand-built non-contiguous mapping.
+        release is not the whole season -- see `_is_whole_season`. Every
+        span NfoForge produces is contiguous -- the mapper sorts guessit's
+        list and keeps first and last -- so the range is exact rather than
+        approximate for everything but a hand-built non-contiguous mapping.
 
         `is_dvd` and `is_optical_source` both read the source override, so
         an entry ordering its components by source cannot disagree with the
@@ -2917,7 +2914,9 @@ class ProcessBackEnd:
 
         source = str(overrides.get("source", "")).lower()
         episodes: tuple[int, ...] = ()
-        if release_info.episode_start is not None and not release_info.is_pack:
+        if release_info.episode_start is not None and not self._is_whole_season(
+            context, release_info
+        ):
             end = release_info.episode_end or release_info.episode_start
             episodes = tuple(range(release_info.episode_start, end + 1))
 
@@ -2931,6 +2930,45 @@ class ProcessBackEnd:
             season=release_info.season,
             episodes=episodes,
         )
+
+    @staticmethod
+    def _is_whole_season(
+        context: ProcessingContext, release_info: SeriesReleaseInfo
+    ) -> bool:
+        """Whether the release is the season itself rather than episodes of it.
+
+        Only a release covering every episode TVDB lists for the season is
+        designated "S01". Anything short of that keeps its range, because
+        "S01" on a partial pack claims a whole season the download does not
+        contain -- a worse error than a range that is merely more precise
+        than it needs to be.
+
+        Completeness is decided on the episode *set*, not the ends: a pack
+        of E01-E05 and E07-E10 spans 1 to 10 and is still missing one.
+
+        Two answers are given without asking TVDB. A release spanning more
+        than one season is a pack whatever its episodes are, since no single
+        episode range describes it. And a season TVDB does not list -- no
+        data at all, a failed lookup, a season it does not cover -- is
+        unproven rather than complete, so it keeps its range: an empty set
+        is a subset of everything, and treating that as complete would put
+        "S01" on every release whose lookup failed.
+        """
+        if not release_info.is_pack or release_info.season is None:
+            return False
+
+        if (
+            release_info.season_end is not None
+            and release_info.season_end != release_info.season
+        ):
+            return True
+
+        listed = season_episode_numbers(
+            context.media_search.tvdb_data,
+            release_info.season,
+            release_info.episode_order_type_id,
+        )
+        return bool(listed) and listed <= set(release_info.episode_numbers)
 
     @staticmethod
     def _release_info_token_kwargs(

--- a/src/backend/token_replacer.py
+++ b/src/backend/token_replacer.py
@@ -35,6 +35,7 @@ from src.backend.utils.rename_normalizations import (
 )
 from src.backend.utils.resolution import VideoResolutionAnalyzer
 from src.backend.utils.streaming_services import abbreviate_streaming_service
+from src.backend.utils.tvdb_episodes import tvdb_episode_list
 from src.backend.utils.working_dir import RUNTIME_DIR
 from src.config.models import DynamicRangeSettings, HdrType, ResolutionKey
 from src.enums.media_type import MediaType
@@ -3463,33 +3464,13 @@ class TokenReplacer:
     ) -> list[dict[str, Any]]:
         """Episode list for one TVDB ordering, or the flat list.
 
-        ``episodes_by_type`` holds one list per ordering; the flat
-        ``episodes`` key is the official/aired order. An id that is absent,
-        or names an ordering this payload does not carry, falls back to the
-        flat list, which is what every lookup did before orderings were
-        recorded.
-
-        The id is matched against both the int and str forms of each key: a
-        saved job round-trips ``tvdb_data`` through JSON, which turns the int
-        keys of ``episodes_by_type`` into strings, while the mapping row's
-        id stays an int.
+        The payload's shape is described in `tvdb_episodes`, which the
+        tracker title's season-completeness check reads through as well.
         """
-        tvdb_data = self.media_search_obj.tvdb_data if self.media_search_obj else None
-        if not tvdb_data:
-            return []
-
-        if episode_order_type_id is not None:
-            episodes_by_type = tvdb_data.get("episodes_by_type") or {}
-            if isinstance(episodes_by_type, dict):
-                type_data = episodes_by_type.get(episode_order_type_id)
-                if type_data is None:
-                    type_data = episodes_by_type.get(str(episode_order_type_id))
-                if isinstance(type_data, dict):
-                    episodes = type_data.get("episodes")
-                    if isinstance(episodes, list):
-                        return cast(list[dict[str, Any]], episodes)
-
-        return cast(list[dict[str, Any]], tvdb_data.get("episodes", []))
+        return tvdb_episode_list(
+            self.media_search_obj.tvdb_data if self.media_search_obj else None,
+            episode_order_type_id,
+        )
 
     def _get_tvdb_episode_dict(
         self, season: int, episode: int, episode_order_type_id: Any | None = None

--- a/src/backend/trackers/media_support.py
+++ b/src/backend/trackers/media_support.py
@@ -80,6 +80,6 @@ UNIT3D_TRACKERS: frozenset[TrackerSelection] = frozenset(
 )
 
 # Whether a tracker's upload has a release-name field at all is a title rule,
-# so it lives on that tracker's entry -- see `accepts_a_release_name` in
-# `title_rules.py`. It used to be a frozenset here, beside the media-type
-# support tables, which answer a different question.
+# so it lives on that tracker's entry rather than here beside the media-type
+# support tables, which answer a different question -- see
+# `accepts_a_release_name` in `title_rules.py`.

--- a/src/backend/trackers/title_render.py
+++ b/src/backend/trackers/title_render.py
@@ -1,13 +1,12 @@
 """Render a release title through a tracker's entry.
 
-Two stages, replacing the four rewriting layers that grew up separately:
-compose from the entry (or the user's global template when it has none),
-then normalise from the entry. This module is the normalisation half.
+Two stages: compose from the entry (or the user's global template when it
+has none), then normalise from the entry. This module is the normalisation
+half.
 
 Normalisation always applies, whether or not the entry composes, so the
-seven trackers with no layout of their own still get their separator,
-colon and vocabulary imposed on the user's house style -- which is exactly
-what they do today through their own `generate_release_title`.
+seven trackers with no layout of their own still get their separator, colon
+and vocabulary imposed on the user's house style.
 """
 
 from __future__ import annotations
@@ -47,20 +46,18 @@ _TAG_SEPARATOR_LOOKBEHIND = r"(?<!-)"
 # that way) is untouched.
 _TRAILING_TAG_GAP = re.compile(r"\s+-(\S+)$")
 
-# BeyondHD's DD exception, carried over verbatim from the uploader's
-# own rule so the spelling cannot drift from what it enforced.
+# BeyondHD's DD exception: "DD5.1" closed up, where "DDP 5.1" stays spaced.
 _DD_CHANNELS = re.compile(r"\bDD\s+(\d\.[01])")
 
-# How NfoForge already spells each identity, mirroring
-# `{video_dynamic_range_type}`. Four of the eight are not written the way the
-# identity is named -- HDR10 is "HDR", HDR10+ is "HDR10Plus", and the two
-# Dolby Vision composites follow -- so the identity name is not usable as a
-# default. That token is what every packaged tracker template uses, so this
-# is what every tracker has been receiving; Aither's published "REMUX HDR
-# HEVC" and LST's "REMUX DV HDR HEVC" both show it.
+# How NfoForge spells each identity, mirroring `{video_dynamic_range_type}`.
+# Four of the eight are not written the way the identity is named -- HDR10 is
+# "HDR", HDR10+ is "HDR10Plus", and the two Dolby Vision composites follow --
+# so the identity name is not usable as a default. These spellings are what
+# trackers expect: Aither's published "REMUX HDR HEVC" and LST's "REMUX DV
+# HDR HEVC" both show it.
 #
-# It is also the vocabulary the per-tracker overrides are written against:
-# the three trackers publishing "HDR10+" map it from "HDR10Plus".
+# They are also what an entry's vocabulary is written against: the three
+# trackers publishing "HDR10+" map it from "HDR10Plus".
 _DEFAULT_SPELLINGS: Mapping[HdrType, str] = MappingProxyType(
     {
         "SDR": "SDR",

--- a/src/backend/trackers/title_rules.py
+++ b/src/backend/trackers/title_rules.py
@@ -7,15 +7,15 @@ setting that enforcement would override anyway.
 One entry per tracker, with no inheritance between them. Two entries that
 are currently identical stay written out separately: a tracker changing its
 rules must not require unpicking a shared abstraction, and must not be able
-to alter another tracker by accident. That is not a hypothetical -- the
-shipped config's worst defect was a template copied between two trackers
-whose published rules differ, which propagated an error into a tracker that
-never shared those rules. `test_no_two_entries_share_an_object` pins it.
+to alter another tracker by accident. Sharing one object between two
+trackers gives both of them whichever set of rules was written first, and
+two trackers are only identical until one of them publishes a change.
+`test_no_two_entries_share_an_object` pins it.
 
 An entry has two sections. Normalisation always applies. Composition is
 optional -- nine entries have none. Seven of those render the user's global
-title template, which is exactly what they do today; the remaining two
-render no title at all, having no release name field to put one in.
+title template; the remaining two render no title at all, having no release
+name field to put one in.
 
 A tracker rule never reaches a filename. Every rule lives in an entry, never
 in a token handler: handlers are shared, and `file_name_mode` selects only
@@ -267,10 +267,10 @@ def _is_series(release: ReleaseProperties) -> bool:
 # the entry's vocabulary rather than by a token that refuses to render it.
 _DUB = ("{audio_language_dual}", "{localization|unless(audio_language_dual)}")
 
-# Components carry no `:opt= :` prefix. The shipped templates needed one to
-# avoid a double space where a token did not resolve; normalisation closes
-# that gap for every entry now, so the plain form is enough and reads as the
-# published rules are written.
+# Components are plain tokens, carrying no `:opt= :` separator prefix.
+# Normalisation closes the gap an unresolved token leaves, for every entry,
+# so a component does not have to carry its own separator -- which lets the
+# list read the way the published rules are written.
 
 # Every entry is constructed inline. Two that read alike are still two
 # objects, so editing one cannot reach the other.
@@ -448,10 +448,9 @@ TITLE_RULES: Mapping[TrackerSelection, TrackerTitleEntry] = MappingProxyType(
                 omit=(OmitRule(when=_is_series, components=("{release_year}",)),),
             ),
         ),
-        # ReelFliX. Its shipped template was a near copy of BeyondHD's,
-        # but its published rules match LST and Aither -- so every remux was
-        # emitting audio before video where its rules require video first.
-        # That defect is why entries do not share objects.
+        # ReelFliX. Its published rules match LST and Aither rather than
+        # BeyondHD's, which is easy to get backwards given how alike the
+        # four read: video goes ahead of audio on a remux.
         TrackerSelection.REELFLIX: TrackerTitleEntry(
             normalisation=Normalisation(
                 colon=ColonReplace.KEEP,
@@ -503,7 +502,7 @@ TITLE_RULES: Mapping[TrackerSelection, TrackerTitleEntry] = MappingProxyType(
                 ),
             ),
         ),
-        # BeyondHD. Six differences from the shipped template:
+        # BeyondHD. Six rules that set it apart from the other three:
         #
         # - audio is {audio_codec} plus channels, giving "DDP Atmos 5.1" as
         #   BeyondHD requires, not the "DDP 5.1 Atmos" the other three want.
@@ -570,31 +569,27 @@ TITLE_RULES: Mapping[TrackerSelection, TrackerTitleEntry] = MappingProxyType(
                 omit=(OmitRule(when=_is_series, components=("{release_year}",)),),
             ),
         ),
-        # The four below are transcribed from the shipped config rather than
-        # from published rules, none having been gathered for them. What the
-        # config says is copied rather than improved -- {edition} rather than
-        # {cut}, undivided {audio_codec}, dash colon handling and the
-        # over-1080 SDR form all stand.
+        # No published rules have been gathered for the four below, so their
+        # layout is assumed rather than checked: {edition} rather than {cut},
+        # undivided {audio_codec}, dash colon handling and the over-1080 SDR
+        # form. Hold an entry here more loosely than the four above, and
+        # replace it outright if that tracker's rules are ever gathered.
         #
-        # Two things do not come from the config, because the config had
-        # nothing to say about either.
+        # Two things are not assumed.
         #
-        # Their shipped overrides cover films only, so a series on these
-        # trackers used to render the user's global template. An entry has no
-        # media-type split, so the composition now serves both, with the
-        # designator supplying the season and episode and an episode title
-        # beside it. Aither names the episode from its published examples;
-        # only LST, ReelFliX and BeyondHD are known to leave it out.
+        # An entry has no media-type split, so one composition serves films
+        # and series alike, the designator supplying the season and episode
+        # and an episode title sitting beside it. Aither names the episode
+        # from its published examples; only LST, ReelFliX and BeyondHD are
+        # known to leave it out.
         #
-        # The title is {title_exact}, where the config said {title_clean}.
-        # Clean answers to the user's `title_clean_rules`, which ship
-        # aggressive: they unidecode, drop apostrophes and flatten every
-        # non-alphanumeric to a space, so "Amelie's Cafe: Fire & Ice" reached
-        # these four as "Amelies Cafe Fire and Ice" and reached the four with
-        # gathered rules intact. Nothing published asks for that, a tracker
-        # rule that varies with a user setting is not a rule, and the split
-        # tracked which entries were transcribed rather than anything about
-        # the trackers. The episode title matches at the same tier.
+        # The title is {title_exact} rather than {title_clean}. Clean answers
+        # to the user's `title_clean_rules`, which ship aggressive: they
+        # unidecode, drop apostrophes and flatten every non-alphanumeric to a
+        # space, so "Amelie's Cafe: Fire & Ice" would reach these four as
+        # "Amelies Cafe Fire and Ice" while reaching the other four intact.
+        # A tracker rule that varies with a user setting is not a rule. The
+        # episode title matches at the same tier.
         TrackerSelection.DARK_PEERS: TrackerTitleEntry(
             normalisation=Normalisation(
                 colon=ColonReplace.REPLACE_WITH_DASH,
@@ -701,10 +696,9 @@ TITLE_RULES: Mapping[TrackerSelection, TrackerTitleEntry] = MappingProxyType(
 def accepts_a_release_name(tracker: TrackerSelection) -> bool:
     """Whether an upload to `tracker` carries a release name at all.
 
-    Was a frozenset beside the media-type support tables, which answers a
-    different question. A tracker's title rules are one object now, and
-    "there is no title" is one of them, so the answer comes from the entry
-    rather than from a list that has to be kept in step with it.
+    A tracker's title rules are one object, and "there is no title" is one
+    of them, so the answer comes from the entry rather than from a separate
+    list that would have to be kept in step with it.
 
     This is the accessor for a caller holding only a `TrackerSelection`.
     The renderer and `resolve_tracker_title` have the entry in hand already

--- a/src/backend/trackers/title_rules.py
+++ b/src/backend/trackers/title_rules.py
@@ -114,13 +114,25 @@ class ReleaseProperties:
     earns its place from a checked tracker -- `is_remux` and `is_disc` from
     the remux order swap and BeyondHD's dynamic range baseline, `is_dvd`
     from BeyondHD's DVD order and the LST and ReelFliX omit rules,
+    `is_optical_source` from BeyondHD's source-before-resolution rule,
     `resolution` and `hdr_identity` from every dynamic range rule, and
     `season`/`episodes` from the designator.
+
+    `is_optical_source` is not `is_disc`. It says the release came off
+    optical media -- Blu-ray, UHD Blu-ray or DVD -- however it was encoded,
+    where `is_disc` says the upload *is* a full disc. An encode from a
+    Blu-ray is the first and not the second.
+
+    It is a positive test for optical media rather than a negative one for
+    web, so a release whose source could not be determined keeps the order
+    every tracker used before this rule existed instead of being named as a
+    disc on a guess.
     """
 
     is_remux: bool = False
     is_disc: bool = False
     is_dvd: bool = False
+    is_optical_source: bool = False
     resolution: int = 1080
     hdr_identity: HdrType = "SDR"
     season: int | None = None
@@ -236,6 +248,10 @@ def _is_disc_or_remux(release: ReleaseProperties) -> bool:
 
 def _is_dvd(release: ReleaseProperties) -> bool:
     return release.is_dvd
+
+
+def _is_optical_source(release: ReleaseProperties) -> bool:
+    return release.is_optical_source
 
 
 def _is_dvd_remux(release: ReleaseProperties) -> bool:
@@ -487,8 +503,7 @@ TITLE_RULES: Mapping[TrackerSelection, TrackerTitleEntry] = MappingProxyType(
                 ),
             ),
         ),
-        # BeyondHD. Four differences from the shipped template, all from its
-        # published rules:
+        # BeyondHD. Six differences from the shipped template:
         #
         # - audio is {audio_codec} plus channels, giving "DDP Atmos 5.1" as
         #   BeyondHD requires, not the "DDP 5.1 Atmos" the other three want.
@@ -496,6 +511,17 @@ TITLE_RULES: Mapping[TrackerSelection, TrackerTitleEntry] = MappingProxyType(
         # - HYBRID sits against REMUX, since BeyondHD requires them adjacent.
         # - the DVD order is "MPEG-2 DD2.0", so the codec leads there
         #   where audio leads everywhere else.
+        # - an optical source leads its resolution -- "BluRay 1080p", "UHD
+        #   BluRay 2160p", "DVD 480p" -- where the other three write the
+        #   resolution first. Web keeps the resolution first, so a WEB-DL
+        #   still reads "2160p AMZN WEB-DL" with the service against WEB-DL
+        #   as every tracker requiring one wants it.
+        # - frame size, cut and localization are stated in that order ahead
+        #   of the source run: "IMAX Directors Cut Subbed REPACK UHD BluRay
+        #   2160p", or "... REPACK 2160p AMZN WEB-DL" off optical. The other
+        #   three order the first two the opposite way and suppress Subbed
+        #   through their vocabulary, so BeyondHD is the only entry that
+        #   states a subbed release at all.
         TrackerSelection.BEYOND_HD: TrackerTitleEntry(
             normalisation=Normalisation(
                 colon=ColonReplace.KEEP,
@@ -507,12 +533,19 @@ TITLE_RULES: Mapping[TrackerSelection, TrackerTitleEntry] = MappingProxyType(
                     "{title_exact}",
                     "{release_year}",
                     Designator.SIMPLE,
-                    "{cut}",
                     "{frame_size}",
+                    "{cut}",
+                    "{localization}",
                     "{re_release}",
-                    "{resolution}",
-                    "{streaming_service}",
-                    "{source}",
+                    ConditionalOrder(
+                        when=_is_optical_source,
+                        then=("{source}", "{resolution}"),
+                        otherwise=(
+                            "{resolution}",
+                            "{streaming_service}",
+                            "{source}",
+                        ),
+                    ),
                     "{hybrid}",
                     "{remux}",
                     ConditionalOrder(

--- a/src/backend/trackers/utils.py
+++ b/src/backend/trackers/utils.py
@@ -55,9 +55,9 @@ DISC_TITLE_REGEX = regex.compile(
 _CHANNEL_LAYOUT_REGEX = re.compile(r"(?<!\d)[1-9]\.[01](?:\.[0-9])?(?!\d)")
 _CHANNEL_LAYOUT_SENTINEL = "\x00"
 # A video codec's internal period is the same casualty as a channel layout:
-# nothing in the string distinguishes it from a separator. `H.264` shipped as
-# `H 264` to every tracker that spaces its titles, including one whose own
-# published example spells it `H.264`.
+# nothing in the string distinguishes it from a separator. Unprotected,
+# `H.264` reaches every tracker that spaces its titles as `H 264` -- including
+# one whose own published example spells it `H.264`.
 #
 # The left boundary excludes an alphanumeric rather than requiring whitespace,
 # because both title forms reach here: a composed title is space-separated,
@@ -79,8 +79,9 @@ def strip_title_dots(release_title: str) -> str:
 
     Both are protected before the periods are stripped rather than
     reconstructed afterwards. Reconstruction requires knowing every codec that can
-    precede the channels, and anything the list missed (AAC, Opus, LPCM, an Atmos
-    suffix between the codec and the channels, ...) silently shipped as "5 1".
+    precede the channels, and anything such a list missed (AAC, Opus, LPCM, an
+    Atmos suffix between the codec and the channels, ...) would silently become
+    "5 1".
     """
     name = _CHANNEL_LAYOUT_REGEX.sub(
         lambda match: match.group(0).replace(".", _CHANNEL_LAYOUT_SENTINEL),

--- a/src/backend/utils/tvdb_episodes.py
+++ b/src/backend/utils/tvdb_episodes.py
@@ -1,0 +1,86 @@
+"""Reading episode lists out of a TVDB payload.
+
+Two callers need the same list for different questions -- the token
+replacer resolves one episode's data from it, and the tracker title asks
+whether a release covers a whole season -- so the shape of the payload is
+described once here rather than twice at the call sites.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+
+def tvdb_episode_list(
+    tvdb_data: dict[str, Any] | None, episode_order_type_id: Any | None = None
+) -> list[dict[str, Any]]:
+    """Episode list for one TVDB ordering, or the flat list.
+
+    ``episodes_by_type`` holds one list per ordering; the flat ``episodes``
+    key is the official/aired order. An id that is absent, or names an
+    ordering this payload does not carry, falls back to the flat list.
+
+    The id is matched against both the int and str forms of each key: a
+    saved job round-trips ``tvdb_data`` through JSON, which turns the int
+    keys of ``episodes_by_type`` into strings, while the mapping row's id
+    stays an int.
+    """
+    if not tvdb_data:
+        return []
+
+    if episode_order_type_id is not None:
+        episodes_by_type = tvdb_data.get("episodes_by_type") or {}
+        if isinstance(episodes_by_type, dict):
+            type_data = episodes_by_type.get(episode_order_type_id)
+            if type_data is None:
+                type_data = episodes_by_type.get(str(episode_order_type_id))
+            if isinstance(type_data, dict):
+                episodes = type_data.get("episodes")
+                if isinstance(episodes, list):
+                    return cast(list[dict[str, Any]], episodes)
+
+    return cast(list[dict[str, Any]], tvdb_data.get("episodes", []))
+
+
+def season_episode_numbers(
+    tvdb_data: dict[str, Any] | None,
+    season: int,
+    episode_order_type_id: Any | None = None,
+) -> frozenset[int]:
+    """Every episode number TVDB lists for one season.
+
+    Empty means "unknown", not "no episodes": a payload with no TVDB data,
+    a season the payload does not cover, and a genuinely empty season are
+    indistinguishable here. A caller deciding whether a release is a
+    complete season must treat empty as unproven rather than as trivially
+    satisfied -- an empty set is a subset of everything.
+    """
+    numbers: set[int] = set()
+    for episode in tvdb_episode_list(tvdb_data, episode_order_type_id):
+        if not isinstance(episode, dict):
+            continue
+        if _as_int(episode.get("seasonNumber")) != season:
+            continue
+        number = _as_int(episode.get("number"))
+        if number is not None:
+            numbers.add(number)
+    return frozenset(numbers)
+
+
+def _as_int(value: Any) -> int | None:
+    """A TVDB numeric field as an int, or ``None`` where it is not one.
+
+    Saved jobs round-trip through JSON and hand-built payloads vary, so a
+    season or episode number arrives as an int or as the string form of
+    one.
+    """
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        try:
+            return int(value.strip())
+        except ValueError:
+            return None
+    return None

--- a/src/payloads/series.py
+++ b/src/payloads/series.py
@@ -33,6 +33,23 @@ class SeriesReleaseInfo:
     season_end: int | None = None
     episode_start: int | None = None
     episode_end: int | None = None
+    episode_numbers: tuple[int, ...] = ()
+    """Every episode the release covers, not just the ends.
+
+    `episode_start`/`episode_end` cannot answer whether a release is a
+    complete season: a pack of E01-E05 and E07-E10 has ends of 1 and 10 and
+    is still missing an episode. Asking that question needs the set.
+    """
+
+    episode_order_type_id: Any | None = None
+    """Which TVDB ordering the mapping rows were built from, if they say.
+
+    The same season is a different length in different orderings, so a
+    completeness check has to count episodes in the ordering the user
+    mapped against. ``None`` means the rows predate the field or none was
+    recorded, and the flat official/aired list applies.
+    """
+
     episode_count: int = 0
     episode_format: EpisodeFormat = EpisodeFormat.STANDARD
     input_is_directory: bool = False
@@ -127,6 +144,10 @@ def build_series_release_info(media_input: MediaInputPayload) -> SeriesReleaseIn
     # file only covers a single episode) so a lone file spanning multiple
     # episodes (e.g. "S01E01E02") still contributes its true upper bound.
     episode_ends: list[int] = []
+    # the union of every file's own range, which is what a completeness
+    # check needs: the ends alone cannot see a hole in the middle.
+    episode_numbers: set[int] = set()
+    order_type_ids: list[Any] = []
     for file_path in file_list:
         mapping = _mapping_for_path(file_path, mappings)
         season = _int_or_none(mapping.get("season")) if mapping else None
@@ -136,7 +157,11 @@ def build_series_release_info(media_input: MediaInputPayload) -> SeriesReleaseIn
             seasons.append(season)
         if episode is not None:
             episode_starts.append(episode)
-            episode_ends.append(episode_end if episode_end is not None else episode)
+            upper = episode_end if episode_end is not None else episode
+            episode_ends.append(upper)
+            episode_numbers.update(range(episode, upper + 1))
+        if mapping and mapping.get("episode_order_type_id") is not None:
+            order_type_ids.append(mapping["episode_order_type_id"])
 
     # backfill each dimension independently: a partially mapped set (say every
     # file has a season but none has an episode) must not have guessit's
@@ -155,9 +180,9 @@ def build_series_release_info(media_input: MediaInputPayload) -> SeriesReleaseIn
                 episode_start, episode_end = _episode_range(parsed.get("episode"))
                 if episode_start is not None:
                     episode_starts.append(episode_start)
-                    episode_ends.append(
-                        episode_end if episode_end is not None else episode_start
-                    )
+                    upper = episode_end if episode_end is not None else episode_start
+                    episode_ends.append(upper)
+                    episode_numbers.update(range(episode_start, upper + 1))
 
     season = min(seasons) if seasons else None
     season_end = max(seasons) if seasons else None
@@ -174,6 +199,8 @@ def build_series_release_info(media_input: MediaInputPayload) -> SeriesReleaseIn
         season_end=season_end,
         episode_start=episode_start,
         episode_end=episode_end,
+        episode_numbers=tuple(sorted(episode_numbers)),
+        episode_order_type_id=order_type_ids[0] if order_type_ids else None,
         episode_count=episode_count,
         episode_format=media_input.series_episode_format,
         input_is_directory=media_input.input_is_directory(),

--- a/tests/test_backend/test_tracker_naming_rules.py
+++ b/tests/test_backend/test_tracker_naming_rules.py
@@ -48,9 +48,11 @@ Each needs a new token rather than an edit to an entry:
 from copy import deepcopy
 from dataclasses import replace
 from pathlib import Path
+import re
 
 import pytest
 
+from src.backend.process import ProcessBackEnd
 from src.backend.token_replacer import TokenReplacer
 from src.backend.tokens import FileToken
 from src.backend.trackers.title_render import (
@@ -74,10 +76,12 @@ from src.backend.utils.filename_claims import detect_filename_claims
 from src.backend.utils.hdr_identity import resolve_hdr_identity
 from src.config.models import ClaimSwitches
 from src.config.tv_tokens import SUPPORTED_TVR_FORMATS
+from src.context.processing_context import ProcessingContext
 from src.enums.media_type import MediaType
 from src.enums.token_replacer import ColonReplace, UnfilledTokenRemoval
 from src.enums.tracker_selection import TrackerSelection
 from src.payloads.media_search import MediaSearchPayload
+from src.payloads.series import build_series_release_info
 
 # The release shapes the rules distinguish. Only the *name* matters here: it
 # drives the filename attributes (REMUX/HYBRID/REPACK) and the source guess,
@@ -150,10 +154,16 @@ def _series_payloads(
 ) -> tuple[object, MediaSearchPayload]:
     """Turn the example payload into one of the three series shapes.
 
-    A season pack maps no episode at all, which is how the app represents
-    one. A span carries `episode_end`, which is the only definition of a
-    span in the token replacer -- so a test cannot accidentally build a
-    span that the tokens would not recognise as one.
+    Passing no episodes stands in for a pack here, because `_render` builds
+    `ReleaseProperties` directly and a pack resolves to no episodes. It is
+    not how the app represents one: `build_series_release_info` reads the
+    per-file mappings, so a real pack carries every episode it covers. See
+    `test_a_season_pack_is_designated_by_its_season_alone`, which goes
+    through that derivation rather than around it.
+
+    A span carries `episode_end`, which is the only definition of a span in
+    the token replacer -- so a test cannot accidentally build a span that
+    the tokens would not recognise as one.
     """
     path = media.input_path
     episode_map: dict[Path, dict[str, object]] = {}
@@ -906,3 +916,88 @@ def test_an_explicit_service_choice_is_honoured(tracker: TrackerSelection) -> No
 
     assert " PMTP WEB-DL " in rendered
     assert "AMZN" not in rendered
+
+
+# -- the designator, from a real payload ----------------------------------
+#
+# Every test above builds ReleaseProperties by hand. That is right for
+# pinning what an entry says and wrong for pinning what a release resolves
+# to: a hand-built season pack passes `episodes=()`, which
+# `build_series_release_info` never produces for one. A real pack maps every
+# file it contains, so its episodes are exactly as populated as a span's and
+# `is_pack` is the only thing telling the two apart. The two tests below go
+# through the production derivation instead.
+
+
+def _pack_media(episode_count: int):
+    """A season pack as the app builds one: a file per episode, each mapped."""
+    files = [
+        Path(f"Show.Name.S01E{number:02d}.2160p.UHD.BluRay.x265-SomeGroup.mkv")
+        for number in range(1, episode_count + 1)
+    ]
+    source_info = next(iter(EXAMPLE_MEDIA_INPUT_PAYLOAD.file_list_mediainfo.values()))
+    return replace(
+        EXAMPLE_MEDIA_INPUT_PAYLOAD,
+        media_type=MediaType.SERIES,
+        input_path=Path("Show.Name.S01.2160p.UHD.BluRay.x265-SomeGroup"),
+        file_list=files,
+        file_list_mediainfo={path: source_info for path in files},
+        series_episode_map={
+            path: {"season": 1, "episode": number + 1}
+            for number, path in enumerate(files)
+        },
+    )
+
+
+def _span_media():
+    """One file covering two episodes, which is a span rather than a pack."""
+    path = Path("Show.Name.S01E01E02.2160p.UHD.BluRay.x265-SomeGroup.mkv")
+    source_info = next(iter(EXAMPLE_MEDIA_INPUT_PAYLOAD.file_list_mediainfo.values()))
+    return replace(
+        EXAMPLE_MEDIA_INPUT_PAYLOAD,
+        media_type=MediaType.SERIES,
+        input_path=path,
+        file_list=[path],
+        file_list_mediainfo={path: source_info},
+        series_episode_map={path: {"season": 1, "episode": 1, "episode_end": 2}},
+    )
+
+
+def _designator_for(media) -> str:
+    """The designator a payload resolves to, through the production path."""
+    release_info = build_series_release_info(media)
+    context = ProcessingContext(media_input=media, media_search=EXAMPLE_SEARCH_PAYLOAD)
+    backend = object.__new__(ProcessBackEnd)
+    release = backend._release_properties(context, release_info)
+
+    composition = TITLE_RULES[TrackerSelection.AITHER].composition
+    assert composition is not None
+    token_string = compose_token_string(composition, release)
+    designator = re.search(r"\bS\d\d(?:E[\dE-]+)?", token_string)
+    assert designator is not None, token_string
+    return designator.group(0)
+
+
+def test_a_season_pack_is_designated_by_its_season_alone() -> None:
+    """A pack is "Show S01 ...", never "Show S01E01-05 ...".
+
+    It carries every episode it covers, so the range says nothing a reader
+    wants: the release is the season. `is_pack` is what distinguishes it,
+    and the filename side already reads that flag -- both
+    `SeriesReleaseInfo.display_tag` and the `{episode_number}` token kwarg
+    consult it, so a title that does not disagrees with the filename beside
+    it.
+    """
+    media = _pack_media(5)
+    assert build_series_release_info(media).is_pack
+
+    assert _designator_for(media) == "S01"
+
+
+def test_a_single_file_span_keeps_its_episode_range() -> None:
+    """The control. One file covering two episodes is not a pack, and its
+    range is the whole point of the designator."""
+    media = _span_media()
+    assert not build_series_release_info(media).is_pack
+
+    assert _designator_for(media) == "S01E01-02"

--- a/tests/test_backend/test_tracker_naming_rules.py
+++ b/tests/test_backend/test_tracker_naming_rules.py
@@ -45,6 +45,7 @@ Each needs a new token rather than an edit to an entry:
   fixed for titles alone.
 """
 
+from collections.abc import Sequence
 from copy import deepcopy
 from dataclasses import replace
 from pathlib import Path
@@ -924,16 +925,15 @@ def test_an_explicit_service_choice_is_honoured(tracker: TrackerSelection) -> No
 # pinning what an entry says and wrong for pinning what a release resolves
 # to: a hand-built season pack passes `episodes=()`, which
 # `build_series_release_info` never produces for one. A real pack maps every
-# file it contains, so its episodes are exactly as populated as a span's and
-# `is_pack` is the only thing telling the two apart. The two tests below go
-# through the production derivation instead.
+# file it contains, so its episodes are exactly as populated as a span's.
+# The tests below go through the production derivation instead.
 
 
-def _pack_media(episode_count: int):
-    """A season pack as the app builds one: a file per episode, each mapped."""
+def _pack_media(episodes: Sequence[int]):
+    """A pack as the app builds one: a file per episode, each mapped."""
     files = [
         Path(f"Show.Name.S01E{number:02d}.2160p.UHD.BluRay.x265-SomeGroup.mkv")
-        for number in range(1, episode_count + 1)
+        for number in episodes
     ]
     source_info = next(iter(EXAMPLE_MEDIA_INPUT_PAYLOAD.file_list_mediainfo.values()))
     return replace(
@@ -943,8 +943,8 @@ def _pack_media(episode_count: int):
         file_list=files,
         file_list_mediainfo={path: source_info for path in files},
         series_episode_map={
-            path: {"season": 1, "episode": number + 1}
-            for number, path in enumerate(files)
+            path: {"season": 1, "episode": number}
+            for path, number in zip(files, episodes, strict=True)
         },
     )
 
@@ -963,35 +963,92 @@ def _span_media():
     )
 
 
-def _designator_for(media) -> str:
+def _search_listing(season_length: int | None) -> MediaSearchPayload:
+    """A search payload whose TVDB data lists a season of `season_length`.
+
+    ``None`` carries no TVDB data at all, which is the state a lookup that
+    failed or was skipped leaves behind.
+    """
+    tvdb_data = (
+        {
+            "episodes": [
+                {"seasonNumber": 1, "number": number}
+                for number in range(1, season_length + 1)
+            ]
+        }
+        if season_length is not None
+        else None
+    )
+    return MediaSearchPayload(
+        media_type=MediaType.SERIES, title=SERIES_TITLE, tvdb_data=tvdb_data
+    )
+
+
+def _designator_for(media, search: MediaSearchPayload | None = None) -> str:
     """The designator a payload resolves to, through the production path."""
     release_info = build_series_release_info(media)
-    context = ProcessingContext(media_input=media, media_search=EXAMPLE_SEARCH_PAYLOAD)
+    context = ProcessingContext(
+        media_input=media,
+        media_search=search if search is not None else EXAMPLE_SEARCH_PAYLOAD,
+    )
     backend = object.__new__(ProcessBackEnd)
     release = backend._release_properties(context, release_info)
 
     composition = TITLE_RULES[TrackerSelection.AITHER].composition
     assert composition is not None
     token_string = compose_token_string(composition, release)
-    designator = re.search(r"\bS\d\d(?:E[\dE-]+)?", token_string)
+    designator = re.search(r"S\d\d(?:E[\dE-]+)?", token_string)
     assert designator is not None, token_string
     return designator.group(0)
 
 
-def test_a_season_pack_is_designated_by_its_season_alone() -> None:
-    """A pack is "Show S01 ...", never "Show S01E01-05 ...".
+def test_a_whole_season_is_designated_by_its_season_alone() -> None:
+    """A release covering every episode TVDB lists for the season is "S01".
 
-    It carries every episode it covers, so the range says nothing a reader
-    wants: the release is the season. `is_pack` is what distinguishes it,
-    and the filename side already reads that flag -- both
-    `SeriesReleaseInfo.display_tag` and the `{episode_number}` token kwarg
-    consult it, so a title that does not disagrees with the filename beside
+    The range says nothing a reader wants when the release *is* the season,
+    and the filename side already agrees: `SeriesReleaseInfo.display_tag`
+    and the `{episode_number}` token kwarg both collapse a pack to its
+    season, so a title carrying a range disagrees with the filename beside
     it.
     """
-    media = _pack_media(5)
-    assert build_series_release_info(media).is_pack
+    media = _pack_media(range(1, 11))
 
-    assert _designator_for(media) == "S01"
+    assert _designator_for(media, _search_listing(10)) == "S01"
+
+
+def test_a_partial_pack_keeps_its_episode_range() -> None:
+    """Five episodes of a ten-episode season is not the season.
+
+    Collapsing it to "S01" would claim the whole season, which is a worse
+    error than an over-precise range: someone downloading it gets half of
+    what the title promised.
+    """
+    media = _pack_media(range(1, 6))
+
+    assert _designator_for(media, _search_listing(10)) == "S01E01-05"
+
+
+def test_a_pack_missing_a_middle_episode_is_not_the_whole_season() -> None:
+    """Completeness is the set of episodes, not the span of their ends.
+
+    A pack of E01-E05 and E07-E10 has ends of 1 and 10, so an ends-based
+    check would call it complete. It is not: E06 is absent.
+    """
+    media = _pack_media([*range(1, 6), *range(7, 11)])
+
+    assert _designator_for(media, _search_listing(10)) != "S01"
+
+
+def test_an_unlistable_season_keeps_its_episode_range() -> None:
+    """No TVDB data means the season's length is unknown.
+
+    Unknown resolves to the range rather than to "S01": claiming a complete
+    season on absent evidence is the failure that matters, and a range is
+    merely more precise than it needs to be.
+    """
+    media = _pack_media(range(1, 11))
+
+    assert _designator_for(media, _search_listing(None)) == "S01E01-10"
 
 
 def test_a_single_file_span_keeps_its_episode_range() -> None:
@@ -1000,4 +1057,4 @@ def test_a_single_file_span_keeps_its_episode_range() -> None:
     media = _span_media()
     assert not build_series_release_info(media).is_pack
 
-    assert _designator_for(media) == "S01E01-02"
+    assert _designator_for(media, _search_listing(10)) == "S01E01-02"

--- a/tests/test_backend/test_tracker_naming_rules.py
+++ b/tests/test_backend/test_tracker_naming_rules.py
@@ -21,7 +21,11 @@ The rules being pinned, quoted as saved:
 - ReelFliX ........ the same remux/encode split as Aither and LST, video
                     ahead of audio on a remux; blank tag preferred over a
                     NOGROUP placeholder
-- BeyondHD ........ remux/encode/web-dl with no tag must end "-NOGROUP"
+- BeyondHD ........ remux/encode/web-dl with no tag must end "-NOGROUP";
+                    an optical source leads its resolution ("BluRay 1080p"),
+                    while web keeps "2160p AMZN WEB-DL"; frame size, cut and
+                    localization are stated in that order ahead of the source
+                    ("IMAX Directors Cut Subbed REPACK UHD BluRay 2160p")
 
 Known gaps, deliberately not asserted because NfoForge has no token for them.
 Each needs a new token rather than an edit to an entry:
@@ -82,6 +86,13 @@ REMUX_NAME = "Movie.Name.2026.REPACK.UHD.BluRay.2160p.TrueHD.Atmos.7.1.DV.HEVC.R
 ENCODE_NAME = "Movie.Name.2026.1080p.BluRay.TrueHD.Atmos.7.1.DV.HEVC.x265-SomeGroup.mkv"
 WEB_NAME = (
     "Movie.Name.2026.2160p.AMZN.WEB-DL.TrueHD.Atmos.7.1.DV.HEVC.H.265-SomeGroup.mkv"
+)
+# Carries all three of the components BeyondHD states ahead of its source,
+# which the other three trackers order differently and one of which they do
+# not state at all.
+CLAIMED_NAME = (
+    "Movie.Name.2026.IMAX.Directors.Cut.Subbed.REPACK.UHD.BluRay.2160p."
+    "TrueHD.Atmos.7.1.DV.HEVC.REMUX-SomeGroup.mkv"
 )
 
 
@@ -223,6 +234,7 @@ def _render(
     release = ReleaseProperties(
         is_remux=bool(overrides.get("remux")),
         is_dvd="dvd" in source.lower(),
+        is_optical_source="dvd" in source.lower() or "bluray" in source.lower(),
         resolution=height,
         hdr_identity=resolve_hdr_identity(media_info),
         season=season,
@@ -473,6 +485,78 @@ def test_beyondhd_glues_dd_to_its_channel_layout(
     ddp = _render(TrackerSelection.BEYOND_HD, WEB_NAME, "WEB-DL")
     assert "DDP 7.1" in ddp
     assert "DDP7.1" not in ddp
+
+
+@pytest.mark.parametrize(
+    ("name", "source", "expected"),
+    [
+        (ENCODE_NAME, "BluRay", "BluRay 2160p"),
+        (REMUX_NAME, "UHD BluRay", "UHD BluRay 2160p"),
+        (ENCODE_NAME, "DVD", "DVD 2160p"),
+        (WEB_NAME, "WEB-DL", "2160p AMZN WEB-DL"),
+    ],
+    ids=["encode", "remux", "dvd", "web"],
+)
+def test_beyondhd_leads_an_optical_source_with_the_source(
+    name: str, source: str, expected: str
+) -> None:
+    """BeyondHD writes "BluRay 1080p" where the other three write "1080p
+    BluRay". Web is the exception: the resolution still comes first, which
+    keeps the service abbreviation against WEB-DL where every tracker
+    asking for one wants it.
+
+    The DVD row pairs a source with the fixture's own 2160p, which no real
+    release does. What it pins is the branch rather than the pairing -- a
+    DVD is optical, so it leads on the same rule as the two Blu-ray shapes
+    rather than by way of the codec-first order it separately triggers.
+    """
+    assert expected in _render(TrackerSelection.BEYOND_HD, name, source)
+
+
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        ("UHD BluRay", "IMAX Directors Cut Subbed REPACK UHD BluRay 2160p"),
+        ("WEB-DL", "IMAX Directors Cut Subbed REPACK 2160p AMZN WEB-DL"),
+    ],
+    ids=["optical", "web"],
+)
+def test_beyondhd_states_frame_size_cut_and_localization_before_the_source(
+    source: str, expected: str
+) -> None:
+    """Frame size, cut and localization, in that order, against the source.
+
+    The group travels with the source under the same optical rule, so a
+    WEB-DL reads the same up to the point where the resolution and source
+    swap places. REPACK keeps its own position between the group and the
+    source rather than moving with either.
+
+    The service is supplied rather than detected because the name carries
+    none, and it is supplied for both rows: the optical branch has no
+    `{streaming_service}` component, so an explicit choice cannot put one in
+    a Blu-ray title.
+    """
+    rendered = _render(
+        TrackerSelection.BEYOND_HD, CLAIMED_NAME, source, streaming_service="AMZN"
+    )
+
+    assert f"Movie Name 2026 {expected} " in rendered
+
+
+@pytest.mark.parametrize("tracker", REMUX_AUDIO_LAST)
+def test_the_other_three_order_the_cut_first_and_state_no_subbed(
+    tracker: TrackerSelection,
+) -> None:
+    """The control, so the BeyondHD test above is about BeyondHD.
+
+    Aither, LST and ReelFliX write the cut ahead of the frame size, and
+    their vocabulary maps "Subbed" to nothing -- so a subbed release is
+    named as one on BeyondHD alone.
+    """
+    rendered = _render(tracker, CLAIMED_NAME, "UHD BluRay")
+
+    assert "Directors Cut IMAX" in rendered
+    assert "Subbed" not in rendered
 
 
 @pytest.mark.parametrize("tracker", ALL_FOUR)
@@ -803,16 +887,15 @@ def test_a_non_web_release_carries_no_streaming_service(
     source change into a BluRay title."""
     rendered = _render(tracker, WEB_NAME, "BluRay")
 
-    # BeyondHD puts Atmos with the codec and the channels after it,
-    # where the other three spell it the other way round.
-    audio = (
-        "TrueHD Atmos 7.1"
-        if tracker is TrackerSelection.BEYOND_HD
-        else "TrueHD 7.1 Atmos"
-    )
+    # Two spellings BeyondHD does not share with the other three: an
+    # optical source leads its resolution, and Atmos goes with the codec
+    # rather than after the channels.
+    beyond_hd = tracker is TrackerSelection.BEYOND_HD
+    quality = "BluRay 2160p" if beyond_hd else "2160p BluRay"
+    audio = "TrueHD Atmos 7.1" if beyond_hd else "TrueHD 7.1 Atmos"
 
     assert "AMZN" not in rendered
-    assert rendered == (f"Movie Name 2026 2160p BluRay {audio} DV HDR x265-SomeGroup")
+    assert rendered == (f"Movie Name 2026 {quality} {audio} DV HDR x265-SomeGroup")
 
 
 @pytest.mark.parametrize("tracker", ALL_FOUR)


### PR DESCRIPTION
BeyondHD's components change order. An optical source now leads its resolution -- "BluRay 1080p" rather than "1080p BluRay" -- with DVD and UHD Blu-ray following the same rule; a WEB-DL is unaffected. Frame size, cut and localization are stated in that order immediately ahead of the source and travel with it: the first two were ordered the other way round, and there was no localization component at all, so a subbed or dubbed release was detected and shown on the rename page but never named in the title. BeyondHD is now the only entry that states Subbed, since the other three suppress it through their vocabulary.

The season pack fix affects every tracker with a composition rather than BeyondHD alone. A pack was designated "S01E01-05" instead of "S01": `_release_properties` derived the episode range from the per-file mappings without consulting whether the release was a pack, which both `SeriesReleaseInfo.display_tag` and the `{episode_number}` token kwarg already do. Consulting `is_pack` alone is not enough either -- it is `episode_count > 1` and never sees the season's real length, so a partial pack would claim a season it does not contain. Only a release covering every episode TVDB lists for the season is named that way. Completeness is decided on the episode set rather than its ends, since E01-E05 plus E07-E10 spans 1 to 10 and is still missing one, and a season TVDB cannot list is treated as unproven rather than complete. `SeriesReleaseInfo` gains that set and the TVDB ordering its rows were mapped against; `tvdb_episode_list` is lifted out of `TokenReplacer` rather than copied.

The suite was green throughout because its season-pack fixture passed no episodes at all, a shape `build_series_release_info` never produces; the new tests go through that derivation rather than around it. A final commit rewrites comments across the trackers package that described rules by diffing them against the removed per-tracker title config -- comments only, no behaviour change.

Replaces #293.
