### PR TITLE
feat: one release group setting, and a switch for the parsed one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- **Your release group is a setting now**, in Settings -> General beside Releasers Name. It pre-fills the rename page's Release Group and is what `{release_group}` prints wherever the rename page has not run. The value was always in the config file but had no field to set it in.
+- A seventh claim switch, **Release group**, alongside the other six on the movie and series settings pages. Off means the group in an input filename is never read -- not into the field, and not into your output.
+
+### Changed
+
+- Configuration schema 13. The movie and series release group settings fold into one entry in `[general]`. Your release group is who you publish as rather than a property of a film or a show, so it is one value for both. A profile with either of the old keys set keeps it; the movie side wins if somehow both were.
+- **The release group in your output is only ever one you chose.** It comes from the rename page's field, or from your configured group where that page has not run. Nothing reads a group out of the input filename except the claim detector, which the new switch governs. Previously the renderer parsed the filename itself, so it could print the group of whoever made the file you were working from, regardless of what the rename page showed.
+  - Clearing the Release Group field on the rename page now publishes with no group, rather than falling back to your configured one. It is the whole answer for that release.
+  - A profile with renaming disabled and no release group configured emits no group. Set yours in Settings -> General.
+
+### Fixed
+
+- The NFO template preview shows the release group the NFO will actually carry. It rendered your edition from what you chose on the rename page but parsed the group out of the filename separately, so typing a group and previewing the template showed two different groups.
+- The filename and title examples on the movie and series settings pages show your configured release group instead of the example filename's `SomeGroup`.
+- With renaming disabled, editions, frame sizes, re-release markers and the rest are read from the input filenames again. Claim detection only ever ran on the rename page, so a run that skipped it rendered every claim empty.
+
 ## [1.1.10] - 2026-08-26
 
 ### Added

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,22 @@
+# Context
+
+Glossary for NfoForge. Terms only — no implementation detail, no decisions.
+
+## Group tag
+
+The group name printed on the output: filename, NFO, tracker release title.
+It is the identity the user publishes under, so it belongs to the user rather
+than to any one release or media type.
+
+A release has at most one group tag. Where none resolves, some trackers
+substitute a placeholder of their own rather than printing nothing.
+
+## Source group
+
+The group name read out of an input filename — whoever produced the file the
+user is working from. It is a claim: the filename asserts it and nothing can
+verify it.
+
+A source group is not a [group tag](#group-tag). It becomes one only when the
+user accepts it as their own. Conflating the two is how another group's tag
+reaches a user's upload.

--- a/docs/snippets/generated_templates/file_tokens.md
+++ b/docs/snippets/generated_templates/file_tokens.md
@@ -46,7 +46,7 @@
 | `{original_title_fallback_title_clean}` | Original title (fallback to {title_clean}) |
 | `{re_release}` | Repack/Proper |
 | `{release_date}` | Release date (movies - UTC) |
-| `{release_group}` | Release group |
+| `{release_group}` | Release group (from Settings > General, or the rename page) |
 | `{release_year}` | Release year |
 | `{release_year_parentheses}` | Release year with parentheses |
 | `{releasers_name}` | Releaser's name (Anonymous) |

--- a/src/backend/process.py
+++ b/src/backend/process.py
@@ -102,6 +102,7 @@ from src.backend.upload_retry import (
 )
 from src.backend.utils.anime import is_anime_release
 from src.backend.utils.file_utilities import release_stem
+from src.backend.utils.filename_claims import detect_filename_claims
 from src.backend.utils.hdr_identity import resolve_hdr_identity
 from src.backend.utils.image_optimizer import MultiProcessImageOptimizer
 from src.backend.utils.images import (
@@ -181,6 +182,41 @@ class ProcessBackEnd:
         self.transmission_client: TransmissionClient | None = None
         self.watch_folder_counter = 0
         self.clients_can_logout = (self.qbit_client, self.deluge_client)
+
+    def _seed_claim_overrides(self, context: ProcessingContext) -> None:
+        """Run stage 1 for a run that never reached a rename page.
+
+        Renaming is optional (`mvr_enabled`/`tvr_enabled`), and with it off
+        the wizard routes straight past the page that detects claims and
+        populates the overrides. Nothing else did it, so the NFO and the
+        tracker titles rendered as though the filenames claimed nothing --
+        every claim token empty, including the group.
+
+        Detection belongs to the run rather than to one page, so it happens
+        here for any path that reaches processing without it. The switches
+        still govern: a category the user turned off is not detected, which
+        is the whole point of it being a switch.
+
+        A run that *did* reach the rename page is left alone. Its overrides
+        are the user's stage-2 decisions, and a blank there is one of them.
+        """
+        if context.shared_data.dynamic_data.get("override_tokens") is not None:
+            return
+
+        file_list = context.media_input.file_list
+        if not file_list:
+            return
+
+        claims = detect_filename_claims(
+            [path.stem for path in file_list],
+            self.config.settings.series.claims
+            if context.media_input.media_type is MediaType.SERIES
+            else self.config.settings.movie.claims,
+            context.custom_edition_info,
+        )
+        context.shared_data.dynamic_data["override_tokens"] = (
+            claims.as_override_tokens()
+        )
 
     async def dupe_checks(
         self,
@@ -950,6 +986,10 @@ class ProcessBackEnd:
         # make sure we have all the latest templates in case changes was made during the wizard
         self.template_selector_be.load_templates()
 
+        # Before anything reads the overrides -- the qBittorrent save path
+        # below is the first to.
+        self._seed_claim_overrides(context)
+
         def record_outcome(
             tracker: TrackerSelection, outcome: TrackerRunOutcome
         ) -> None:
@@ -1147,6 +1187,7 @@ class ProcessBackEnd:
                     media_search_obj=context.media_search,
                     unfilled_token_mode=UnfilledTokenRemoval.KEEP,
                     releasers_name=self.config.settings.general.releasers_name,
+                    group_tag=self.config.settings.general.release_group,
                     screen_shots=formatted_screens,
                     screen_shots_comparison=comparison_screens,
                     screen_shots_even_obj=even_screens,
@@ -2801,6 +2842,7 @@ class ProcessBackEnd:
                     "frame_size_override"
                 ),
                 override_tokens=context.shared_data.dynamic_data.get("override_tokens"),
+                group_tag=self.config.settings.general.release_group,
                 title_clean_rules=self.config.settings.global_management.title_clean_rules,
                 user_tokens=user_tokens,
                 video_dynamic_range=dynamic_range,

--- a/src/backend/token_replacer.py
+++ b/src/backend/token_replacer.py
@@ -114,6 +114,7 @@ class TokenReplacer:
         "token_type",
         "unfilled_token_mode",
         "releasers_name",
+        "group_tag",
         "override_tokens",
         "user_tokens",
         "edition_override",
@@ -170,6 +171,7 @@ class TokenReplacer:
         token_type: Iterable[TokenType] | type[TokenType] | None = None,
         unfilled_token_mode: UnfilledTokenRemoval = UnfilledTokenRemoval.KEEP,
         releasers_name: str | None = "",
+        group_tag: str = "",
         override_tokens: dict[str, str] | None = None,
         user_tokens: dict[str, str] | None = None,
         edition_override: str | None = None,
@@ -214,6 +216,10 @@ class TokenReplacer:
             unfilled_token_mode (UnfilledTokenRemoval): What to do with unused tokens.
             eg. (TokenType, TokenType).
             releasers_name (Optional[str]): Releasers name.
+            group_tag (str): The user's configured group tag, printed by
+              {release_group} where no override supplies one. This is the only
+              fallback that token has -- nothing here parses a filename for a
+              group, so a caller that omits both emits none.
             override_tokens (Optional[dict[str, str]]): Override tokens with a supplied value regardless of logic.
             user_tokens (Optional[dict[str, str]]): User tokens (must be prefixed with usr_).
             edition_override (Optional[str]): Edition override.
@@ -276,6 +282,7 @@ class TokenReplacer:
         self.token_type = token_type
         self.unfilled_token_mode = UnfilledTokenRemoval(unfilled_token_mode)
         self.releasers_name = releasers_name
+        self.group_tag = group_tag
         self.override_tokens = override_tokens
         self.user_tokens = user_tokens
         self.edition_override = edition_override
@@ -2090,8 +2097,15 @@ class TokenReplacer:
             )
 
     def _release_group(self, token_data: TokenData) -> str:
-        release_group = str(self.guess_name.get("release_group", ""))
-        return self._optional_user_input(release_group.lstrip("-"), token_data)
+        """The user's group tag.
+
+        Stage 1 detects the source group; an accepted claim arrives as an
+        override and short-circuits this handler before it runs, so a blank
+        the user typed stays blank rather than falling through to the tag.
+        Nothing is parsed out of the filename here, for the same reason as
+        {edition} -- a claim the user never saw must not reach output.
+        """
+        return self._optional_user_input(self.group_tag, token_data)
 
     def _release_date(self, token_data: TokenData) -> str:
         if self.media_search_obj.media_type is not MediaType.MOVIE:

--- a/src/backend/tokens.py
+++ b/src/backend/tokens.py
@@ -193,7 +193,10 @@ class Tokens:
         "{original_language_iso_639_2}",
         "Original language (ENG)",
     )
-    RELEASE_GROUP = FileToken("{release_group}", "Release group")
+    RELEASE_GROUP = FileToken(
+        "{release_group}",
+        "Release group (from Settings > General, or the rename page)",
+    )
     RELEASE_DATE = FileToken("{release_date}", "Release date (movies - UTC)")
     RELEASERS_NAME = FileToken("{releasers_name}", "Releaser's name (Anonymous)")
     RELEASE_YEAR = FileToken("{release_year}", "Release year")

--- a/src/backend/torrent_clients/qbittorrent/save_path.py
+++ b/src/backend/torrent_clients/qbittorrent/save_path.py
@@ -294,6 +294,7 @@ def _render_save_path_template(
         token_type=FileToken,
         unfilled_token_mode=UnfilledTokenRemoval.KEEP,
         releasers_name=config.general.releasers_name,
+        group_tag=config.general.release_group,
         override_tokens=context.shared_data.dynamic_data.get("override_tokens"),
         user_tokens=user_tokens,
         edition_override=context.shared_data.dynamic_data.get("edition_override"),

--- a/src/backend/utils/filename_claims.py
+++ b/src/backend/utils/filename_claims.py
@@ -5,10 +5,16 @@ the two cannot disagree about what a filename claims. Pure: no Qt, no
 config object, no filesystem access, no MediaInfo.
 
 A claim here is something MediaInfo cannot verify -- an edition, an IMAX
-framing, a REPACK marker. The six such claims are switchable. Streaming
-service and release group are always parsed, because they are identity
-fields a user always wants pre-filled rather than opinions about the
-release.
+framing, a REPACK marker, the group that made the input file. All seven
+such claims are switchable.
+
+Streaming service is the one identity field still parsed unconditionally,
+and it stays that way because nothing competes with it: there is no "my
+streaming service" for a user to configure, and the two trackers that
+require the abbreviation scope it to web sources. The source group left
+this class when it gained a competing user-owned value -- the group tag in
+`[general]` -- which gave "do not read this from the filename" a meaning it
+did not have before.
 
 Every claim is pack-wide: it is reported only when every file agrees. One
 dissenting episode means the claim is not the pack's.
@@ -109,13 +115,17 @@ def detect_file_claims(
         ),
         remux=switched("remux", lambda s: "REMUX" if "remux" in s.lower() else ""),
         hybrid=switched("hybrid", lambda s: "HYBRID" if "hybrid" in s.lower() else ""),
-        # No switch: identity fields the user always wants pre-filled.
+        # `lstrip("-")` strips a leading dash guessit sometimes leaves on the
+        # value. This is now the only place a source group is read: the
+        # renderer has no filename parse of its own to disagree with.
+        release_group=switched(
+            "release_group",
+            lambda _: str(guess.get("release_group", "") or "").lstrip("-"),
+        ),
+        # No switch: nothing competes with it, so "off" would mean nothing.
         streaming_service=abbreviate_streaming_service(
             str(guess.get("streaming_service", "") or "")
         ),
-        # `lstrip("-")` mirrors the token handler, which has always stripped
-        # a leading dash guessit sometimes leaves on the value.
-        release_group=str(guess.get("release_group", "") or "").lstrip("-"),
     )
 
 

--- a/src/config/codec.py
+++ b/src/config/codec.py
@@ -13,7 +13,7 @@ TomlMutableMapping = TypeVar("TomlMutableMapping", bound=MutableMapping[str, Any
 class TomlConfigCodec:
     """Document-level TOML schema utilities used by the typed config manager."""
 
-    SCHEMA_VERSION = 12
+    SCHEMA_VERSION = 13
 
     @classmethod
     def validate_schema(cls, document: Mapping[str, Any]) -> None:

--- a/src/config/migrations.py
+++ b/src/config/migrations.py
@@ -108,6 +108,7 @@ SCHEMA_9_VERSION = 9
 SCHEMA_10_VERSION = 10
 SCHEMA_11_VERSION = 11
 SCHEMA_12_VERSION = 12
+SCHEMA_13_VERSION = 13
 
 # A migration accepts (document, packaged_default) and returns the migrated
 # document plus a list of sections it could not account for.
@@ -718,6 +719,8 @@ def migrate_v7_to_v8(
 # 4 REPLACE_WITH_SPACE_DASH, 5 REPLACE_WITH_SPACE_DASH_SPACE.
 _FILENAME_COLON_REMAP = {4: 3, 5: 3}
 
+# Frozen at the six claims schema 9 defined. A claim added later belongs in
+# `operations._CLAIM_KEYS`; adding it here would rewrite what this hop wrote.
 _CLAIM_NAMES = (
     "edition",
     "frame_size",
@@ -971,6 +974,61 @@ def migrate_v11_to_v12(
     return new_doc, []
 
 
+def migrate_v12_to_v13(
+    old_doc: Mapping[str, Any],
+    default_document: Mapping[str, Any] | None,
+) -> tuple[dict[str, Any], list[str]]:
+    """Fold the two release group keys into one, and switch release group
+    parsing.
+
+    The group tag printed on output is the user's publishing identity, not a
+    property of whether the release is a film or a show, so the movie and
+    series copies become a single ``[general]`` entry beside `releasers_name`.
+    Neither old key ever had a UI, so at most one is realistically set; the
+    first non-empty wins and the movie side is checked first.
+
+    The source group -- what the input filename claims -- becomes a switchable
+    claim like the other six, so both sections gain a
+    ``*_parse_claim_release_group`` key. It is written explicitly rather than
+    left to the loader's default, matching how schema 9 introduced the
+    original six, and set to True so parsing keeps working as it did.
+
+    Unlike most hops this one can change output: a profile with renaming
+    disabled and no group tag set used to have the source group read straight
+    out of the filename by the renderer. That read is gone -- the claim
+    switches now govern every path -- so such a profile emits no group until
+    one is configured.
+    """
+
+    del default_document
+    new_doc: dict[str, Any] = {"schema_version": SCHEMA_13_VERSION}
+    for key, value in old_doc.items():
+        if key != "schema_version":
+            new_doc[key] = value
+
+    group_tag = ""
+    for section_key, old_key, prefix in (
+        ("movie_management", "mvr_release_group", "mvr"),
+        ("series_management", "tvr_release_group", "tvr"),
+    ):
+        section = new_doc.get(section_key)
+        if not isinstance(section, Mapping):
+            continue
+        new_section = dict(section)
+        if not group_tag:
+            group_tag = str(_unwrap(new_section.get(old_key, "")) or "").strip()
+        new_section.pop(old_key, None)
+        new_section[f"{prefix}_parse_claim_release_group"] = True
+        new_doc[section_key] = new_section
+
+    general = new_doc.get("general")
+    new_general = dict(general) if isinstance(general, Mapping) else {}
+    new_general["release_group"] = group_tag
+    new_doc["general"] = new_general
+
+    return new_doc, []
+
+
 MIGRATIONS: dict[int, MigrationFn] = {
     SCHEMA_1_VERSION: migrate_unversioned_to_v2,
     SCHEMA_2_VERSION: migrate_v2_to_v3,
@@ -983,6 +1041,7 @@ MIGRATIONS: dict[int, MigrationFn] = {
     SCHEMA_9_VERSION: migrate_v9_to_v10,
     SCHEMA_10_VERSION: migrate_v10_to_v11,
     SCHEMA_11_VERSION: migrate_v11_to_v12,
+    SCHEMA_12_VERSION: migrate_v12_to_v13,
 }
 
 

--- a/src/config/models.py
+++ b/src/config/models.py
@@ -102,6 +102,9 @@ class GeneralSettings:
     theme: NfoForgeTheme
     enable_plugins: bool
     releasers_name: str
+    # The group tag printed on output. The user's publishing identity, so it
+    # is theirs rather than the movie or series side's -- see CONTEXT.md.
+    release_group: str
     tmdb_language: str
     media_search_mode: MediaSearchMode
     timeout: int
@@ -190,9 +193,8 @@ class ClaimSwitches:
     """Which claims are read out of the input filename.
 
     A claim is parsed if and only if `enabled` and its own switch are both
-    true. The six are claims MediaInfo cannot verify; quality/source,
-    streaming service and release group are always parsed and have no
-    switch, because they are identity fields the user always wants.
+    true. All seven are claims MediaInfo cannot verify; quality/source and
+    streaming service are always parsed and have no switch.
     """
 
     enabled: bool
@@ -202,6 +204,7 @@ class ClaimSwitches:
     re_release: bool
     remux: bool
     hybrid: bool
+    release_group: bool
 
 
 @dataclass(slots=True)
@@ -212,7 +215,6 @@ class MovieSettings:
     claims: ClaimSwitches
     filename_token: str
     title_token: str
-    release_group: str
 
 
 @dataclass(slots=True)
@@ -234,7 +236,6 @@ class SeriesSettings:
     standard_title_token: str
     daily_title_token: str
     anime_title_token: str
-    release_group: str
 
 
 @dataclass(slots=True)

--- a/src/config/operations.py
+++ b/src/config/operations.py
@@ -89,6 +89,9 @@ from src.payloads.watch_folder import WatchFolder
 
 PayloadT = TypeVar("PayloadT", bound=CheveretoV3Payload | CheveretoV4Payload)
 
+# `migrations._CLAIM_NAMES` is a separate, frozen copy of the first six: the
+# v8->v9 hop must keep writing exactly the keys schema 9 defined, so a claim
+# added here does not belong there.
 _CLAIM_KEYS = (
     "edition",
     "frame_size",
@@ -96,6 +99,7 @@ _CLAIM_KEYS = (
     "re_release",
     "remux",
     "hybrid",
+    "release_group",
 )
 
 
@@ -224,6 +228,7 @@ class TypedTomlOperations:
             ).value
             general_data["enable_plugins"] = self.settings.general.enable_plugins
             general_data["releasers_name"] = self.settings.general.releasers_name
+            general_data["release_group"] = self.settings.general.release_group
             general_data["tmdb_language"] = self.settings.general.tmdb_language
             general_data["media_search_mode"] = (
                 self.settings.general.media_search_mode.value
@@ -885,7 +890,6 @@ class TypedTomlOperations:
                 )
             movie_management["mvr_token"] = self.settings.movie.filename_token
             movie_management["mvr_title_token"] = self.settings.movie.title_token
-            movie_management["mvr_release_group"] = self.settings.movie.release_group
 
             # series management
             series_management = self._toml_table(self._toml_data, "series_management")
@@ -929,7 +933,6 @@ class TypedTomlOperations:
                 self.settings.series.anime_title_token
             )
             series_management.pop("tvr_title_token", None)
-            series_management["tvr_release_group"] = self.settings.series.release_group
 
             # global management
             global_management = self._toml_table(self._toml_data, "global_management")
@@ -1737,6 +1740,7 @@ class TypedTomlOperations:
                     theme=nfo_forge_theme,
                     enable_plugins=bool(general_data["enable_plugins"]),
                     releasers_name=str(general_data["releasers_name"]),
+                    release_group=str(general_data["release_group"]),
                     tmdb_language=str(general_data["tmdb_language"]),
                     media_search_mode=MediaSearchMode(
                         general_data["media_search_mode"]
@@ -1801,7 +1805,6 @@ class TypedTomlOperations:
                     claims=_load_claims(movie_management, "mvr"),
                     filename_token=str(movie_management["mvr_token"]),
                     title_token=str(movie_management["mvr_title_token"]),
-                    release_group=str(movie_management["mvr_release_group"]),
                 ),
                 series=SeriesSettings(
                     enabled=bool(series_management["tvr_enabled"]),
@@ -1833,7 +1836,6 @@ class TypedTomlOperations:
                     standard_title_token=load_series_token("tvr_standard_title_token"),
                     daily_title_token=load_series_token("tvr_daily_title_token"),
                     anime_title_token=load_series_token("tvr_anime_title_token"),
-                    release_group=str(series_management["tvr_release_group"]),
                 ),
                 global_management=GlobalManagementSettings(
                     title_clean_rules=[

--- a/src/frontend/custom_widgets/template_selector.py
+++ b/src/frontend/custom_widgets/template_selector.py
@@ -668,6 +668,7 @@ class TemplateSelector(QWidget):
                     episode_format=release_info.episode_format,
                     multi_episode_style=self.config.settings.series.multi_episode_style,
                     releasers_name=self.config.settings.general.releasers_name,
+                    group_tag=self.config.settings.general.release_group,
                     dummy_screen_shots=False
                     if self.context.shared_data.url_data
                     or self.context.shared_data.loaded_images

--- a/src/frontend/stacked_windows/settings/base.py
+++ b/src/frontend/stacked_windows/settings/base.py
@@ -13,6 +13,7 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
+from src.backend.utils.filename_claims import FilenameClaims
 from src.config.config import ConfigManager
 from src.config.models import ClaimSwitches
 from src.enums.token_replacer import FILENAME_COLON_OPTIONS, ColonReplace
@@ -133,8 +134,7 @@ class BaseSettings(QWidget):
         master = QCheckBox("Parse claims from input filename", parent)
         master.setToolTip(
             "Read claims that MediaInfo cannot verify out of the input "
-            "filename. Quality/source, streaming service and release group "
-            "are always parsed."
+            "filename. Quality/source and streaming service are always parsed."
         )
         return master
 
@@ -149,6 +149,7 @@ class BaseSettings(QWidget):
                 ("re_release", "Re-release (PROPER / REPACK)"),
                 ("remux", "REMUX"),
                 ("hybrid", "HYBRID"),
+                ("release_group", "Release group"),
             )
         }
 
@@ -168,6 +169,14 @@ class BaseSettings(QWidget):
         # `toggled` does not fire when the checked state is unchanged, so
         # the greyed state is applied explicitly rather than relied upon.
         self._on_claims_master_toggled(claims.enabled)
+
+    def _preview_overrides(self, claims: FilenameClaims) -> dict[str, str]:
+        """What the example filename claims, with the configured group tag
+        winning over its own group as it does on the rename page."""
+        overrides = claims.as_override_tokens()
+        if group_tag := self.config.settings.general.release_group:
+            overrides["release_group"] = group_tag
+        return overrides
 
     def _current_claim_switches(self) -> ClaimSwitches:
         return ClaimSwitches(

--- a/src/frontend/stacked_windows/settings/general.py
+++ b/src/frontend/stacked_windows/settings/general.py
@@ -100,6 +100,17 @@ class GeneralSettings(BaseSettings):
         releasers_name_lbl.setToolTip("Sets the releaser's name. As displayed in NFOs")
         self.releasers_name_entry = QLineEdit(self)
 
+        release_group_lbl = QLabel("Release Group")
+        release_group_lbl.setToolTip(
+            "Your group tag, printed by the {release_group} token in filenames, "
+            "titles and NFOs. Pre-fills the rename page, where it can still be "
+            "changed for a one-off release. Leave blank to take the group from "
+            "the input filename instead."
+        )
+        self.release_group_entry = QLineEdit(self)
+        self.release_group_entry.setToolTip(release_group_lbl.toolTip())
+        self.release_group_entry.setPlaceholderText("No group tag")
+
         global_timeout_lbl = QLabel("Global Timeout", self)
         global_timeout_lbl.setToolTip("Sets global timeout for network requests")
         self.global_timeout_spinbox = QSpinBox(self)
@@ -236,6 +247,7 @@ class GeneralSettings(BaseSettings):
         self.add_layout(
             create_form_layout(releasers_name_lbl, self.releasers_name_entry)
         )
+        self.add_layout(create_form_layout(release_group_lbl, self.release_group_entry))
         self.add_layout(
             create_form_layout(global_timeout_lbl, self.global_timeout_spinbox)
         )
@@ -270,6 +282,7 @@ class GeneralSettings(BaseSettings):
         self.load_combo_box(self.theme_combo, NfoForgeTheme, payload.theme)
         self._change_theme()
         self.releasers_name_entry.setText(payload.releasers_name)
+        self.release_group_entry.setText(payload.release_group)
         self.global_timeout_spinbox.setValue(payload.timeout)
         self._load_tmdb_language_combo(payload.tmdb_language)
         self.load_combo_box(
@@ -525,6 +538,9 @@ class GeneralSettings(BaseSettings):
         self.config.settings.general.releasers_name = (
             self.releasers_name_entry.text().strip()
         )
+        self.config.settings.general.release_group = (
+            self.release_group_entry.text().strip()
+        )
         self.config.settings.general.tmdb_language = (
             self.tmdb_language_combo.currentData()
         )
@@ -557,6 +573,7 @@ class GeneralSettings(BaseSettings):
         )
         self.theme_combo.setCurrentIndex(self.config.defaults.general.theme.value - 1)
         self.releasers_name_entry.clear()
+        self.release_group_entry.clear()
         # set TMDB language to default
         for i in range(self.tmdb_language_combo.count()):
             if (

--- a/src/frontend/stacked_windows/settings/movies_management.py
+++ b/src/frontend/stacked_windows/settings/movies_management.py
@@ -281,10 +281,7 @@ class MoviesManagementSettings(BaseSettings):
             video_dynamic_range=self._get_live_video_dynamic_range(),
             override_title_rules=override_title_rules,
             user_tokens=user_tokens,
-            # Stage 1 detection, the same function the rename pages call,
-            # so the preview and the wizard cannot disagree about what the
-            # example filename claims.
-            override_tokens=self._detected_claims().as_override_tokens(),
+            override_tokens=self._preview_overrides(self._detected_claims()),
             flat_filters=self.config.plugin_manager.flat_filters(
                 enabled=self.config.settings.general.enable_plugins
             ),

--- a/src/frontend/stacked_windows/settings/series_management.py
+++ b/src/frontend/stacked_windows/settings/series_management.py
@@ -403,10 +403,7 @@ class SeriesManagementSettings(BaseSettings):
             video_dynamic_range=self._get_live_video_dynamic_range(),
             override_title_rules=override_title_rules,
             user_tokens=user_tokens,
-            # Stage 1 detection, the same function the rename pages call,
-            # so the preview and the wizard cannot disagree about what the
-            # example filename claims.
-            override_tokens=self._detected_claims().as_override_tokens(),
+            override_tokens=self._preview_overrides(self._detected_claims()),
             flat_filters=self.config.plugin_manager.flat_filters(
                 enabled=self.config.settings.general.enable_plugins
             ),

--- a/src/frontend/wizards/rename_encode.py
+++ b/src/frontend/wizards/rename_encode.py
@@ -235,10 +235,13 @@ class RenameEncode(BaseWizardPage):
 
         release_group_lbl = QLabel("Release Group", self)
         release_group_lbl.setToolTip(
-            "Release group name (this requires the token {release_group} in the token string)"
+            "The group name on your output. Pre-filled from Settings > General, "
+            "or from the input filename when release group parsing is on. "
+            "Clearing it publishes this release with no group."
         )
         self.release_group_entry = QLineEdit(self)
         self.release_group_entry.setToolTip(release_group_lbl.toolTip())
+        self.release_group_entry.setPlaceholderText("No group tag")
         self.release_group_entry.textEdited.connect(self.update_generated_name)
 
         token_override_lbl = QLabel("Override File Name Tokens", self)
@@ -321,7 +324,7 @@ class RenameEncode(BaseWizardPage):
     def initializePage(self) -> None:
         # this is a movie so there's only ever 1 to rename, grab it with index 0
         media_file = self.context.media_input.file_list[0]
-        release_group_name = self.config.settings.movie.release_group
+        release_group_name = self.config.settings.general.release_group
 
         self.media_label.setText(media_file.stem)
         self.media_label.setToolTip(media_file.stem)
@@ -348,11 +351,11 @@ class RenameEncode(BaseWizardPage):
             if quality_idx > -1:
                 self.quality_combo.setCurrentIndex(quality_idx)
 
-        # The settings value means "my group"; the detected one means
-        # "whoever made the source file". Configured wins, but a blank
-        # setting must not leave the field empty while the output silently
-        # carries the detected group -- that is the invisible claim this
-        # design removes everywhere else.
+        # The settings value is the user's group tag; the detected one is the
+        # source group, meaning whoever made the input file. Configured wins,
+        # and with parsing off there is nothing to fall back to -- the
+        # renderer has no filename parse of its own, so what this field shows
+        # is what the output carries.
         self.release_group_entry.setText(release_group_name or claims.release_group)
 
         self.update_generated_name()
@@ -779,12 +782,13 @@ class RenameEncode(BaseWizardPage):
         else:
             self.token_override.setText(token)
 
-        # treat release group as a pure override token
-        release_group = self.release_group_entry.text().strip()
-        if release_group:
-            self.backend.override_tokens["release_group"] = release_group
-        else:
-            self.backend.override_tokens.pop("release_group", None)
+        # This page is stage 2, so the field is the whole answer: written
+        # unconditionally, including blank. A blank here is the user deciding
+        # this release carries no group, which has to beat the configured tag
+        # rather than fall through to it.
+        self.backend.override_tokens["release_group"] = (
+            self.release_group_entry.text().strip()
+        )
 
         user_tokens = {
             k: v

--- a/src/frontend/wizards/rename_encode_series.py
+++ b/src/frontend/wizards/rename_encode_series.py
@@ -256,10 +256,13 @@ class RenameEncodeSeries(BaseWizardPage):
         # Release group
         release_group_lbl = QLabel("Release Group", self)
         release_group_lbl.setToolTip(
-            "Release group name (this requires the token {release_group} in the token string)"
+            "The group name on your output. Pre-filled from Settings > General, "
+            "or from the input filenames when release group parsing is on. "
+            "Clearing it publishes this release with no group."
         )
         self.release_group_entry = QLineEdit(self)
         self.release_group_entry.setToolTip(release_group_lbl.toolTip())
+        self.release_group_entry.setPlaceholderText("No group tag")
         self.release_group_entry.textEdited.connect(self.update_generated_name)
 
         # Token override section
@@ -337,7 +340,7 @@ class RenameEncodeSeries(BaseWizardPage):
     def initializePage(self) -> None:
         """Initialize the page with series data and load episode batch."""
         media_files = self.context.media_input.file_list
-        release_group_name = self.config.settings.series.release_group
+        release_group_name = self.config.settings.general.release_group
 
         if not media_files:
             raise FileNotFoundError("No files found in media input payload")
@@ -381,11 +384,11 @@ class RenameEncodeSeries(BaseWizardPage):
         else:
             self.quality_combo.setCurrentIndex(0)
 
-        # The settings value means "my group"; the detected one means
-        # "whoever made the source file". Configured wins, but a blank
-        # setting must not leave the field empty while the output silently
-        # carries the detected group -- that is the invisible claim this
-        # design removes everywhere else.
+        # The settings value is the user's group tag; the detected one is the
+        # source group, meaning whoever made the input files. Configured wins,
+        # and with parsing off there is nothing to fall back to -- the
+        # renderer has no filename parse of its own, so what this field shows
+        # is what the output carries.
         self.release_group_entry.setText(release_group_name or claims.release_group)
 
         # Initial call to update_generated_name populates the override token
@@ -940,12 +943,13 @@ class RenameEncodeSeries(BaseWizardPage):
         else:
             self.token_override.setText(token)
 
-        # Treat release group as a pure override token
-        release_group = self.release_group_entry.text().strip()
-        if release_group:
-            self.backend.override_tokens["release_group"] = release_group
-        else:
-            self.backend.override_tokens.pop("release_group", None)
+        # This page is stage 2, so the field is the whole answer: written
+        # unconditionally, including blank. A blank here is the user deciding
+        # this release carries no group, which has to beat the configured tag
+        # rather than fall through to it.
+        self.backend.override_tokens["release_group"] = (
+            self.release_group_entry.text().strip()
+        )
 
         # Run the renamer for a representative (first mapped) episode so the
         # override token grid mirrors the movie page's live preview. Without

--- a/tests/test_backend/test_claim_override_seeding.py
+++ b/tests/test_backend/test_claim_override_seeding.py
@@ -1,0 +1,137 @@
+"""Stage 1 for a run that never reached a rename page.
+
+Renaming is optional, and with it off the wizard routes straight past the
+page that detects claims and populates the overrides. Nothing else did it, so
+the NFO and the tracker titles rendered as though the filenames claimed
+nothing. Detection belongs to the run rather than to one page.
+"""
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+
+from src.backend.process import ProcessBackEnd
+from src.config.config import ConfigManager
+from src.config.models import ClaimSwitches
+from src.context.processing_context import ProcessingContext
+from src.enums.media_type import MediaType
+from src.payloads.media_inputs import MediaInputPayload
+from src.payloads.media_search import MediaSearchPayload
+
+MOVIE_STEM = "Movie.2024.Directors.Cut.IMAX.REPACK.1080p.BluRay.x264-GRP"
+
+
+def _switches(**overrides: bool) -> ClaimSwitches:
+    base = {
+        "enabled": True,
+        "edition": True,
+        "frame_size": True,
+        "localization": True,
+        "re_release": True,
+        "remux": True,
+        "hybrid": True,
+        "release_group": True,
+    }
+    base.update(overrides)
+    return ClaimSwitches(**base)  # pyright: ignore[reportArgumentType]
+
+
+def _backend(
+    movie_claims: ClaimSwitches | None = None,
+    series_claims: ClaimSwitches | None = None,
+) -> ProcessBackEnd:
+    backend = object.__new__(ProcessBackEnd)
+    backend.config = cast(
+        ConfigManager,
+        SimpleNamespace(
+            settings=SimpleNamespace(
+                movie=SimpleNamespace(claims=movie_claims or _switches()),
+                series=SimpleNamespace(claims=series_claims or _switches()),
+            )
+        ),
+    )
+    return backend
+
+
+def _context(*stems: str, media_type: MediaType = MediaType.MOVIE) -> ProcessingContext:
+    return ProcessingContext(
+        media_input=MediaInputPayload(
+            input_path=Path("input"),
+            media_type=media_type,
+            file_list=[Path(f"{stem}.mkv") for stem in stems],
+        ),
+        media_search=MediaSearchPayload(media_type=media_type),
+    )
+
+
+def test_a_run_that_skipped_the_rename_page_still_detects_its_claims() -> None:
+    context = _context(MOVIE_STEM)
+
+    _backend()._seed_claim_overrides(context)
+
+    overrides = context.shared_data.dynamic_data["override_tokens"]
+    assert overrides["release_group"] == "GRP"
+    assert overrides["edition"] == "Directors Cut"
+    assert overrides["frame_size"] == "IMAX"
+    assert overrides["re_release"] == "REPACK"
+
+
+def test_the_switches_still_govern_the_skip_path() -> None:
+    """A switch the user turned off must mean the same thing everywhere. If
+    seeding ignored it, turning release group parsing off would work on the
+    rename page and silently not work with renaming disabled."""
+    context = _context(MOVIE_STEM)
+
+    _backend(movie_claims=_switches(release_group=False))._seed_claim_overrides(context)
+
+    overrides = context.shared_data.dynamic_data["override_tokens"]
+    assert "release_group" not in overrides
+    assert overrides["edition"] == "Directors Cut"
+
+
+def test_a_run_that_reached_the_rename_page_is_left_alone() -> None:
+    """Those overrides are the user's stage-2 decisions, and a blank group is
+    one of them -- re-detecting would hand back what they cleared."""
+    context = _context(MOVIE_STEM)
+    context.shared_data.dynamic_data["override_tokens"] = {"release_group": ""}
+
+    _backend()._seed_claim_overrides(context)
+
+    assert context.shared_data.dynamic_data["override_tokens"] == {"release_group": ""}
+
+
+def test_a_series_run_reads_the_series_switches() -> None:
+    context = _context(
+        "Show.S01E01.1080p.WEB-DL.x264-GRP",
+        "Show.S01E02.1080p.WEB-DL.x264-GRP",
+        media_type=MediaType.SERIES,
+    )
+
+    _backend(
+        movie_claims=_switches(release_group=False),
+        series_claims=_switches(),
+    )._seed_claim_overrides(context)
+
+    assert context.shared_data.dynamic_data["override_tokens"]["release_group"] == "GRP"
+
+
+def test_a_pack_that_disagrees_carries_no_group() -> None:
+    """Claims are pack-wide: one dissenting episode means the claim is not the
+    pack's, so no control could carry it and no output should."""
+    context = _context(
+        "Show.S01E01.1080p.WEB-DL.x264-GRP",
+        "Show.S01E02.1080p.WEB-DL.x264-OTHER",
+        media_type=MediaType.SERIES,
+    )
+
+    _backend()._seed_claim_overrides(context)
+
+    assert "release_group" not in context.shared_data.dynamic_data["override_tokens"]
+
+
+def test_a_run_with_no_files_seeds_nothing() -> None:
+    context = _context()
+
+    _backend()._seed_claim_overrides(context)
+
+    assert "override_tokens" not in context.shared_data.dynamic_data

--- a/tests/test_backend/test_filename_claims.py
+++ b/tests/test_backend/test_filename_claims.py
@@ -17,6 +17,7 @@ def _switches(**overrides: bool) -> ClaimSwitches:
         "re_release": True,
         "remux": True,
         "hybrid": True,
+        "release_group": True,
     }
     base.update(overrides)
     return ClaimSwitches(**base)  # pyright: ignore[reportArgumentType]
@@ -96,15 +97,28 @@ def test_master_off_suppresses_all_six() -> None:
     assert claims.hybrid == ""
 
 
-def test_always_parsed_categories_ignore_the_master_switch() -> None:
-    # Quality/source, streaming service and release group are identity
-    # fields the user always wants pre-filled, so they have no switch.
+def test_streaming_service_ignores_the_master_switch() -> None:
+    # Quality/source and streaming service have no switch: nothing competes
+    # with them, so "off" would mean nothing.
     stem = "Movie.2024.1080p.AMZN.WEB-DL.x264-GRP"
 
     claims = detect_filename_claims([stem], _switches(enabled=False))
 
     assert claims.streaming_service == "AMZN"
-    assert claims.release_group == "GRP"
+
+
+def test_the_source_group_obeys_its_own_switch() -> None:
+    # Turning the switch off has to reach output, not just the control: the
+    # renderer parses no filename of its own, so an undetected source group
+    # is one that cannot appear anywhere.
+    stem = "Movie.2024.1080p.BluRay.x264-GRP"
+
+    assert detect_filename_claims([stem], _switches()).release_group == "GRP"
+    assert (
+        detect_filename_claims([stem], _switches(release_group=False)).release_group
+        == ""
+    )
+    assert detect_filename_claims([stem], _switches(enabled=False)).release_group == ""
 
 
 def test_no_files_yields_no_claims() -> None:

--- a/tests/test_backend/test_flat_filter_runtime.py
+++ b/tests/test_backend/test_flat_filter_runtime.py
@@ -52,6 +52,7 @@ def test_tracker_title_applies_processing_context_flat_filters() -> None:
         ConfigManager,
         SimpleNamespace(
             settings=SimpleNamespace(
+                general=SimpleNamespace(release_group=""),
                 movie=SimpleNamespace(
                     title_token="{title_clean|append_marker}",  # noqa: S106 - NFO template token string used as test fixture data, not a credential
                     title_colon_replace=ColonReplace.REPLACE_WITH_DASH,

--- a/tests/test_backend/test_generate_tracker_title.py
+++ b/tests/test_backend/test_generate_tracker_title.py
@@ -44,6 +44,7 @@ def _backend(
         ConfigManager,
         SimpleNamespace(
             settings=SimpleNamespace(
+                general=SimpleNamespace(release_group=""),
                 movie=SimpleNamespace(
                     title_token=movie_template,
                     title_colon_replace=movie_colon,

--- a/tests/test_backend/test_prepared_jobs.py
+++ b/tests/test_backend/test_prepared_jobs.py
@@ -43,6 +43,7 @@ def _backend(monkeypatch: pytest.MonkeyPatch) -> ProcessBackEnd:
                     enable_plugins=False,
                     enable_prompt_overview=True,
                     releasers_name="tester",
+                    release_group="",
                 ),
                 trackers=SimpleNamespace(
                     by_selection=lambda: {TrackerSelection.AITHER: info}

--- a/tests/test_backend/test_qbittorrent_save_path.py
+++ b/tests/test_backend/test_qbittorrent_save_path.py
@@ -51,7 +51,7 @@ def _config(
                 )
             ),
             user_tokens=SimpleNamespace(tokens=user_tokens or {}),
-            general=SimpleNamespace(releasers_name=""),
+            general=SimpleNamespace(releasers_name="", release_group=""),
             global_management=SimpleNamespace(
                 title_clean_rules=[],
                 video_dynamic_range=None,

--- a/tests/test_backend/test_rename_encode_series_backend.py
+++ b/tests/test_backend/test_rename_encode_series_backend.py
@@ -41,9 +41,11 @@ def test_series_renamer_uses_the_episode_being_rendered() -> None:
         media_file=second_file,
         # {re_release} used to appear here. It is a claim now, and claims are
         # pack-wide: they arrive as overrides rather than being read off the
-        # episode being rendered. {resolution} and {release_group} are still
-        # per-file, which is what this test is about.
-        token="{resolution} {release_group}",  # noqa: S106 - NFO template token string used as test fixture data, not a credential
+        # episode being rendered. {release_group} left for the same reason,
+        # and because it is the user's own tag rather than anything the
+        # episode can claim. {resolution} is still per-file, which is what
+        # this test is about.
+        token="{resolution}",  # noqa: S106 - NFO template token string used as test fixture data, not a credential
         colon_replacement=ColonReplace.REPLACE_WITH_DASH,
         media_search_payload=_empty_series_search(),
         season_num=1,
@@ -55,7 +57,7 @@ def test_series_renamer_uses_the_episode_being_rendered() -> None:
         multi_episode_style=MultiEpisodeStyle.RANGE,
     )
 
-    assert result == Path("720p.OTHER.mkv")
+    assert result == Path("720p.mkv")
 
 
 def test_series_folder_renamer_renders_multi_season_range() -> None:
@@ -437,7 +439,7 @@ def test_a_lone_repack_still_reaches_that_episodes_filename() -> None:
             user_tokens=None,
             episode_format=EpisodeFormat.STANDARD,
             multi_episode_style=MultiEpisodeStyle.RANGE,
-            file_claims=file_claims,
+            file_claims={**file_claims, "release_group": "GRP"},
         )
 
     assert render(first_file, {}) == Path("GRP.mkv")
@@ -469,7 +471,7 @@ def test_a_pack_wide_choice_wins_over_the_files_own_claim() -> None:
         user_tokens=None,
         episode_format=EpisodeFormat.STANDARD,
         multi_episode_style=MultiEpisodeStyle.RANGE,
-        file_claims={"re_release": "REPACK"},
+        file_claims={"re_release": "REPACK", "release_group": "GRP"},
     )
 
     assert result == Path("PROPER.GRP.mkv")

--- a/tests/test_backend/test_token_replacer_movies.py
+++ b/tests/test_backend/test_token_replacer_movies.py
@@ -92,6 +92,7 @@ def _detected_claims_for(stem: str) -> str:
             re_release=True,
             remux=True,
             hybrid=True,
+            release_group=True,
         ),
     ).frame_size
 
@@ -235,6 +236,7 @@ def test_custom_edition_is_recognized_by_the_detector() -> None:
             re_release=True,
             remux=True,
             hybrid=True,
+            release_group=True,
         ),
         (RenameNormalization("Fan Edit", (r"fan[\s\.\-_]*edit",)),),
     )
@@ -685,6 +687,7 @@ def _title_replacer(
             re_release=True,
             remux=True,
             hybrid=True,
+            release_group=True,
         ),
     ).as_override_tokens()
     if not remux:
@@ -983,6 +986,7 @@ def test_settings_preview_and_rename_render_the_same_claims() -> None:
         re_release=True,
         remux=True,
         hybrid=True,
+        release_group=True,
     )
     claims = detect_filename_claims(
         [EXAMPLE_MEDIA_INPUT_PAYLOAD.input_path.stem], switches
@@ -1136,3 +1140,46 @@ def test_web_source_still_distinguishes_dl_from_rip(stem: str, expected: str) ->
     # The discriminator moves from a raw filename regex to guessit's own
     # `other: Rip`, which is the same information without a second scan.
     assert _claim_replacer("{source}", stem) == expected
+
+
+def _group_replacer(group_tag: str = "", **kwargs: object) -> str | None:
+    return TokenReplacer(
+        media_input_obj=EXAMPLE_MEDIA_INPUT_PAYLOAD,
+        token_string="{release_group}",  # noqa: S106 - NFO template token string used as test fixture data, not a credential
+        media_search_obj=EXAMPLE_SEARCH_PAYLOAD,
+        flatten=True,
+        file_name_mode=False,
+        token_type=FileToken,
+        unfilled_token_mode=UnfilledTokenRemoval.TOKEN_ONLY,
+        group_tag=group_tag,
+        **kwargs,  # pyright: ignore[reportArgumentType]
+    ).get_output()
+
+
+def test_the_configured_group_tag_renders_without_any_override() -> None:
+    """A run that never reached the rename page still carries the user's own
+    group. The tag is a constructor argument for exactly this reason: it does
+    not depend on a page having run."""
+    assert _group_replacer("MYGROUP") == "MYGROUP"
+
+
+def test_no_group_is_read_from_the_filename() -> None:
+    """The example filename ends in -SomeGroup and the renderer must not care.
+
+    Every switchable claim resolves from an override or not at all, and the
+    source group is one now. Reading it here would put a group the user never
+    saw into their output, and would make the parse switch a lie -- turning it
+    off could not stop what it does not feed.
+    """
+    assert EXAMPLE_MEDIA_INPUT_PAYLOAD.input_path.stem.endswith("-SomeGroup")
+
+    assert _group_replacer() == ""
+
+
+def test_an_override_beats_the_configured_group_tag() -> None:
+    """The rename page's field is stage 2, so it wins -- including when the
+    user cleared it, which arrives as "" rather than as a missing key."""
+    assert _group_replacer("MYGROUP", override_tokens={"release_group": "THEIRS"}) == (
+        "THEIRS"
+    )
+    assert _group_replacer("MYGROUP", override_tokens={"release_group": ""}) == ""

--- a/tests/test_backend/test_token_replacer_series.py
+++ b/tests/test_backend/test_token_replacer_series.py
@@ -56,9 +56,12 @@ def test_active_file_drives_file_specific_tokens_in_series_pack() -> None:
             media_input_obj=payload,
             media_search_obj=MediaSearchPayload(media_type=MediaType.SERIES),
             # {re_release} is a claim now, detected pack-wide in stage 1 and
-            # supplied as an override, so it no longer varies per file. The
-            # rest still resolve from whichever file is active.
-            token_string="{resolution}|{release_group}|{original_filename}",  # noqa: S106 - NFO template token string used as test fixture data, not a credential
+            # supplied as an override, so it no longer varies per file.
+            # {release_group} is not file-specific at all any more -- it is
+            # the user's own group tag, one per release, so a pack of files
+            # from different groups still carries whichever one they chose.
+            # The rest still resolve from whichever file is active.
+            token_string="{resolution}|{original_filename}",  # noqa: S106 - NFO template token string used as test fixture data, not a credential
             colon_replace=ColonReplace.REPLACE_WITH_DASH,
             flatten=True,
             file_name_mode=False,
@@ -68,8 +71,8 @@ def test_active_file_drives_file_specific_tokens_in_series_pack() -> None:
             active_file=active_file,
         ).get_output()
 
-    assert render(first_file) == f"1080p|GRP|{first_file.stem}"
-    assert render(second_file) == f"720p|OTHER|{second_file.stem}"
+    assert render(first_file) == f"1080p|{first_file.stem}"
+    assert render(second_file) == f"720p|{second_file.stem}"
 
 
 def test_tmdb_url_token_uses_the_tv_path_for_a_series() -> None:

--- a/tests/test_backend/test_tracker_naming_rules.py
+++ b/tests/test_backend/test_tracker_naming_rules.py
@@ -113,11 +113,19 @@ def _media(name: str):
     )
 
 
-_CLAIM_KEYS = ("edition", "frame_size", "localization", "re_release", "remux", "hybrid")
+_CLAIM_KEYS = (
+    "edition",
+    "frame_size",
+    "localization",
+    "re_release",
+    "remux",
+    "hybrid",
+    "release_group",
+)
 
 
 def _claim_overrides(name: str) -> dict[str, str]:
-    """The six switchable claims stage 1 reads from a release name."""
+    """The switchable claims stage 1 reads from a release name."""
     detected = detect_filename_claims(
         [Path(name).stem],
         ClaimSwitches(
@@ -128,6 +136,7 @@ def _claim_overrides(name: str) -> dict[str, str]:
             re_release=True,
             remux=True,
             hybrid=True,
+            release_group=True,
         ),
     ).as_override_tokens()
     return {k: v for k, v in detected.items() if k in _CLAIM_KEYS}
@@ -219,12 +228,13 @@ def _render(
     Passing a season switches the payload to a series one, so the episode
     tokens are asked the same question the app asks them.
     """
-    # Stage 3 no longer reads the six switchable claims off the filename, so
-    # they arrive as overrides -- exactly what generate_tracker_title
-    # receives from the rename page. Streaming service and release group are
-    # deliberately not injected unless a test asks: those are still detected
-    # downstream, and an override would bypass the service token's own
-    # web-source gating.
+    # Stage 3 reads no claim off the filename, so they arrive as overrides --
+    # exactly what generate_tracker_title receives from the rename page. The
+    # release group is among them now, and an explicit `release_group`
+    # argument still wins, which is how a test states a group its fixture
+    # name does not carry. Streaming service is deliberately not injected
+    # unless a test asks: it is still detected downstream, and an override
+    # would bypass the service token's own web-source gating.
     overrides: dict[str, str] = _claim_overrides(name)
     overrides["source"] = source
     if release_group is not None:

--- a/tests/test_backend/test_upload_retry.py
+++ b/tests/test_backend/test_upload_retry.py
@@ -15,12 +15,25 @@ from src.backend.upload_retry import (
     UploadRetryAction,
 )
 from src.config.config import ConfigManager
+from src.config.models import ClaimSwitches
 from src.context.processing_context import ProcessingContext
+from src.enums.media_type import MediaType
 from src.enums.tracker_selection import TrackerSelection
 from src.exceptions import ProcessCancelled, TrackerClientError, TrackerError
 from src.payloads.shared_data import SharedPayload
 from src.plugins.api import PluginDefinition, PostUploadOutcome, PostUploadRequest
 from src.plugins.manager import PluginManager
+
+_CLAIMS_OFF = ClaimSwitches(
+    enabled=False,
+    edition=False,
+    frame_size=False,
+    localization=False,
+    re_release=False,
+    remux=False,
+    hybrid=False,
+    release_group=False,
+)
 
 
 def _backend() -> ProcessBackEnd:
@@ -423,6 +436,10 @@ def test_injection_cancel_marks_remaining_trackers_and_disconnects(
                         TrackerSelection.BEYOND_HD: tracker_info,
                     }
                 ),
+                # Stage 1 seeding reads the claim switches for the run's
+                # media type; off means it detects nothing, which keeps these
+                # tests about retry behaviour.
+                movie=SimpleNamespace(claims=_CLAIMS_OFF),
                 user_tokens=SimpleNamespace(tokens={}),
                 dependencies=SimpleNamespace(mkbrr=None, enable_mkbrr=False),
                 torrent_clients=SimpleNamespace(
@@ -455,8 +472,13 @@ def test_injection_cancel_marks_remaining_trackers_and_disconnects(
             media_input=SimpleNamespace(
                 require_input_path=lambda: tmp_path / "media.mkv",
                 require_working_dir=lambda: tmp_path,
+                # Stage 1 runs for any path that reaches processing, so the
+                # stub carries what it reads.
+                file_list=[tmp_path / "media.mkv"],
+                media_type=MediaType.MOVIE,
             ),
             shared_data=SharedPayload(),
+            custom_edition_info=(),
         ),
     )
     process_dict = {
@@ -559,6 +581,10 @@ def _process_trackers_backend(
                     post_upload="test.notify",
                     token_replacer="",
                 ),
+                # Stage 1 seeding reads the claim switches for the run's
+                # media type; off means it detects nothing, which keeps these
+                # tests about retry behaviour.
+                movie=SimpleNamespace(claims=_CLAIMS_OFF),
                 user_tokens=SimpleNamespace(tokens={}),
                 dependencies=SimpleNamespace(mkbrr=None, enable_mkbrr=False),
                 torrent_clients=SimpleNamespace(
@@ -601,8 +627,13 @@ def _run_process_trackers(
             media_input=SimpleNamespace(
                 require_input_path=lambda: tmp_path / "media.mkv",
                 require_working_dir=lambda: tmp_path,
+                # Stage 1 runs for any path that reaches processing, so the
+                # stub carries what it reads.
+                file_list=[tmp_path / "media.mkv"],
+                media_type=MediaType.MOVIE,
             ),
             shared_data=SharedPayload(),
+            custom_edition_info=(),
         ),
     )
     process_dict = {"Aither": {"path": tmp_path / "aither.torrent"}}

--- a/tests/test_config/fixtures/schema12_config.toml
+++ b/tests/test_config/fixtures/schema12_config.toml
@@ -1,4 +1,4 @@
-schema_version = 13
+schema_version = 12
 
 [general]
 ui_suffix = ""
@@ -6,9 +6,6 @@ ui_scale_factor = 1.0
 nfo_forge_theme = 1
 enable_plugins = false
 releasers_name = ""
-# The group tag printed on output. Blank means the rename page decides, from
-# the input filename's own group when release group parsing is on.
-release_group = ""
 tmdb_language = "en-US"
 media_search_mode = "Movies & TV"
 timeout = 60
@@ -409,7 +406,7 @@ mvr_colon_replace_filename = 3
 mvr_colon_replace_title = 3
 # Claims MediaInfo cannot verify, read out of the input filename. A claim is
 # parsed only when mvr_parse_claims and its own switch are both true.
-# Quality/source and streaming service are always parsed.
+# Quality/source, streaming service and release group are always parsed.
 mvr_parse_claims = true
 mvr_parse_claim_edition = true
 mvr_parse_claim_frame_size = true
@@ -417,9 +414,10 @@ mvr_parse_claim_localization = true
 mvr_parse_claim_re_release = true
 mvr_parse_claim_remux = true
 mvr_parse_claim_hybrid = true
-mvr_parse_claim_release_group = true
 mvr_token = "{title_clean} {release_year} {re_release} {source} {resolution} {audio_codec} {audio_channel_s} {video_codec}{:opt=-:release_group}"
 mvr_title_token = "{title_clean} {release_year} {re_release} {source} {resolution} {audio_codec} {audio_channel_s} {video_codec}{:opt=-:release_group}"
+# TODO: move to global at the top?
+mvr_release_group = ""
 
 [series_management]
 tvr_enabled = true
@@ -427,7 +425,7 @@ tvr_colon_replace_filename = 3
 tvr_colon_replace_title = 3
 # Claims MediaInfo cannot verify, read out of the input filename. A claim is
 # parsed only when tvr_parse_claims and its own switch are both true.
-# Quality/source and streaming service are always parsed.
+# Quality/source, streaming service and release group are always parsed.
 tvr_parse_claims = true
 tvr_parse_claim_edition = true
 tvr_parse_claim_frame_size = true
@@ -435,7 +433,6 @@ tvr_parse_claim_localization = true
 tvr_parse_claim_re_release = true
 tvr_parse_claim_remux = true
 tvr_parse_claim_hybrid = true
-tvr_parse_claim_release_group = true
 tvr_standard_episode_token = "{title_clean} S{season_number|zfill(2)}E{episode_number|zfill(2)} {episode_title_clean} {re_release} {resolution} {source} {audio_codec} {audio_channel_s} {video_dynamic_range_type_inc_sdr_over_1080} {video_codec}{:opt=-:release_group}"
 tvr_daily_episode_token = "{title_clean} {episode_air_date} {episode_title_clean} {re_release} {resolution} {source} {audio_codec} {audio_channel_s} {video_dynamic_range_type_inc_sdr_over_1080} {video_codec}{:opt=-:release_group}"
 tvr_anime_episode_token = "{title_clean} S{season_number|zfill(2)}E{episode_number|zfill(2)} {episode_number_absolute|zfill(3)} {episode_title_clean} {re_release} {resolution} {source} {audio_codec} {audio_channel_s} {video_dynamic_range_type_inc_sdr_over_1080} {video_codec}{:opt=-:release_group}"
@@ -445,6 +442,7 @@ tvr_multi_episode_style = 4
 tvr_standard_title_token = "{title_clean} S{season_number|zfill(2)}{:opt=E:episode_number|zfill(2)} {episode_title_clean} {re_release} {resolution} {source} {audio_codec} {audio_channel_s} {video_dynamic_range_type_inc_sdr_over_1080} {video_codec}{:opt=-:release_group}"
 tvr_daily_title_token = "{title_clean} {episode_air_date} {episode_title_clean} {re_release} {resolution} {source} {audio_codec} {audio_channel_s} {video_dynamic_range_type_inc_sdr_over_1080} {video_codec}{:opt=-:release_group}"
 tvr_anime_title_token = "{title_clean} S{season_number|zfill(2)}{:opt=E:episode_number|zfill(2)} {episode_number_absolute|zfill(3)} {episode_title_clean} {re_release} {resolution} {source} {audio_codec} {audio_channel_s} {video_dynamic_range_type_inc_sdr_over_1080} {video_codec}{:opt=-:release_group}"
+tvr_release_group = ""
 
 [global_management]
 title_clean_rules = [

--- a/tests/test_config/test_manager.py
+++ b/tests/test_config/test_manager.py
@@ -990,12 +990,16 @@ def test_load_profile_migrates_schema1_and_archives_original(
 
     reloaded = tomlkit.parse(profile.read_text(encoding="utf-8"))
     assert reloaded["schema_version"] == TomlConfigCodec.SCHEMA_VERSION
-    assert reloaded["movie_management"]["mvr_release_group"] == "CustomReleaseGroup"  # type: ignore[reportIndexIssue]
+    # The group tag folded into [general] on the way up; the two per-media-type
+    # keys it came from are gone rather than left behind to drift.
+    assert reloaded["general"]["release_group"] == "CustomReleaseGroup"  # type: ignore[reportIndexIssue]
+    assert "mvr_release_group" not in reloaded["movie_management"]  # type: ignore[reportOperatorIssue]
+    assert "tvr_release_group" not in reloaded["series_management"]  # type: ignore[reportOperatorIssue]
     assert "movie_rename" not in reloaded
     backups = list((profile.parent / "old_configs").glob("test_*.toml"))
     assert len(backups) == 1
     assert backups[0].read_text(encoding="utf-8") == original_text
-    assert manager.settings.movie.release_group == "CustomReleaseGroup"
+    assert manager.settings.general.release_group == "CustomReleaseGroup"
     assert manager.settings.trackers.torrent_leech.username == "custom_tl_user"
 
 
@@ -1016,7 +1020,7 @@ def test_load_profile_migrates_schema2_to_current(
     assert reloaded["schema_version"] == TomlConfigCodec.SCHEMA_VERSION
     # user settings survive the hop
     assert manager.settings.general.releasers_name == "SchemaTwoUser"
-    assert manager.settings.movie.release_group == "SchemaTwoGroup"
+    assert manager.settings.general.release_group == "SchemaTwoGroup"
     assert manager.settings.trackers.last_used_image_host == {}
     # the removed image host is dropped, taking its stale API key with it
     image_hosts = cast(MutableMapping[str, Any], reloaded["image_hosts"])

--- a/tests/test_config/test_migrations_v12_to_v13.py
+++ b/tests/test_config/test_migrations_v12_to_v13.py
@@ -1,0 +1,115 @@
+"""Schema 13 folds the two release group keys into one and switches parsing.
+
+The group tag printed on output is the user's publishing identity rather than
+a property of the media type, so the movie and series copies become a single
+``[general]`` entry. The source group -- what an input filename claims --
+becomes a switchable claim like the other six.
+"""
+
+from typing import Any
+
+from src.config.migrations import migrate_v12_to_v13
+
+
+def _doc(
+    movie: dict[str, Any] | None = None,
+    series: dict[str, Any] | None = None,
+    general: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    doc: dict[str, Any] = {"schema_version": 12}
+    if general is not None:
+        doc["general"] = general
+    if movie is not None:
+        doc["movie_management"] = movie
+    if series is not None:
+        doc["series_management"] = series
+    return doc
+
+
+def test_the_movie_group_tag_folds_into_general() -> None:
+    document, unmapped = migrate_v12_to_v13(
+        _doc(
+            general={"releasers_name": "tester"},
+            movie={
+                "mvr_release_group": "MYGROUP",
+                "mvr_token": "{title}",
+            },
+            series={"tvr_release_group": ""},
+        ),
+        None,
+    )
+
+    assert not unmapped
+    assert document["schema_version"] == 13
+    assert document["general"]["release_group"] == "MYGROUP"
+    assert document["general"]["releasers_name"] == "tester"
+    assert "mvr_release_group" not in document["movie_management"]
+    assert "tvr_release_group" not in document["series_management"]
+    assert document["movie_management"]["mvr_token"] == "{title}"  # noqa: S105 - NFO template token string used as test fixture data, not a credential
+
+
+def test_the_series_group_tag_is_used_when_the_movie_side_is_blank() -> None:
+    document, _ = migrate_v12_to_v13(
+        _doc(
+            movie={"mvr_release_group": ""},
+            series={"tvr_release_group": "TVGROUP"},
+        ),
+        None,
+    )
+
+    assert document["general"]["release_group"] == "TVGROUP"
+
+
+def test_the_movie_side_wins_when_both_are_set() -> None:
+    """Neither key ever had a UI, so both being set is a hand-edited profile.
+    One of them has to win and the choice only has to be stated, not clever."""
+    document, _ = migrate_v12_to_v13(
+        _doc(
+            movie={"mvr_release_group": "MOVIEGROUP"},
+            series={"tvr_release_group": "TVGROUP"},
+        ),
+        None,
+    )
+
+    assert document["general"]["release_group"] == "MOVIEGROUP"
+
+
+def test_both_sections_gain_the_release_group_claim_switch() -> None:
+    """Written explicitly rather than left to the loader's default, so an
+    upgraded profile looks like a fresh one. True keeps parsing working as it
+    did before the switch existed."""
+    document, _ = migrate_v12_to_v13(
+        _doc(movie={"mvr_release_group": ""}, series={"tvr_release_group": ""}),
+        None,
+    )
+
+    assert document["movie_management"]["mvr_parse_claim_release_group"] is True
+    assert document["series_management"]["tvr_parse_claim_release_group"] is True
+
+
+def test_a_profile_with_no_group_tag_set_gets_a_blank_one() -> None:
+    document, unmapped = migrate_v12_to_v13(
+        _doc(movie={"mvr_release_group": ""}, series={"tvr_release_group": ""}),
+        None,
+    )
+
+    assert not unmapped
+    assert document["general"]["release_group"] == ""
+
+
+def test_surrounding_whitespace_is_dropped() -> None:
+    document, _ = migrate_v12_to_v13(
+        _doc(movie={"mvr_release_group": "  MYGROUP  "}),
+        None,
+    )
+
+    assert document["general"]["release_group"] == "MYGROUP"
+
+
+def test_a_document_with_no_management_tables_survives() -> None:
+    """Should not happen at schema 12, but a partial document must not crash
+    the hop -- and must still land the key the loader now reads."""
+    document, unmapped = migrate_v12_to_v13({"schema_version": 12}, None)
+
+    assert not unmapped
+    assert document == {"schema_version": 13, "general": {"release_group": ""}}

--- a/tests/test_frontend/test_general_settings.py
+++ b/tests/test_frontend/test_general_settings.py
@@ -134,3 +134,23 @@ def test_media_search_mode_loads_saves_and_resets(
         MediaSearchMode(widget.media_search_mode_combo.currentData())
         is MediaSearchMode.BOTH
     )
+
+
+def test_release_group_loads_saves_and_resets(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The group tag had no UI at all before this: it round-tripped through
+    the config file but could only be set by hand-editing TOML."""
+    widget, manager = _make_general_settings(tmp_path, monkeypatch)
+
+    assert widget.release_group_entry.text() == ""
+
+    widget.release_group_entry.setText("  MYGROUP  ")
+    widget._save_settings()
+    assert manager.settings.general.release_group == "MYGROUP"
+    manager.save()
+    reloaded = ConfigManager("test", manager.paths)
+    assert reloaded.settings.general.release_group == "MYGROUP"
+
+    widget.apply_defaults()
+    assert widget.release_group_entry.text() == ""

--- a/tests/test_frontend/test_movies_management_settings.py
+++ b/tests/test_frontend/test_movies_management_settings.py
@@ -248,7 +248,7 @@ def test_illegal_chars_checkbox_is_gone(
     assert not hasattr(widget, "replace_illegal_chars")
 
 
-def test_the_six_claim_switches_are_offered(
+def test_every_claim_switch_is_offered(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     widget, _ = _make_movies_management_settings(tmp_path, monkeypatch)
@@ -260,6 +260,7 @@ def test_the_six_claim_switches_are_offered(
         "re_release",
         "remux",
         "hybrid",
+        "release_group",
     }
 
 
@@ -350,3 +351,37 @@ def test_preview_drops_every_category_when_the_master_is_off(
     assert "IMAX" not in example
     assert "Directors.Cut" not in example
     assert "HYBRID" not in example
+
+
+def test_the_preview_shows_the_configured_group_tag_not_the_examples(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The example filename ends in -SomeGroup, which stage 1 detects and
+    supplies as an override. Without the tag winning over it, a user with a
+    group configured saw someone else's in the one place that exists to show
+    them their own output.
+    """
+    widget, manager = _make_movies_management_settings(tmp_path, monkeypatch)
+    token = "{release_group}"  # noqa: S105 - NFO template token string used as test fixture data, not a credential
+
+    manager.settings.general.release_group = ""
+    assert (
+        widget._update_example(
+            token,
+            manager.settings.movie.filename_colon_replace,
+            True,
+            widget.format_file_name_token_example,
+        )
+        == "SomeGroup.mkv"
+    )
+
+    manager.settings.general.release_group = "MYGROUP"
+    assert (
+        widget._update_example(
+            token,
+            manager.settings.movie.filename_colon_replace,
+            True,
+            widget.format_file_name_token_example,
+        )
+        == "MYGROUP.mkv"
+    )

--- a/tests/test_frontend/test_rename_encode_movie.py
+++ b/tests/test_frontend/test_rename_encode_movie.py
@@ -195,7 +195,7 @@ def test_release_group_falls_back_to_the_detected_value(
         monkeypatch,
         file_path=Path("Movie.2024.1080p.WEB-DL.x264-OTHERGROUP.mkv"),
     )
-    page.config.settings.movie.release_group = ""
+    page.config.settings.general.release_group = ""
 
     page.initializePage()
 
@@ -210,8 +210,50 @@ def test_a_configured_release_group_wins_over_the_detected_one(
         monkeypatch,
         file_path=Path("Movie.2024.1080p.WEB-DL.x264-OTHERGROUP.mkv"),
     )
-    page.config.settings.movie.release_group = "MYGROUP"
+    page.config.settings.general.release_group = "MYGROUP"
 
     page.initializePage()
 
     assert page.release_group_entry.text() == "MYGROUP"
+
+
+def test_switching_release_group_parsing_off_leaves_the_field_empty(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The switch has to reach output, not just the control. The renderer
+    parses no filename of its own, so an undetected source group cannot
+    appear anywhere -- which is what makes the empty field honest."""
+    page = _make_movie_rename_page(
+        tmp_path,
+        monkeypatch,
+        file_path=Path("Movie.2024.1080p.WEB-DL.x264-OTHERGROUP.mkv"),
+    )
+    page.config.settings.general.release_group = ""
+    page.config.settings.movie.claims.release_group = False
+
+    page.initializePage()
+
+    assert page.release_group_entry.text() == ""
+    assert page.backend.override_tokens["release_group"] == ""
+
+
+def test_clearing_the_field_beats_the_configured_group_tag(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """This page is stage 2, so a blank here is a decision -- "this release
+    carries no group" -- rather than an absence to fall through from. The
+    override is written as "" instead of being popped, which is what stops
+    the configured tag taking over."""
+    page = _make_movie_rename_page(
+        tmp_path,
+        monkeypatch,
+        file_path=Path("Movie.2024.1080p.WEB-DL.x264-OTHERGROUP.mkv"),
+    )
+    page.config.settings.general.release_group = "MYGROUP"
+    page.initializePage()
+    assert page.backend.override_tokens["release_group"] == "MYGROUP"
+
+    page.release_group_entry.setText("")
+    page.update_generated_name()
+
+    assert page.backend.override_tokens["release_group"] == ""

--- a/tests/test_frontend/test_rename_encode_series.py
+++ b/tests/test_frontend/test_rename_encode_series.py
@@ -544,13 +544,14 @@ def test_a_switched_off_category_leaves_the_others_alone(
 def test_release_group_falls_back_to_the_detected_value(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    # The settings value means "my group"; the filename's means "whoever
-    # made the source". With settings blank the field showed empty while
-    # the output carried OTHERGROUP -- the field and the output disagreed.
+    # The settings value is the user's group tag; the filename's is the
+    # source group, meaning whoever made the input. With settings blank the
+    # field showed empty while the output carried OTHERGROUP -- the field and
+    # the output disagreed.
     page = _series_page_with_episodes(
         tmp_path, monkeypatch, Path("Show.S01E01.1080p.WEB-DL.x264-OTHERGROUP.mkv")
     )
-    page.config.settings.series.release_group = ""
+    page.config.settings.general.release_group = ""
 
     page.initializePage()
 
@@ -563,8 +564,44 @@ def test_a_configured_release_group_wins_over_the_detected_one(
     page = _series_page_with_episodes(
         tmp_path, monkeypatch, Path("Show.S01E01.1080p.WEB-DL.x264-OTHERGROUP.mkv")
     )
-    page.config.settings.series.release_group = "MYGROUP"
+    page.config.settings.general.release_group = "MYGROUP"
 
     page.initializePage()
 
     assert page.release_group_entry.text() == "MYGROUP"
+
+
+def test_switching_release_group_parsing_off_leaves_the_field_empty(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The switch has to reach output, not just the control. The renderer
+    parses no filename of its own, so an undetected source group cannot
+    appear anywhere -- which is what makes the empty field honest."""
+    page = _series_page_with_episodes(
+        tmp_path, monkeypatch, Path("Show.S01E01.1080p.WEB-DL.x264-OTHERGROUP.mkv")
+    )
+    page.config.settings.general.release_group = ""
+    page.config.settings.series.claims.release_group = False
+
+    page.initializePage()
+
+    assert page.release_group_entry.text() == ""
+    assert page.backend.override_tokens["release_group"] == ""
+
+
+def test_clearing_the_field_beats_the_configured_group_tag(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """This page is stage 2, so a blank here is a decision -- "this release
+    carries no group" -- rather than an absence to fall through from."""
+    page = _series_page_with_episodes(
+        tmp_path, monkeypatch, Path("Show.S01E01.1080p.WEB-DL.x264-OTHERGROUP.mkv")
+    )
+    page.config.settings.general.release_group = "MYGROUP"
+    page.initializePage()
+    assert page.backend.override_tokens["release_group"] == "MYGROUP"
+
+    page.release_group_entry.setText("")
+    page.update_generated_name()
+
+    assert page.backend.override_tokens["release_group"] == ""

--- a/tests/test_frontend/test_series_management_settings.py
+++ b/tests/test_frontend/test_series_management_settings.py
@@ -175,7 +175,7 @@ def test_illegal_chars_checkbox_is_gone(
     assert not hasattr(widget, "replace_illegal_chars")
 
 
-def test_the_six_claim_switches_are_offered(
+def test_every_claim_switch_is_offered(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     widget, _ = _make_series_management_settings(tmp_path, monkeypatch)
@@ -187,6 +187,7 @@ def test_the_six_claim_switches_are_offered(
         "re_release",
         "remux",
         "hybrid",
+        "release_group",
     }
 
 


### PR DESCRIPTION
## What

The release group could only be set on the rename screen. A value existed in the config file (`mvr_release_group`/`tvr_release_group`) but had no UI, and the renderer parsed a group out of the input filename independently of all of it.

Three things change:

- **One setting, in Settings -> General**, beside Releasers Name. The group is not a property of a film or a show, so the two per-media-type keys fold into one.
- **A "Release group" claim switch** joins the other six on both management pages. Off means the group in an input filename is never read.
- **`TokenReplacer` no longer parses a filename for a group.** It takes the configured tag and lets an override win, matching how every other switchable claim already resolves (`_edition`, `_frame_size`, `_hybrid`, `_localization`, `_re_release`, `_detect_remux` all had their independent detection removed when they became switchable).

Without it the switch would be a lie: turning parsing off would clear the field while the output still carried the detected group. It also fixes two live divergences; the NFO template preview rendered your edition from the rename page but the group from its own filename parse, and the settings previews showed the example's `SomeGroup` no matter what you configured.

## Behaviour changes

- Clearing the rename page's Release Group field now publishes with no group rather than falling back to the configured one. The page is the whole answer for that release.
- A profile with renaming disabled and no group configured emits no group. Previously the renderer read one off the filename.
- With renaming disabled, claim detection now runs at processing time, so editions/frame sizes/re-release markers reach the NFO and titles again. They had only ever been detected on the rename page.

## Migration

Schema 13. Folds `mvr_release_group` + `tvr_release_group` into `general.release_group` (first non-empty, movie first), drops both, and writes `*_parse_claim_release_group = true` in both sections so parsing keeps working as it did. `migrations._CLAIM_NAMES` stays frozen at six - it belongs to the v8→v9 hop.

## Checks

`ruff check`, `ruff format --check`, `basedpyright` and the full suite pass: 3313 passed, 2 skipped. New coverage for the migration, the switch reaching output, blank-beats-configured, the skip-path seeding, and the settings preview.
