### PR TITLE
feat: flag claims per episode as well as for the pack

### DIFF
--- a/src/backend/rename_encode_series.py
+++ b/src/backend/rename_encode_series.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from src.backend.rename_encode import RenameEncodeBackEnd
 from src.backend.token_replacer import TokenReplacer
 from src.backend.tokens import FileToken
+from src.backend.utils.filename_claims import PER_FILE_CLAIM_KEYS
 from src.config.models import DynamicRangeSettings
 from src.enums.multi_episode_style import MultiEpisodeStyle
 from src.enums.series import EpisodeFormat
@@ -46,12 +47,14 @@ class RenameEncodeSeriesBackEnd(RenameEncodeBackEnd):
             user_tokens: User-defined tokens
             episode_format: Episode format (Standard, Daily, Anime)
             multi_episode_style: How multi-episode spans render in {episode_number}
-            file_claims: Claims this episode's own filename carries, applied
-                beneath the pack-wide overrides. A pack where one episode is
-                a REPACK agrees on nothing, so no control can carry that
-                claim -- but the episode still deserves its marker. A value
-                the user set wins, because these fill gaps rather than
-                overrule choices.
+            file_claims: This episode's resolved claims, from
+                `resolve_file_claims`. The pack's own claims are stripped
+                before these are applied: the pack and its files are
+                separate surfaces, so a pack flagged REPACK says nothing
+                about any one episode, and an episode flagged REPACK says
+                nothing about the pack. Everything else the user overrode
+                (source, audio codec, the group tag) is not a per-file
+                claim and still reaches the filename.
             season_end: Highest season number in a multi-season pack, for {season_number}
                 range rendering. None (or equal to season_num) keeps single-season output.
 
@@ -70,7 +73,12 @@ class RenameEncodeSeriesBackEnd(RenameEncodeBackEnd):
             unfilled_token_mode=UnfilledTokenRemoval.TOKEN_ONLY,
             title_clean_rules=title_clean_rules,
             video_dynamic_range=video_dynamic_range,
-            override_tokens={**(file_claims or {}), **(self.override_tokens or {})},
+            override_tokens={
+                k: v
+                for k, v in (self.override_tokens or {}).items()
+                if k not in PER_FILE_CLAIM_KEYS
+            }
+            | (file_claims or {}),
             user_tokens=user_tokens,
             season_number=season_num,
             season_end=season_end,

--- a/src/backend/utils/filename_claims.py
+++ b/src/backend/utils/filename_claims.py
@@ -22,7 +22,7 @@ dissenting episode means the claim is not the pack's.
 
 from __future__ import annotations
 
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 import re
 
@@ -73,6 +73,42 @@ class FilenameClaims:
             )
             if value
         }
+
+
+PER_FILE_CLAIM_KEYS = frozenset(FilenameClaims.__dataclass_fields__) - {"release_group"}
+"""Claim keys an episode may answer for on its own.
+
+Every claim but the group, and the reason is that the key is shared. The
+`release_group` this module detects is a source group -- whoever made the
+input file. The override token of the same name is the user's group tag,
+the identity they publish under, and a release carries at most one of
+those. Resolving that key per episode would let one input file's source
+group reach the output as the release's tag, which is the conflation the
+two terms exist to keep apart.
+"""
+
+
+def resolve_file_claims(
+    detected: FilenameClaims,
+    edits: Mapping[str, str],
+) -> dict[str, str]:
+    """What one file renders, given its own name and the user's edits to it.
+
+    An edit wins; detection fills the gaps. Presence in `edits` is what
+    makes something an edit, so a value of "" is a decision ("this episode
+    is not a repack") and suppresses the claim, where an absent key falls
+    through to what the filename says. That is the same distinction
+    `as_override_tokens` draws, moved to where the user can act on it.
+
+    An undetected, unedited claim is omitted rather than sent as "", so it
+    stays a gap for whatever renders next rather than becoming an assertion
+    that the file has no such claim.
+    """
+    return {
+        key: edits[key] if key in edits else getattr(detected, key)
+        for key in PER_FILE_CLAIM_KEYS
+        if key in edits or getattr(detected, key)
+    }
 
 
 def _normalized_value(table: Sequence[RenameNormalization], stem: str) -> str:

--- a/src/frontend/custom_widgets/episode_claims_table.py
+++ b/src/frontend/custom_widgets/episode_claims_table.py
@@ -1,0 +1,592 @@
+"""The per-episode half of a pack's claims.
+
+A pack and its files are separate surfaces. The wizard's combo boxes speak
+for the pack -- the folder, the torrent, the release title -- and this table
+speaks for the episodes. Neither cascades into the other, so a pack
+assembled from individually repacked episodes can carry no REPACK of its own
+while the five episodes that are repacks keep their marker.
+
+Editing is delegate-based rather than widget-based on purpose. A complete
+series pack runs to several hundred episodes, and seven live controls per
+row would mean thousands of widgets each with its own layout and paint path.
+`QTableWidgetItem` is cheap; a delegate builds one editor, only while a cell
+is being edited, and sidesteps the scroll-wheel hijacking that combo boxes
+inside a scrolling view are prone to.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from pathlib import Path
+
+from PySide6.QtCore import (
+    QAbstractItemModel,
+    QEvent,
+    QModelIndex,
+    QObject,
+    QPersistentModelIndex,
+    QRect,
+    QSize,
+    Qt,
+    QTimer,
+    Signal,
+    Slot,
+)
+from PySide6.QtGui import QPainter
+from PySide6.QtWidgets import (
+    QAbstractItemView,
+    QApplication,
+    QCheckBox,
+    QComboBox,
+    QFrame,
+    QHeaderView,
+    QLineEdit,
+    QStyle,
+    QStyledItemDelegate,
+    QStyleOptionButton,
+    QStyleOptionComboBox,
+    QStyleOptionViewItem,
+    QTableWidget,
+    QTableWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
+
+from src.backend.utils.filename_claims import FilenameClaims, resolve_file_claims
+from src.backend.utils.rename_normalizations import (
+    EDITION_INFO,
+    FRAME_SIZE_INFO,
+    LOCALIZATION_INFO,
+    RE_RELEASE_INFO,
+)
+from src.backend.utils.streaming_services import STREAMING_SERVICE_CHOICES
+from src.frontend.custom_widgets.custom_token_editor import ComboBoxDelegate
+from src.packages.custom_types import RenameNormalization
+
+# Claim key, column heading. Order is the column order after the episode name.
+VALUE_CLAIMS: tuple[tuple[str, str], ...] = (
+    ("edition", "Edition"),
+    ("frame_size", "Frame Size"),
+    ("localization", "Localization"),
+    ("re_release", "Rerelease"),
+    ("streaming_service", "Service"),
+)
+
+# Rendered as a check state rather than a value, since each has exactly one
+# spelling. The value written into the claim dict is that spelling or "".
+BOOLEAN_CLAIMS: tuple[tuple[str, str], ...] = (
+    ("remux", "REMUX"),
+    ("hybrid", "HYBRID"),
+)
+
+CLAIM_COLUMNS: tuple[str, ...] = tuple(
+    key for key, _ in (*VALUE_CLAIMS, *BOOLEAN_CLAIMS)
+)
+
+# Breathing room beyond the widest dropdown column's content.
+_COLUMN_PADDING = 12
+
+# Floor for the episode name column. It is the only stretching column, so
+# without a floor it absorbs every pixel the claim columns need and collapses
+# to an unreadable sliver before anything else gives.
+_EPISODE_MIN_WIDTH = 260
+
+
+class AlwaysVisibleComboDelegate(ComboBoxDelegate):
+    """A value column that looks like the dropdown it is.
+
+    The base delegate only builds a combo box while a cell is being edited,
+    so an untouched column reads as flat text with no hint that it can be
+    changed. Painting the control instead of instantiating it keeps that
+    affordance on every row without putting a live widget on every row --
+    which at several hundred episodes is the whole reason for a delegate.
+    """
+
+    def createEditor(
+        self,
+        parent: QWidget,
+        option: QStyleOptionViewItem,
+        index: QModelIndex | QPersistentModelIndex,
+    ) -> QComboBox:
+        """Open the editor with its list already down.
+
+        Without this the first click only swaps the painted combo for a real
+        one, which looks identical and does nothing, so the list needs a
+        second click. Deferred by a tick because the popup has to position
+        itself against an editor the view has actually placed.
+        """
+        combo = super().createEditor(parent, option, index)
+        combo.activated.connect(lambda _: self._commit(combo))
+        QTimer.singleShot(0, combo.showPopup)
+        return combo
+
+    def _commit(self, editor: QComboBox) -> None:
+        self.commitData.emit(editor)
+        self.closeEditor.emit(editor)
+
+    def paint(
+        self,
+        painter: QPainter,
+        option: QStyleOptionViewItem,
+        index: QModelIndex | QPersistentModelIndex,
+    ) -> None:
+        combo = QStyleOptionComboBox()
+        combo.rect = option.rect
+        combo.palette = option.palette
+        combo.currentText = str(index.data(Qt.ItemDataRole.DisplayRole) or "")
+        # A suppressed column has `ItemIsEnabled` stripped, so the view has
+        # already left `State_Enabled` out of the option. Recomputing it
+        # from the flags would only restate that.
+        combo.state = option.state
+        style = QApplication.style()
+        style.drawComplexControl(
+            QStyle.ComplexControl.CC_ComboBox, combo, painter, option.widget
+        )
+        style.drawControl(
+            QStyle.ControlElement.CE_ComboBoxLabel, combo, painter, option.widget
+        )
+
+
+class CenteredCheckDelegate(QStyledItemDelegate):
+    """A check indicator drawn like a real checkbox, centred in its column.
+
+    An item's own check state is drawn at the left edge, in the item view's
+    palette, which against this app's dark Fusion palette is close to
+    invisible. This borrows a real `QCheckBox` for its palette and draws the
+    primitive that checkbox would draw, so the table's boxes are the ones
+    from the pack controls below rather than a lookalike.
+    """
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        # Never shown, never laid out. It exists to be asked what a checkbox
+        # on this platform, in this style, is coloured -- which is not
+        # something the item view's palette can answer.
+        self._reference = QCheckBox()
+
+    def paint(
+        self,
+        painter: QPainter,
+        option: QStyleOptionViewItem,
+        index: QModelIndex | QPersistentModelIndex,
+    ) -> None:
+        # The background goes through the same call the default delegate
+        # makes, so these cells shade and highlight exactly like the Episode
+        # column. Drawing `PE_PanelItemViewItem` off the raw option instead
+        # skips `initStyleOption`, which is what fills in the background
+        # brush and the alternating-row state, and the column came out a
+        # different colour from every other one.
+        background = QStyleOptionViewItem(option)
+        self.initStyleOption(background, index)
+        background.text = ""
+        # Its own indicator would be drawn at the left edge, in the item
+        # palette -- the thing this delegate exists to replace.
+        background.features &= ~QStyleOptionViewItem.ViewItemFeature.HasCheckIndicator
+        widget = background.widget
+        style = widget.style() if widget else QApplication.style()
+        style.drawControl(
+            QStyle.ControlElement.CE_ItemViewItem, background, painter, widget
+        )
+
+        button = QStyleOptionButton()
+        button.palette = self._reference.palette()
+        size = style.pixelMetric(
+            QStyle.PixelMetric.PM_IndicatorWidth, option, self._reference
+        )
+        button.rect = QRect(0, 0, size, size)
+        button.rect.moveCenter(option.rect.center())
+        button.state = (
+            QStyle.StateFlag.State_On
+            if _is_checked(index)
+            else QStyle.StateFlag.State_Off
+        )
+        button.state |= QStyle.StateFlag.State_Active
+        if index.flags() & Qt.ItemFlag.ItemIsUserCheckable:
+            button.state |= QStyle.StateFlag.State_Enabled
+        style.drawPrimitive(
+            QStyle.PrimitiveElement.PE_IndicatorCheckBox,
+            button,
+            painter,
+            self._reference,
+        )
+
+    def editorEvent(
+        self,
+        event: QEvent,
+        model: QAbstractItemModel,
+        option: QStyleOptionViewItem,
+        index: QModelIndex | QPersistentModelIndex,
+    ) -> bool:
+        """Toggle on a click anywhere in the cell.
+
+        The base implementation hit-tests the indicator where the style
+        would have put it, which is not where this one is drawn. Accepting
+        the whole cell is both correct here and a larger target.
+        """
+        if event.type() != QEvent.Type.MouseButtonRelease:
+            return False
+        if not index.flags() & Qt.ItemFlag.ItemIsUserCheckable:
+            return False
+        model.setData(
+            index,
+            Qt.CheckState.Unchecked if _is_checked(index) else Qt.CheckState.Checked,
+            Qt.ItemDataRole.CheckStateRole,
+        )
+        return True
+
+
+def _is_checked(index: QModelIndex | QPersistentModelIndex) -> bool:
+    """Whether the item at `index` is checked.
+
+    `index.data(CheckStateRole)` hands back a plain int, and PySide6's
+    enums do not compare equal to ints -- `2 == Qt.CheckState.Checked` is
+    False. Comparing the two directly therefore reads as "never checked"
+    without erroring, which paints every box empty and makes every toggle
+    a no-op. Convert first.
+    """
+    return (
+        Qt.CheckState(index.data(Qt.ItemDataRole.CheckStateRole) or 0)
+        == Qt.CheckState.Checked
+    )
+
+
+def _choices(items: Sequence[RenameNormalization]) -> list[str]:
+    """Combo entries for a normalisation table, blank first.
+
+    Blank is not padding: it is how the user says "this episode carries no
+    edition", which is a different statement from leaving detection alone.
+    """
+    return ["", *(item.normalized for item in items)]
+
+
+class EpisodeClaimsTable(QWidget):
+    """One row per episode, one column per claim the episode may carry."""
+
+    claims_changed = Signal()
+
+    def __init__(
+        self,
+        custom_edition_info: Sequence[RenameNormalization] = (),
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self.setObjectName("episodeClaimsTable")
+
+        self._paths: list[Path] = []
+        self._detected: dict[Path, FilenameClaims] = {}
+        self._edits: dict[Path, dict[str, str]] = {}
+        self._disabled: set[str] = set()
+        # Guards the difference between the table being filled in and the
+        # user filling it in. Only the latter is an edit.
+        self._loading = False
+        # Re-entrancy guard for the column fit below.
+        self._fitting = False
+
+        self.search_bar = QLineEdit(self)
+        self.search_bar.setPlaceholderText("Search episodes...")
+        self.search_bar.textChanged.connect(self.filter_rows)
+
+        self.table = QTableWidget(self)
+        self.table.setColumnCount(1 + len(CLAIM_COLUMNS))
+        self.table.setHorizontalHeaderLabels(
+            ["Episode", *(label for _, label in (*VALUE_CLAIMS, *BOOLEAN_CLAIMS))]
+        )
+        self.table.setMinimumHeight(220)
+        self.table.setFrameShape(QFrame.Shape.Box)
+        self.table.setFrameShadow(QFrame.Shadow.Sunken)
+        self.table.verticalHeader().setVisible(False)
+        # Single click opens the dropdown. `AllEditTriggers` fires on the
+        # cell becoming current, which needs cells to be selectable at all:
+        # under `NoSelection` nothing becomes current and the only way in
+        # was a double click.
+        self.table.setSelectionMode(QAbstractItemView.SelectionMode.SingleSelection)
+        self.table.setSelectionBehavior(QAbstractItemView.SelectionBehavior.SelectItems)
+        self.table.setHorizontalScrollMode(QAbstractItemView.ScrollMode.ScrollPerPixel)
+        self.table.setEditTriggers(QAbstractItemView.EditTrigger.AllEditTriggers)
+
+        value_choices = {
+            "edition": _choices((*EDITION_INFO, *custom_edition_info)),
+            "frame_size": _choices(FRAME_SIZE_INFO),
+            "localization": _choices(LOCALIZATION_INFO),
+            "re_release": _choices(RE_RELEASE_INFO),
+            "streaming_service": ["", *STREAMING_SERVICE_CHOICES],
+        }
+        for column, (key, _) in enumerate(VALUE_CLAIMS, start=1):
+            self.table.setItemDelegateForColumn(
+                column, AlwaysVisibleComboDelegate(value_choices[key], self)
+            )
+        for offset in range(len(BOOLEAN_CLAIMS)):
+            self.table.setItemDelegateForColumn(
+                1 + len(VALUE_CLAIMS) + offset, CenteredCheckDelegate(self)
+            )
+
+        self._fix_column_widths(value_choices)
+
+        self.table.itemChanged.connect(self._on_item_changed)
+        self.table.viewport().installEventFilter(self)
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(self.search_bar)
+        layout.addWidget(self.table)
+
+    def _fix_column_widths(self, value_choices: dict[str, list[str]]) -> None:
+        """Size every column once, from what it *could* hold.
+
+        Measuring current contents instead makes the columns move: pick a
+        long edition, clear it again, and the row reflows. The set of
+        options is fixed at construction, so the widest one is knowable up
+        front and the layout can then be left alone forever.
+
+        One width across all five dropdowns, so they read as one row of
+        choices rather than five unrelated controls.
+        """
+        cell_metrics = self.table.fontMetrics()
+        header = self.table.horizontalHeader()
+        header_metrics = header.fontMetrics()
+
+        widest = max(
+            *(
+                cell_metrics.horizontalAdvance(choice)
+                for choices in value_choices.values()
+                for choice in choices
+            ),
+            *(header_metrics.horizontalAdvance(label) for _, label in VALUE_CLAIMS),
+        )
+        # Through the style rather than by hand: a combo box is its text
+        # plus a drop-down arrow, and only the style knows how wide that is.
+        value_width = (
+            QApplication.style()
+            .sizeFromContents(
+                QStyle.ContentsType.CT_ComboBox,
+                QStyleOptionComboBox(),
+                QSize(widest, cell_metrics.height()),
+            )
+            .width()
+            + _COLUMN_PADDING
+        )
+
+        # Interactive rather than Stretch. Stretch has no floor, so the
+        # episode name is squeezed to a sliver before any claim column
+        # gives; `_fit_episode_column` stretches it by hand instead, down
+        # to a limit, and lets the table's own scroll bar take the rest.
+        header.setSectionResizeMode(0, QHeaderView.ResizeMode.Interactive)
+        for column in range(1, 1 + len(VALUE_CLAIMS)):
+            self.table.setColumnWidth(column, value_width)
+        for offset, (_, label) in enumerate(BOOLEAN_CLAIMS):
+            self.table.setColumnWidth(
+                1 + len(VALUE_CLAIMS) + offset,
+                header_metrics.horizontalAdvance(label) + _COLUMN_PADDING * 2,
+            )
+        self._fit_episode_column()
+
+    def _fit_episode_column(self) -> None:
+        """Give the episode name whatever the claim columns are not using.
+
+        Down to `_EPISODE_MIN_WIDTH`, past which the table overflows and
+        scrolls. The scroll bar belongs to the table, under it, rather than
+        to the page: a minimum width on the widget would push the overflow
+        out to the wizard's own scroll bar at the bottom of the window,
+        which is a long way from the thing that is actually too narrow.
+        """
+        if self._fitting:
+            return
+        claims = sum(
+            self.table.columnWidth(column)
+            for column in range(1, self.table.columnCount())
+        )
+        wanted = max(_EPISODE_MIN_WIDTH, self.table.viewport().width() - claims)
+        if wanted == self.table.columnWidth(0):
+            return
+        # Widening the column can bring the scroll bar in, which resizes the
+        # viewport, which lands back here. Settle it in one pass rather than
+        # letting the two chase each other a pixel at a time.
+        self._fitting = True
+        try:
+            self.table.setColumnWidth(0, wanted)
+        finally:
+            self._fitting = False
+
+    def eventFilter(self, watched: QObject, event: QEvent) -> bool:
+        """Refit whenever the viewport itself changes size.
+
+        Not the widget's own `resizeEvent`: that arrives before the table
+        child has been laid out, so the viewport width read there is the
+        previous one. Fitting from a stale width sets a column that is
+        wrong by exactly the delta, which the next event corrects -- and
+        during a window drag that is a scroll bar blinking on and off. It
+        is also why the column started at its minimum, since at
+        construction there is no layout yet to read.
+        """
+        if watched is self.table.viewport() and event.type() == QEvent.Type.Resize:
+            self._fit_episode_column()
+        return super().eventFilter(watched, event)
+
+    # -- population ----------------------------------------------------
+    def load(self, rows: Sequence[tuple[Path, FilenameClaims]]) -> None:
+        """Fill the table, discarding any edits made against the old rows.
+
+        `rows` arrive in display order; the caller sorts, because it is the
+        caller that knows each file's season and episode.
+        """
+        self._paths = [path for path, _ in rows]
+        self._detected = dict(rows)
+        # Suppression belongs to the release's source quality, not to the
+        # rows, so it outlives them: new rows arriving under a web source
+        # must not come up carrying a REMUX their filenames happen to claim.
+        self._edits = {path: dict.fromkeys(self._disabled, "") for path in self._paths}
+        self._repopulate()
+
+    def _repopulate(self) -> None:
+        self._loading = True
+        try:
+            self.table.setRowCount(0)
+            self.table.clearContents()
+            self.table.setRowCount(len(self._paths))
+            for row, path in enumerate(self._paths):
+                name_item = QTableWidgetItem(path.stem)
+                name_item.setToolTip(path.name)
+                name_item.setFlags(
+                    name_item.flags()
+                    & ~Qt.ItemFlag.ItemIsEditable
+                    & ~Qt.ItemFlag.ItemIsSelectable
+                )
+                self.table.setItem(row, 0, name_item)
+                self._write_row(row, path)
+        finally:
+            self._loading = False
+
+    def _write_row(self, row: int, path: Path) -> None:
+        resolved = self.resolved_claims_for(path)
+        for column, (key, _) in enumerate(VALUE_CLAIMS, start=1):
+            item = QTableWidgetItem(resolved.get(key, ""))
+            if key in self._disabled:
+                # Both flags, not just the editable one: the delegate paints
+                # the enabled state, so leaving it enabled would draw a live
+                # looking dropdown that refuses to open.
+                item.setFlags(
+                    item.flags()
+                    & ~Qt.ItemFlag.ItemIsEditable
+                    & ~Qt.ItemFlag.ItemIsEnabled
+                )
+            self.table.setItem(row, column, item)
+
+        boolean_start = 1 + len(VALUE_CLAIMS)
+        for offset, (key, spelling) in enumerate(BOOLEAN_CLAIMS):
+            item = QTableWidgetItem("")
+            # Not selectable, for the same reason the episode name is not:
+            # a selected cell fills with `palette.highlight()`, and on this
+            # platform that is the identical colour the checkbox itself is
+            # drawn in, so selecting a cell erased the box inside it.
+            # Clicking still toggles -- `editorEvent` is routed to enabled
+            # items whether or not they can be selected.
+            flags = (
+                item.flags()
+                & ~Qt.ItemFlag.ItemIsEditable
+                & ~Qt.ItemFlag.ItemIsSelectable
+            )
+            if key not in self._disabled:
+                flags |= Qt.ItemFlag.ItemIsUserCheckable
+            item.setFlags(flags)
+            item.setCheckState(
+                Qt.CheckState.Checked
+                if resolved.get(key) == spelling
+                else Qt.CheckState.Unchecked
+            )
+            self.table.setItem(row, boolean_start + offset, item)
+
+    # -- reading -------------------------------------------------------
+    def resolved_claims_for(self, path: Path) -> dict[str, str]:
+        """This episode's claims: its filename's, with the user's on top.
+
+        Detection ran once, at load. Re-running it per read would mean a
+        guessit parse per episode on every keystroke in the pack controls.
+        """
+        detected = self._detected.get(path)
+        if detected is None:
+            return {}
+        return resolve_file_claims(detected, self._edits.get(path, {}))
+
+    # -- editing -------------------------------------------------------
+    @Slot(QTableWidgetItem)
+    def _on_item_changed(self, item: QTableWidgetItem) -> None:
+        if self._loading:
+            return
+        column = item.column()
+        if column == 0 or column > len(CLAIM_COLUMNS):
+            return
+        path = self._paths[item.row()]
+        key = CLAIM_COLUMNS[column - 1]
+
+        if column <= len(VALUE_CLAIMS):
+            self._edits[path][key] = item.text().strip()
+        else:
+            spelling = BOOLEAN_CLAIMS[column - 1 - len(VALUE_CLAIMS)][1]
+            checked = item.checkState() == Qt.CheckState.Checked
+            self._edits[path][key] = spelling if checked else ""
+
+        self.claims_changed.emit()
+
+    def apply_to_all(self, key: str, value: str) -> None:
+        """Stamp one claim onto every episode.
+
+        Recorded as an edit on every row, including an empty one: applying a
+        blank is the user saying no episode carries this, which has to beat
+        what the filenames say.
+        """
+        for path in self._paths:
+            self._edits[path][key] = value
+        self._repopulate()
+        self.claims_changed.emit()
+
+    def revert_to_detected(self, key: str) -> None:
+        """Drop the user's edits for one claim, in every row.
+
+        Reverts to what each filename says, which is not necessarily what
+        the row held before the last bulk apply -- a manual edit made
+        earlier is dropped too. Holding a snapshot to restore instead would
+        mean deciding when it goes stale.
+        """
+        for edits in self._edits.values():
+            edits.pop(key, None)
+        self._repopulate()
+        self.claims_changed.emit()
+
+    def set_claim_enabled(self, key: str, enabled: bool) -> None:
+        """Enable or suppress one claim across every episode.
+
+        Disabling clears the column rather than parking its values out of
+        reach, so nothing the release cannot have -- REMUX on a web pack --
+        survives in hidden state. Re-enabling therefore has nothing stored
+        to put back and returns the column to what the filenames say, which
+        is what the pack's own checkbox does on the same signal. Edits made
+        before the suppression are not restored; holding a snapshot to
+        restore instead would mean deciding when it goes stale.
+        """
+        if enabled == (key not in self._disabled):
+            return
+        if enabled:
+            # Re-enabling *is* reverting: suppression stored nothing, so
+            # what comes back is whatever the filenames say.
+            self._disabled.discard(key)
+            self.revert_to_detected(key)
+            return
+        self._disabled.add(key)
+        for edits in self._edits.values():
+            edits[key] = ""
+        self._repopulate()
+        self.claims_changed.emit()
+
+    # -- view ----------------------------------------------------------
+    @Slot(str)
+    def filter_rows(self, text: str) -> None:
+        """Show only episodes whose name contains `text`.
+
+        Hiding rather than rebuilding: a hidden row keeps its edits, so
+        searching to reach one episode cannot cost the user the others.
+        """
+        needle = text.strip().lower()
+        for row in range(self.table.rowCount()):
+            item = self.table.item(row, 0)
+            name = item.text().lower() if item else ""
+            self.table.setRowHidden(row, bool(needle) and needle not in name)

--- a/src/frontend/wizards/rename_encode.py
+++ b/src/frontend/wizards/rename_encode.py
@@ -519,8 +519,21 @@ class RenameEncode(BaseWizardPage):
         return claims
 
     def _detected_claims(self) -> FilenameClaims:
+        """The film's claims -- the film's alone.
+
+        `file_list` is not one file. The input page has no media type to
+        branch on (it is not set until the next page), so a folder input
+        keeps every video that is not a sample, and a film shipped with an
+        `Extras` folder arrives as several paths. Reading the whole list
+        here applied the pack-agreement rule to bloopers, which then
+        outvoted the film: switching Quality to a disc source cleared the
+        REMUX tick the film had earned.
+
+        Index 0 is the film, the same assumption `initializePage` states
+        and pre-fills from, so the two now answer alike.
+        """
         return detect_filename_claims(
-            [path.stem for path in self.context.media_input.file_list],
+            [self.context.media_input.file_list[0].stem],
             self.config.settings.movie.claims,
             self.context.custom_edition_info,
         )

--- a/src/frontend/wizards/rename_encode_series.py
+++ b/src/frontend/wizards/rename_encode_series.py
@@ -17,6 +17,7 @@ from PySide6.QtWidgets import (
     QHeaderView,
     QLabel,
     QLineEdit,
+    QMenu,
     QMessageBox,
     QScrollArea,
     QSizePolicy,
@@ -31,6 +32,7 @@ from src.backend.rename_encode_series import RenameEncodeSeriesBackEnd
 from src.backend.rename_files import RenamePlan, RenameResult
 from src.backend.tokens import FileToken, Tokens, TokenSelection, TokenType
 from src.backend.utils.filename_claims import (
+    PER_FILE_CLAIM_KEYS,
     FilenameClaims,
     detect_file_claims,
     detect_filename_claims,
@@ -54,6 +56,7 @@ from src.config.tv_tokens import (
 from src.context.processing_context import ProcessingContext
 from src.enums.rename import QualitySelection
 from src.frontend.custom_widgets.combo_box import CustomComboBox
+from src.frontend.custom_widgets.episode_claims_table import EpisodeClaimsTable
 from src.frontend.custom_widgets.rename_preview_dialog import RenamePreviewDialog
 from src.frontend.custom_widgets.token_table import TokenTable
 from src.frontend.global_signals import GSigs
@@ -121,15 +124,20 @@ class RenameEncodeSeries(BaseWizardPage):
 
         main_layout = QVBoxLayout(main_widget)
 
-        # Episode list section (shows count only)
-        episode_list_group = QGroupBox("Episodes to Rename")
+        # The episode half of the release. Built before the pack controls
+        # below, because each of those carries a menu that acts on it.
+        episode_list_group = QGroupBox("Episodes (filenames)")
         episode_list_layout = QVBoxLayout(episode_list_group)
 
-        self.episode_count_label = QLabel("No episodes loaded")
-        episode_list_layout.addWidget(self.episode_count_label)
+        self.episode_claims = EpisodeClaimsTable(
+            context.custom_edition_info, parent=self
+        )
+        self.episode_claims.claims_changed.connect(self.update_generated_name)
+        episode_list_layout.addWidget(self.episode_claims)
 
-        # Options section (similar to movies but adapted for series)
-        options_group_box = QGroupBox("Rename Options")
+        # The pack half. These drive the folder, the torrent and the release
+        # title, and nothing here reaches an episode filename.
+        options_group_box = QGroupBox("Pack (folder, torrent, release title)")
         options_group_box.setSizePolicy(
             QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Maximum
         )
@@ -251,7 +259,10 @@ class RenameEncodeSeries(BaseWizardPage):
         checkboxes_layout = QHBoxLayout()
         checkboxes_layout.setContentsMargins(0, 0, 0, 0)
         checkboxes_layout.addWidget(self.remux_checkbox)
+        checkboxes_layout.addWidget(self._bulk_button("remux"))
         checkboxes_layout.addWidget(self.hybrid_checkbox)
+        checkboxes_layout.addWidget(self._bulk_button("hybrid"))
+        checkboxes_layout.addStretch(1)
 
         # Release group
         release_group_lbl = QLabel("Release Group", self)
@@ -298,13 +309,19 @@ class RenameEncodeSeries(BaseWizardPage):
 
         # Layout options widgets
         options_layout.addWidget(edition_lbl, 0, 0)
-        options_layout.addWidget(self.edition_combo, 1, 0)
+        options_layout.addLayout(self._claim_row(self.edition_combo, "edition"), 1, 0)
         options_layout.addWidget(frame_size_lbl, 0, 1)
-        options_layout.addWidget(self.frame_size_combo, 1, 1)
+        options_layout.addLayout(
+            self._claim_row(self.frame_size_combo, "frame_size"), 1, 1
+        )
         options_layout.addWidget(localization_lbl, 0, 2)
-        options_layout.addWidget(self.localization_combo, 1, 2)
+        options_layout.addLayout(
+            self._claim_row(self.localization_combo, "localization"), 1, 2
+        )
         options_layout.addWidget(re_release_lbl, 2, 0)
-        options_layout.addWidget(self.re_release_combo, 3, 0)
+        options_layout.addLayout(
+            self._claim_row(self.re_release_combo, "re_release"), 3, 0
+        )
         options_layout.addWidget(self.repack_reason_lbl, 2, 1)
         options_layout.addWidget(self.repack_reason_combo, 3, 1, 1, 2)
         options_layout.addWidget(self.proper_reason_lbl, 2, 1)
@@ -312,7 +329,9 @@ class RenameEncodeSeries(BaseWizardPage):
         options_layout.addWidget(quality_combo_lbl, 4, 0)
         options_layout.addWidget(self.quality_combo, 5, 0)
         options_layout.addWidget(service_combo_lbl, 4, 1)
-        options_layout.addWidget(self.service_combo, 5, 1)
+        options_layout.addLayout(
+            self._claim_row(self.service_combo, "streaming_service"), 5, 1
+        )
         options_layout.addLayout(checkboxes_layout, 6, 0, 1, 1)
         options_layout.addWidget(build_h_line((6, 4, 6, 4)), 18, 0, 1, 3)
         options_layout.addWidget(release_group_lbl, 19, 0)
@@ -324,8 +343,22 @@ class RenameEncodeSeries(BaseWizardPage):
         self.options_scroll_area.setFrameShape(QFrame.Shape.NoFrame)
         self.options_scroll_area.setWidget(options_widget)
 
+        # The pack's controls produce one string and nothing on this page
+        # showed it. Cheap to render, unlike the episode names: one call
+        # against the folder token rather than one per episode.
+        pack_name_lbl = QLabel("Pack Name", self)
+        pack_name_lbl.setToolTip(
+            "The renamed folder, which the .torrent is also named after"
+        )
+        self.pack_name_preview = QLineEdit(self)
+        self.pack_name_preview.setReadOnly(True)
+        self.pack_name_preview.setPlaceholderText("No pack name generated")
+        self.pack_name_preview.setToolTip(pack_name_lbl.toolTip())
+
         group_box_layout = QVBoxLayout(options_group_box)
         group_box_layout.setContentsMargins(0, 0, 0, 0)
+        group_box_layout.addWidget(pack_name_lbl)
+        group_box_layout.addWidget(self.pack_name_preview)
         group_box_layout.addWidget(self.options_scroll_area)
 
         # Add all sections to main layout
@@ -337,6 +370,53 @@ class RenameEncodeSeries(BaseWizardPage):
         page_layout = QVBoxLayout(self)
         page_layout.addWidget(main_scroll)
 
+    # -- pack controls acting on the episode table ---------------------
+    def _claim_row(self, control: QWidget, key: str) -> QHBoxLayout:
+        """A pack control paired with the menu that reaches the episodes.
+
+        The menu sits here rather than on the table's column header because
+        both its actions need a pack value to work from: "apply to all"
+        copies this control, and the control is what the user has just set
+        when they reach for it.
+        """
+        layout = QHBoxLayout()
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(control)
+        layout.addWidget(self._bulk_button(key))
+        return layout
+
+    def _bulk_button(self, key: str) -> QToolButton:
+        """The menu that lets a pack control reach every episode.
+
+        The two surfaces are otherwise independent, which makes the common
+        case -- the whole release is a REPACK -- one edit per episode. This
+        is the shortcut, and the way back from it.
+        """
+        button = QToolButton(self)
+        button.setText("...")
+        button.setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
+        button.setToolTip("Apply this to every episode, or undo doing so")
+        menu = QMenu(button)
+        menu.addAction("Apply to all episodes", partial(self._apply_claim_to_all, key))
+        menu.addAction(
+            "Revert episodes to detected",
+            partial(self.episode_claims.revert_to_detected, key),
+        )
+        button.setMenu(menu)
+        return button
+
+    def _apply_claim_to_all(self, key: str) -> None:
+        """Copy the pack's answer for `key` onto every episode.
+
+        Read from `override_tokens` rather than from the widgets. Every
+        claim control already writes its value there through
+        `_update_override_tokens`, so asking the widgets again would be a
+        second answer to the same question, free to drift from the first.
+        An absent key means the control is empty, which applies as a
+        deliberate blank.
+        """
+        self.episode_claims.apply_to_all(key, self.backend.override_tokens.get(key, ""))
+
     def initializePage(self) -> None:
         """Initialize the page with series data and load episode batch."""
         media_files = self.context.media_input.file_list
@@ -345,17 +425,13 @@ class RenameEncodeSeries(BaseWizardPage):
         if not media_files:
             raise FileNotFoundError("No files found in media input payload")
 
-        # Display episode count only
-        episode_count = len(media_files)
-        self.episode_count_label.setText(
-            f"Found {episode_count} episode{'s' if episode_count != 1 else ''} to rename"
-        )
-
-        # Only infer a pack-wide override when every episode agrees. File-specific
-        # attributes are otherwise resolved from each active file during rendering.
+        # The pack controls still read the pack: a claim every episode agrees
+        # on is the release's claim. What they no longer do is speak for the
+        # episodes, which now seed themselves from their own filenames.
         claims = self._pre_load_attribute_combos(
             [Path(path).stem for path in media_files]
         )
+        self._load_episode_claims()
 
         apply_plugin_override(
             self.context.shared_data.dynamic_data,
@@ -445,10 +521,6 @@ class RenameEncodeSeries(BaseWizardPage):
 
         rename_map: dict[Path, Path] = {}
         failed_files: list[Path] = []
-        # Detected once for the pack rather than per episode: the per-file
-        # lookup below only needs to know which categories the pack agrees
-        # on, and guessit is not cheap.
-        pack_overrides = self._detected_claims().as_override_tokens()
         for (
             media_file,
             media_data,
@@ -456,7 +528,7 @@ class RenameEncodeSeries(BaseWizardPage):
             renamed_file = self.backend.series_renamer(
                 media_input_obj=self.context.media_input,
                 media_file=media_file,
-                file_claims=self._file_claim_overrides(media_file, pack_overrides),
+                file_claims=self._file_claim_overrides(media_file),
                 token=token,
                 colon_replacement=self.config.settings.series.filename_colon_replace,
                 media_search_payload=self.context.media_search,
@@ -700,23 +772,51 @@ class RenameEncodeSeries(BaseWizardPage):
         self.hybrid_checkbox.setChecked(bool(claims.hybrid))
         return claims
 
-    def _file_claim_overrides(
-        self, media_file: Path, pack_overrides: dict[str, str]
-    ) -> dict[str, str]:
-        """This episode's own claims, for categories the pack does not share.
+    def _load_episode_claims(self) -> None:
+        """Seed the episode table from each file's own name.
 
-        Where every file agrees, the control carries the claim and the user
-        can clear it; re-supplying it per file would quietly undo that.
-        Where the files disagree there is no control value to clear -- one
-        combo cannot say "REPACK, but only episode 2" -- so the episode's
-        own filename is the best answer available.
+        Ordered by season then episode rather than by however the files came
+        off disk: at several hundred rows across several seasons, filesystem
+        order is not how anyone reads a pack. The mapping is the source
+        because it is what `validatePage` iterates, so no row can exist
+        without somewhere to rename to.
         """
-        own = detect_file_claims(
-            media_file.stem,
-            self.config.settings.series.claims,
-            self.context.custom_edition_info,
-        ).as_override_tokens()
-        return {k: v for k, v in own.items() if k not in pack_overrides}
+        episode_map = self.context.media_input.series_episode_map or {}
+        ordered = sorted(
+            episode_map.items(),
+            key=lambda item: (
+                item[1].get("season") or 0,
+                item[1].get("episode") or 0,
+                item[0].name,
+            ),
+        )
+        self.episode_claims.load(
+            [
+                (
+                    media_file,
+                    detect_file_claims(
+                        media_file.stem,
+                        self.config.settings.series.claims,
+                        self.context.custom_edition_info,
+                    ),
+                )
+                for media_file, _ in ordered
+            ]
+        )
+
+    def _file_claim_overrides(self, media_file: Path) -> dict[str, str]:
+        """This episode's claims, as the table currently holds them.
+
+        The pack's claims are not consulted. A pack flagged REPACK says
+        nothing about any one episode, and this is the episode's answer:
+        what its filename claims, with whatever the user typed over the top.
+
+        The table is the only source. It and every caller here are built
+        from `series_episode_map`, so a file without a row cannot arise; a
+        detect-on-the-spot fallback for that case would run guessit again
+        for every claim-free episode, which is most of a pack.
+        """
+        return self.episode_claims.resolved_claims_for(media_file)
 
     def _detected_claims(self) -> FilenameClaims:
         return detect_filename_claims(
@@ -870,7 +970,9 @@ class RenameEncodeSeries(BaseWizardPage):
     def _update_quality_combo(self, _: int) -> None:
         cur_text = self.quality_combo.currentText()
 
-        # If not using DVD or Bluray disable REMUX
+        # If not using DVD or Bluray disable REMUX. The rule is about the
+        # release rather than the control, so it reaches the episode column
+        # too -- a per-file REMUX on a web pack is not a thing.
         if cur_text:
             if QualitySelection(cur_text) not in {
                 QualitySelection.DVD,
@@ -879,11 +981,14 @@ class RenameEncodeSeries(BaseWizardPage):
             }:
                 self.remux_checkbox.setChecked(False)
                 self.remux_checkbox.setEnabled(False)
+                self.episode_claims.set_claim_enabled("remux", False)
             else:
                 self.remux_checkbox.setEnabled(True)
+                self.episode_claims.set_claim_enabled("remux", True)
                 self._auto_check_remux_checkbox()
         else:
             self.remux_checkbox.setEnabled(True)
+            self.episode_claims.set_claim_enabled("remux", True)
             self._auto_check_remux_checkbox()
 
         self._sync_service_combo_to_quality(cur_text)
@@ -900,6 +1005,7 @@ class RenameEncodeSeries(BaseWizardPage):
         """
         if not quality_text:
             self.service_combo.setEnabled(True)
+            self.episode_claims.set_claim_enabled("streaming_service", True)
             return
 
         is_web = QualitySelection(quality_text) in {
@@ -909,6 +1015,7 @@ class RenameEncodeSeries(BaseWizardPage):
         if not is_web:
             self.service_combo.setCurrentIndex(0)
         self.service_combo.setEnabled(is_web)
+        self.episode_claims.set_claim_enabled("streaming_service", is_web)
 
     @Slot(int)
     def _update_service_combo(self, _: int) -> None:
@@ -936,6 +1043,31 @@ class RenameEncodeSeries(BaseWizardPage):
         else:
             self.backend.override_tokens[k] = v
         self.update_generated_name()
+
+    def _update_pack_name_preview(self, user_tokens: dict[str, str]) -> None:
+        """Render the folder name the pack controls currently produce.
+
+        The same call `validatePage` makes, so what is shown is what will be
+        written. A pack with no resolvable season has no folder name to
+        render, which is the one case the field goes empty.
+        """
+        release_info = build_series_release_info(self.context.media_input)
+        if release_info.season is None:
+            self.pack_name_preview.clear()
+            return
+
+        folder_path = self.backend.series_folder_renamer(
+            media_input_obj=self.context.media_input,
+            token=self.config.settings.series.season_folder_token,
+            colon_replacement=self.config.settings.series.filename_colon_replace,
+            media_search_payload=self.context.media_search,
+            title_clean_rules=self.config.settings.global_management.title_clean_rules,
+            video_dynamic_range=self.config.settings.global_management.video_dynamic_range,
+            user_tokens=user_tokens,
+            season_num=release_info.season,
+            season_end=release_info.season_end,
+        )
+        self.pack_name_preview.setText(folder_path.name if folder_path else "")
 
     @Slot(int)
     def update_generated_name(self, _: int | None = None) -> None:
@@ -973,12 +1105,15 @@ class RenameEncodeSeries(BaseWizardPage):
             if TokenSelection(t) is TokenSelection.FILE_TOKEN
         }
 
+        # Before the episode render, not after: both renderers assign
+        # `backend.token_replacer`, and the override grid below reads it
+        # expecting the episode's tokens rather than the folder's.
+        self._update_pack_name_preview(user_tokens)
+
         get_file_name = self.backend.series_renamer(
             media_input_obj=self.context.media_input,
             media_file=representative_path,
-            file_claims=self._file_claim_overrides(
-                representative_path, self._detected_claims().as_override_tokens()
-            ),
+            file_claims=self._file_claim_overrides(representative_path),
             token=token,
             colon_replacement=self.config.settings.series.filename_colon_replace,
             media_search_payload=self.context.media_search,
@@ -1002,10 +1137,16 @@ class RenameEncodeSeries(BaseWizardPage):
                 r"\{(?:[:][^:}]+:)*([a-z_]+)(?:\|[^:}]*)?(?:[:][^:}]+:)*\}", token
             )
             sort_token_data = self.backend.token_replacer.token_data.get_dict()  # pyright: ignore[reportAttributeAccessIssue]
+            # Claims are excluded: the episode table owns them now. This grid
+            # shows one representative episode's values but writes pack-wide,
+            # so leaving a claim here would be a second control for the same
+            # value, disagreeing with the first about which surface it means.
             sorted_token_data = {
                 k: sort_token_data[k]
                 for k in sort_token_order
-                if k in sort_token_data and sort_token_data[k]
+                if k in sort_token_data
+                and sort_token_data[k]
+                and k not in PER_FILE_CLAIM_KEYS
             }
             self.rename_token_control.populate_table(sorted_token_data)
 

--- a/tests/test_backend/test_filename_claims.py
+++ b/tests/test_backend/test_filename_claims.py
@@ -1,9 +1,11 @@
 import pytest
 
 from src.backend.utils.filename_claims import (
+    PER_FILE_CLAIM_KEYS,
     FilenameClaims,
     detect_file_claims,
     detect_filename_claims,
+    resolve_file_claims,
 )
 from src.config.models import ClaimSwitches
 
@@ -174,3 +176,59 @@ def test_per_file_claims_honour_the_switches() -> None:
     )
 
     assert claims.re_release == ""
+
+
+def test_a_per_file_edit_wins_over_the_filenames_own_claim() -> None:
+    # The user is looking at the episode and disagreeing with its name. That
+    # is a decision, and detection does not get to overrule it.
+    detected = detect_file_claims(
+        "Show.S01E02.REPACK.1080p.WEB-DL.H.264-GRP", _switches()
+    )
+
+    resolved = resolve_file_claims(detected, {"re_release": "PROPER"})
+
+    assert resolved["re_release"] == "PROPER"
+
+
+def test_a_cleared_per_file_edit_suppresses_the_claim() -> None:
+    # Clearing the cell is a decision -- "this episode is not a repack,
+    # whatever its name says" -- so it has to reach output as an empty
+    # override rather than falling back through to detection.
+    detected = detect_file_claims(
+        "Show.S01E02.REPACK.1080p.WEB-DL.H.264-GRP", _switches()
+    )
+
+    resolved = resolve_file_claims(detected, {"re_release": ""})
+
+    assert resolved["re_release"] == ""
+
+
+def test_an_unedited_claim_falls_through_to_the_filename() -> None:
+    detected = detect_file_claims(
+        "Show.S01E02.REPACK.1080p.WEB-DL.H.264-GRP", _switches()
+    )
+
+    resolved = resolve_file_claims(detected, {})
+
+    assert resolved["re_release"] == "REPACK"
+
+
+def test_an_undetected_unedited_claim_is_omitted_not_emptied() -> None:
+    # Omission leaves a gap for whatever renders next; "" would assert the
+    # file has no such claim, which nothing here is entitled to say.
+    detected = detect_file_claims("Show.S01E02.1080p.WEB-DL.H.264-GRP", _switches())
+
+    resolved = resolve_file_claims(detected, {})
+
+    assert "re_release" not in resolved
+    assert "edition" not in resolved
+
+
+def test_the_group_is_never_resolved_per_file() -> None:
+    # A release has at most one group tag, so the group is whole-release
+    # even though it is detected per file like everything else.
+    detected = detect_file_claims("Show.S01E02.1080p.WEB-DL.H.264-GRP", _switches())
+
+    assert detected.release_group == "GRP"
+    assert "release_group" not in resolve_file_claims(detected, {})
+    assert "release_group" not in PER_FILE_CLAIM_KEYS

--- a/tests/test_backend/test_rename_encode_series_backend.py
+++ b/tests/test_backend/test_rename_encode_series_backend.py
@@ -76,6 +76,60 @@ def test_series_folder_renamer_renders_multi_season_range() -> None:
     assert result == Path("S01-S05")
 
 
+def test_the_pack_folder_ignores_what_the_episodes_claim() -> None:
+    """The other half of the split. A pack assembled from individually
+    repacked episodes is itself a first release, so a REPACK sitting in the
+    episode filenames must not reach the folder -- and through the folder,
+    the torrent name and the release title."""
+    repacked = Path("Show.S01E02.REPACK.1080p.WEB-DL-GRP.mkv")
+    payload = MediaInputPayload(
+        input_path=Path("Show.S01"),
+        media_type=MediaType.SERIES,
+        file_list=[Path("Show.S01E01.1080p.WEB-DL-GRP.mkv"), repacked],
+    )
+    backend = RenameEncodeSeriesBackEnd()
+
+    result = backend.series_folder_renamer(
+        media_input_obj=payload,
+        token="S{season_number|zfill(2)} {re_release}",  # noqa: S106 - NFO template token string used as test fixture data, not a credential
+        colon_replacement=ColonReplace.REPLACE_WITH_DASH,
+        media_search_payload=_empty_series_search(),
+        season_num=1,
+        title_clean_rules=None,
+        video_dynamic_range=None,
+        user_tokens=None,
+        season_end=1,
+    )
+
+    assert result == Path("S01")
+
+
+def test_the_pack_folder_carries_the_packs_own_claim() -> None:
+    """Independence runs both ways: a pack the user did flag renders it,
+    whatever the episodes say."""
+    payload = MediaInputPayload(
+        input_path=Path("Show.S01"),
+        media_type=MediaType.SERIES,
+        file_list=[Path("Show.S01E01.1080p.WEB-DL-GRP.mkv")],
+    )
+    backend = RenameEncodeSeriesBackEnd()
+    backend.override_tokens["re_release"] = "REPACK"
+
+    result = backend.series_folder_renamer(
+        media_input_obj=payload,
+        token="S{season_number|zfill(2)} {re_release}",  # noqa: S106 - NFO template token string used as test fixture data, not a credential
+        colon_replacement=ColonReplace.REPLACE_WITH_DASH,
+        media_search_payload=_empty_series_search(),
+        season_num=1,
+        title_clean_rules=None,
+        video_dynamic_range=None,
+        user_tokens=None,
+        season_end=1,
+    )
+
+    assert result == Path("S01.REPACK")
+
+
 def test_series_folder_renamer_single_season_includes_title() -> None:
     backend = RenameEncodeSeriesBackEnd()
     result = backend.series_folder_renamer(
@@ -446,9 +500,10 @@ def test_a_lone_repack_still_reaches_that_episodes_filename() -> None:
     assert render(second_file, {"re_release": "REPACK"}) == Path("REPACK.GRP.mkv")
 
 
-def test_a_pack_wide_choice_wins_over_the_files_own_claim() -> None:
-    """File claims fill gaps; they do not overrule a decision. A user who
-    cleared the control must not have the claim handed back per file."""
+def test_a_pack_wide_claim_does_not_reach_an_episodes_filename() -> None:
+    """The pack and its files are separate surfaces. A pack flagged PROPER
+    says nothing about what any one episode is, so the pack's claim stops at
+    the folder, torrent and title -- the episode renders its own."""
     media_file = Path("Show.S01E02.REPACK.1080p.WEB-DL-GRP.mkv")
     payload = MediaInputPayload(
         input_path=Path("Show.S01"),
@@ -474,4 +529,37 @@ def test_a_pack_wide_choice_wins_over_the_files_own_claim() -> None:
         file_claims={"re_release": "REPACK", "release_group": "GRP"},
     )
 
-    assert result == Path("PROPER.GRP.mkv")
+    assert result == Path("REPACK.GRP.mkv")
+
+
+def test_a_pack_wide_override_that_is_not_a_claim_still_reaches_the_filename() -> None:
+    """Only claims are split by surface. Source, codecs and the group tag
+    describe the whole release, so they keep reaching every episode -- the
+    partition must not swallow them along with the claims."""
+    media_file = Path("Show.S01E02.1080p.WEB-DL-GRP.mkv")
+    payload = MediaInputPayload(
+        input_path=Path("Show.S01"),
+        media_type=MediaType.SERIES,
+        file_list=[media_file],
+    )
+    backend = RenameEncodeSeriesBackEnd()
+    backend.override_tokens["source"] = "BluRay"
+    backend.override_tokens["release_group"] = "GRP"
+
+    result = backend.series_renamer(
+        media_input_obj=payload,
+        media_file=media_file,
+        token="{source} {release_group}",  # noqa: S106 - NFO template token string used as test fixture data, not a credential
+        colon_replacement=ColonReplace.REPLACE_WITH_DASH,
+        media_search_payload=_empty_series_search(),
+        season_num=1,
+        episode_num=2,
+        title_clean_rules=None,
+        video_dynamic_range=None,
+        user_tokens=None,
+        episode_format=EpisodeFormat.STANDARD,
+        multi_episode_style=MultiEpisodeStyle.RANGE,
+        file_claims={},
+    )
+
+    assert result == Path("BluRay.GRP.mkv")

--- a/tests/test_frontend/test_rename_encode_movie.py
+++ b/tests/test_frontend/test_rename_encode_movie.py
@@ -44,6 +44,7 @@ def _make_movie_rename_page(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     file_path: Path = Path("Movie.2020.mkv"),
+    file_list: list[Path] | None = None,
 ) -> RenameEncode:
     monkeypatch.setattr(
         "src.config.config.FindDependencies.update_dependencies",
@@ -55,7 +56,7 @@ def _make_movie_rename_page(
     media_input = MediaInputPayload(
         input_path=Path("Movie Folder"),
         media_type=MediaType.MOVIE,
-        file_list=[file_path],
+        file_list=file_list if file_list is not None else [file_path],
     )
     media_search = MediaSearchPayload(media_type=MediaType.MOVIE, title="Movie Title")
     context = ProcessingContext(media_input=media_input, media_search=media_search)
@@ -151,6 +152,27 @@ def test_hybrid_is_pre_ticked_from_the_filename(
     page.initializePage()
 
     assert page.hybrid_checkbox.isChecked() is True
+
+
+def test_extras_in_the_folder_do_not_erase_the_films_claims(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A movie's file_list can hold more than one file: the input page has no
+    media-type branch, so a folder with an Extras subfolder yields several
+    videos. The page pre-fills from the film alone but re-detected across the
+    whole list under the pack-agreement rule, so switching Quality to a disc
+    source silently cleared the REMUX tick the film had earned."""
+    page = _make_movie_rename_page(
+        tmp_path,
+        monkeypatch,
+        file_list=[
+            Path("Movie.2024.1080p.BluRay.REMUX.AVC-GRP.mkv"),
+            Path("Deleted-Scenes.mkv"),
+            Path("Bloopers.mkv"),
+        ],
+    )
+
+    assert page._detected_claims().remux == "REMUX"  # pyright: ignore[reportPrivateUsage]
 
 
 def test_claims_are_pre_filled_from_the_filename(

--- a/tests/test_frontend/test_rename_encode_series.py
+++ b/tests/test_frontend/test_rename_encode_series.py
@@ -1,15 +1,22 @@
 from pathlib import Path
 
+from PySide6.QtCore import Qt
 from PySide6.QtTest import QTest
 from PySide6.QtWidgets import QDialog, QMessageBox
 import pytest
 
 from src.backend.rename_encode_series import RenameEncodeSeriesBackEnd
+from src.backend.utils.filename_claims import PER_FILE_CLAIM_KEYS
 from src.config.config import ConfigManager
 from src.config.paths import ConfigPaths
 from src.context.processing_context import ProcessingContext
 from src.enums.media_type import MediaType
 from src.enums.series import EpisodeFormat
+from src.frontend.custom_widgets.episode_claims_table import (
+    CLAIM_COLUMNS,
+    VALUE_CLAIMS,
+    _is_checked,
+)
 from src.frontend.wizards.rename_encode_series import RenameEncodeSeries
 from src.payloads.media_inputs import MediaInputPayload
 from src.payloads.media_search import MediaSearchPayload
@@ -639,3 +646,498 @@ def test_clearing_the_field_beats_the_configured_group_tag(
     page.update_generated_name()
 
     assert page.backend.override_tokens["release_group"] == ""
+
+
+def _select(combo, text: str) -> None:
+    """Pick an entry the way the dropdown does.
+
+    `CustomComboBox` is always editable, and on an editable combo
+    `setCurrentText` writes the line edit without moving the index, so the
+    `currentIndexChanged` handlers never run.
+    """
+    index = combo.findText(text)
+    assert index > -1, f"{text!r} is not in the combo"
+    combo.setCurrentIndex(index)
+
+
+def _two_episode_page(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> RenameEncodeSeries:
+    """A pack where episode 2 is a repack and episode 1 is not."""
+    return _make_series_rename_page(
+        tmp_path,
+        monkeypatch,
+        episode_map={
+            Path("Show.S01E01.1080p.WEB-DL.x264-GRP.mkv"): {"season": 1, "episode": 1},
+            Path("Show.S01E02.REPACK.1080p.WEB-DL.x264-GRP.mkv"): {
+                "season": 1,
+                "episode": 2,
+            },
+        },
+    )
+
+
+def test_each_episode_row_seeds_from_its_own_filename(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The case the pack controls cannot express: one combo cannot say
+    "REPACK, but only episode 2"."""
+    page = _two_episode_page(tmp_path, monkeypatch)
+
+    page.initializePage()
+
+    table = page.episode_claims
+    assert page.re_release_combo.currentText() == ""
+    assert (
+        table.resolved_claims_for(Path("Show.S01E01.1080p.WEB-DL.x264-GRP.mkv")).get(
+            "re_release"
+        )
+        is None
+    )
+    assert (
+        table.resolved_claims_for(Path("Show.S01E02.REPACK.1080p.WEB-DL.x264-GRP.mkv"))[
+            "re_release"
+        ]
+        == "REPACK"
+    )
+
+
+def test_a_pack_claim_leaves_the_episode_rows_alone(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Setting the pack control is not a statement about any episode."""
+    page = _two_episode_page(tmp_path, monkeypatch)
+    page.initializePage()
+
+    _select(page.re_release_combo, "PROPER")
+
+    assert page.backend.override_tokens["re_release"] == "PROPER"
+    assert (
+        page.episode_claims.resolved_claims_for(
+            Path("Show.S01E01.1080p.WEB-DL.x264-GRP.mkv")
+        ).get("re_release")
+        is None
+    )
+
+
+def test_apply_to_all_stamps_the_pack_value_on_every_episode(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    page = _two_episode_page(tmp_path, monkeypatch)
+    page.initializePage()
+    _select(page.re_release_combo, "PROPER")
+
+    page._apply_claim_to_all("re_release")  # pyright: ignore[reportPrivateUsage]
+
+    claims = page.episode_claims
+    for media_file in page.context.media_input.file_list:
+        assert claims.resolved_claims_for(media_file)["re_release"] == "PROPER"
+
+
+def test_revert_to_detected_undoes_an_accidental_apply(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Q7's shortcut has to be survivable when it was a misclick."""
+    page = _two_episode_page(tmp_path, monkeypatch)
+    page.initializePage()
+    _select(page.re_release_combo, "PROPER")
+    page._apply_claim_to_all("re_release")  # pyright: ignore[reportPrivateUsage]
+
+    page.episode_claims.revert_to_detected("re_release")
+
+    claims = page.episode_claims
+    assert (
+        claims.resolved_claims_for(Path("Show.S01E01.1080p.WEB-DL.x264-GRP.mkv")).get(
+            "re_release"
+        )
+        is None
+    )
+    assert (
+        claims.resolved_claims_for(
+            Path("Show.S01E02.REPACK.1080p.WEB-DL.x264-GRP.mkv")
+        )["re_release"]
+        == "REPACK"
+    )
+
+
+def test_a_web_source_suppresses_remux_on_every_episode(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A per-file REMUX on a web pack is not a thing, so the column is
+    cleared outright rather than parked in hidden state."""
+    media_file = Path("Show.S01E01.1080p.BluRay.REMUX.AVC-GRP.mkv")
+    page = _make_series_rename_page(
+        tmp_path,
+        monkeypatch,
+        episode_map={media_file: {"season": 1, "episode": 1}},
+    )
+    page.initializePage()
+    assert page.episode_claims.resolved_claims_for(media_file)["remux"] == "REMUX"
+
+    _select(page.quality_combo, "WEB-DL")
+
+    assert page.episode_claims.resolved_claims_for(media_file)["remux"] == ""
+
+
+def test_returning_to_a_disc_source_restores_the_detected_remux(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Suppression has to be survivable. The pack checkbox re-detects when
+    the quality comes back, so leaving the episodes suppressed would strand
+    them disagreeing with it, invisibly."""
+    media_file = Path("Show.S01E01.1080p.BluRay.REMUX.AVC-GRP.mkv")
+    page = _make_series_rename_page(
+        tmp_path,
+        monkeypatch,
+        episode_map={media_file: {"season": 1, "episode": 1}},
+    )
+    page.initializePage()
+    _select(page.quality_combo, "WEB-DL")
+    assert page.episode_claims.resolved_claims_for(media_file)["remux"] == ""
+
+    _select(page.quality_combo, "BluRay")
+
+    assert page.episode_claims.resolved_claims_for(media_file)["remux"] == "REMUX"
+    assert page.remux_checkbox.isChecked() is True
+
+
+def test_apply_to_all_reads_the_pack_value_from_the_override_tokens(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """One answer to "what does the pack say", not two. The claim controls
+    all write `override_tokens`, so bulk apply reads it rather than asking
+    the widgets a second time."""
+    page = _two_episode_page(tmp_path, monkeypatch)
+    page.initializePage()
+    page.backend.override_tokens["re_release"] = "PROPER"
+
+    page._apply_claim_to_all("re_release")  # pyright: ignore[reportPrivateUsage]
+
+    claims = page.episode_claims
+    for media_file in page.context.media_input.file_list:
+        assert claims.resolved_claims_for(media_file)["re_release"] == "PROPER"
+
+
+def test_the_pack_name_preview_shows_what_the_pack_controls_produce(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The pack's controls produce one string, and nothing on the page showed
+    it. Setting a pack claim has to move it."""
+    page = _two_episode_page(tmp_path, monkeypatch)
+    page.config.settings.series.season_folder_token = (
+        "{title_clean} S{season_number|zfill(2)} {re_release}"  # noqa: S105 - NFO template token string used as test fixture data, not a credential
+    )
+
+    page.initializePage()
+    assert page.pack_name_preview.text() == "Show.Title.S01"
+
+    _select(page.re_release_combo, "REPACK")
+
+    assert page.pack_name_preview.text() == "Show.Title.S01.REPACK"
+
+
+def test_the_pack_preview_does_not_steal_the_override_grid(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Both renderers assign `backend.token_replacer`. The grid reads it
+    expecting the episode's tokens, so the folder render has to come first."""
+    page = _two_episode_page(tmp_path, monkeypatch)
+    page.config.settings.series.standard_episode_token = TEST_TOKEN
+
+    page.initializePage()
+    page.token_override.setText(TEST_TOKEN)
+    page.override_group.setChecked(True)
+
+    token_values = page.rename_token_control.get_token_values()
+    assert token_values.get("{episode_number}") == "01"
+
+
+def test_column_widths_do_not_move_when_values_change(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Widths come from the full option list at construction, not from what
+    the cells happen to hold. Sizing to contents made the table reflow when
+    a long edition was picked and again when it was cleared."""
+    page = _two_episode_page(tmp_path, monkeypatch)
+    page.initializePage()
+    table = page.episode_claims.table
+    before = [table.columnWidth(c) for c in range(table.columnCount())]
+
+    page.episode_claims.apply_to_all("edition", "Directors Cut")
+    during = [table.columnWidth(c) for c in range(table.columnCount())]
+    page.episode_claims.revert_to_detected("edition")
+
+    assert during == before
+    assert [table.columnWidth(c) for c in range(table.columnCount())] == before
+
+
+def test_every_dropdown_column_shares_one_width(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    page = _two_episode_page(tmp_path, monkeypatch)
+    page.initializePage()
+    table = page.episode_claims.table
+
+    widths = {table.columnWidth(c) for c in range(1, 6)}
+
+    assert len(widths) == 1
+
+
+def test_a_switched_off_category_is_not_detected_per_episode_either(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Both halves of the page read the same switches. A category the user
+    turned off must not come back through the episode table, which is the
+    one surface that reads each filename individually."""
+    repacked = Path("Show.S01E02.REPACK.1080p.WEB-DL.x264-GRP.mkv")
+    page = _make_series_rename_page(
+        tmp_path,
+        monkeypatch,
+        episode_map={repacked: {"season": 1, "episode": 2}},
+    )
+    page.config.settings.series.claims.re_release = False
+
+    page.initializePage()
+
+    assert page.re_release_combo.currentText() == ""
+    assert "re_release" not in page.episode_claims.resolved_claims_for(repacked)
+
+
+def test_the_master_switch_reaches_the_episode_table(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    media_file = Path("Show.S01E01.IMAX.REPACK.HYBRID.1080p.BluRay.REMUX.AVC-GRP.mkv")
+    page = _make_series_rename_page(
+        tmp_path,
+        monkeypatch,
+        episode_map={media_file: {"season": 1, "episode": 1}},
+    )
+    page.config.settings.series.claims.enabled = False
+
+    page.initializePage()
+
+    resolved = page.episode_claims.resolved_claims_for(media_file)
+    assert not {"edition", "frame_size", "re_release", "remux", "hybrid"} & set(
+        resolved
+    )
+
+
+def test_a_switched_off_category_is_still_settable_by_hand(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Switching a category off means "do not read this from the filename",
+    not "this release cannot have one" -- so the column stays editable, the
+    way the pack combo stays selectable."""
+    media_file = Path("Show.S01E01.1080p.WEB-DL.x264-GRP.mkv")
+    page = _make_series_rename_page(
+        tmp_path,
+        monkeypatch,
+        episode_map={media_file: {"season": 1, "episode": 1}},
+    )
+    page.config.settings.series.claims.re_release = False
+    page.initializePage()
+
+    table = page.episode_claims.table
+    re_release_column = 1 + [k for k, _ in VALUE_CLAIMS].index("re_release")
+
+    assert table.item(0, re_release_column).flags() & Qt.ItemFlag.ItemIsEditable
+
+
+def test_streaming_service_is_detected_per_episode_despite_the_master_switch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The documented asymmetry, pinned so it stays deliberate: service has
+    no switch because nothing competes with it, and the settings tooltip
+    says so. It is the one column the claim switches never gate."""
+    media_file = Path("Show.S01E01.1080p.AMZN.WEB-DL.x264-GRP.mkv")
+    page = _make_series_rename_page(
+        tmp_path,
+        monkeypatch,
+        episode_map={media_file: {"season": 1, "episode": 1}},
+    )
+    page.config.settings.series.claims.enabled = False
+
+    page.initializePage()
+
+    claims = page.episode_claims.resolved_claims_for(media_file)
+    assert claims["streaming_service"] == "AMZN"
+
+
+def _remux_index(page: RenameEncodeSeries, row: int = 0):
+    table = page.episode_claims.table
+    column = 1 + len(VALUE_CLAIMS)
+    return table.model().index(row, column)
+
+
+def test_clicking_a_remux_cell_toggles_it_both_ways(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Regression guard: `index.data(CheckStateRole)` returns a plain int and
+    PySide6 enums do not compare equal to ints, so `data(...) ==
+    Qt.CheckState.Checked` was always False. The delegate therefore painted
+    every box empty and read every cell as unchecked, which turned toggling
+    off into a no-op and made bulk apply look broken."""
+    media_file = Path("Show.S01E01.1080p.BluRay.x264-GRP.mkv")
+    page = _make_series_rename_page(
+        tmp_path, monkeypatch, episode_map={media_file: {"season": 1, "episode": 1}}
+    )
+    page.initializePage()
+    claims = page.episode_claims
+    model = claims.table.model()
+    index = _remux_index(page)
+
+    model.setData(index, Qt.CheckState.Checked, Qt.ItemDataRole.CheckStateRole)
+    assert claims.resolved_claims_for(media_file)["remux"] == "REMUX"
+
+    model.setData(index, Qt.CheckState.Unchecked, Qt.ItemDataRole.CheckStateRole)
+    assert claims.resolved_claims_for(media_file)["remux"] == ""
+
+
+def test_the_delegate_reads_the_check_state_it_is_given(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """What the delegate paints has to follow the model. This asserts the
+    int/enum conversion directly, since a wrong answer here is invisible in
+    every other test -- the data is right, only the pixels are wrong."""
+    media_file = Path("Show.S01E01.1080p.BluRay.REMUX.AVC-GRP.mkv")
+    page = _make_series_rename_page(
+        tmp_path, monkeypatch, episode_map={media_file: {"season": 1, "episode": 1}}
+    )
+    page.initializePage()
+
+    assert _is_checked(_remux_index(page)) is True
+
+    page.episode_claims.apply_to_all("remux", "")
+
+    assert _is_checked(_remux_index(page)) is False
+
+
+def test_pack_level_apply_to_all_reaches_the_remux_column(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    page = _two_episode_page(tmp_path, monkeypatch)
+    page.initializePage()
+    page.remux_checkbox.setChecked(True)
+
+    page._apply_claim_to_all("remux")  # pyright: ignore[reportPrivateUsage]
+
+    claims = page.episode_claims
+    for media_file in page.context.media_input.file_list:
+        assert claims.resolved_claims_for(media_file)["remux"] == "REMUX"
+    assert _is_checked(_remux_index(page, 0))
+    assert _is_checked(_remux_index(page, 1))
+
+
+def test_a_checkbox_cell_never_fills_with_the_selection_colour(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """On this palette `highlight()` is the exact colour the checkbox
+    indicator is drawn in, so a selected cell painted the box out of
+    existence. The episode name column solves it by not being selectable;
+    these do the same, and clicking still toggles because `editorEvent`
+    reaches enabled items whether or not they can be selected."""
+    media_file = Path("Show.S01E01.1080p.BluRay.x264-GRP.mkv")
+    page = _make_series_rename_page(
+        tmp_path, monkeypatch, episode_map={media_file: {"season": 1, "episode": 1}}
+    )
+    page.initializePage()
+    table = page.episode_claims.table
+
+    for offset in range(2):
+        item = table.item(0, 1 + len(VALUE_CLAIMS) + offset)
+        assert not item.flags() & Qt.ItemFlag.ItemIsSelectable
+        assert item.flags() & Qt.ItemFlag.ItemIsUserCheckable
+
+    # still togglable through the model, which is what a click drives
+    index = _remux_index(page)
+    table.model().setData(index, Qt.CheckState.Checked, Qt.ItemDataRole.CheckStateRole)
+    assert page.episode_claims.resolved_claims_for(media_file)["remux"] == "REMUX"
+
+
+def test_a_narrow_window_scrolls_rather_than_crushing_the_episode_column(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The episode name is the only column that stretches, so with no floor
+    it absorbs every pixel the claim columns need and collapses to a sliver
+    before anything else gives. It floors instead, and the overflow becomes
+    the table's own scroll bar -- under the table, where the problem is,
+    rather than the wizard's at the bottom of the window."""
+    page = _two_episode_page(tmp_path, monkeypatch)
+    page.initializePage()
+    table = page.episode_claims.table
+
+    page.show()
+    try:
+        # the column is fitted from the viewport width, which only settles
+        # once the layout has actually run
+        page.resize(1600, 700)
+        QTest.qWait(1)
+        wide = table.columnWidth(0)
+
+        page.resize(700, 700)
+        QTest.qWait(1)
+        narrow = table.columnWidth(0)
+
+        assert wide > narrow, "the episode column should stretch when there is room"
+        assert narrow >= 200, "and stop shrinking before it becomes unreadable"
+        assert all(table.columnWidth(c) > 0 for c in range(table.columnCount())), (
+            "no column may be squeezed out of existence"
+        )
+        assert table.horizontalScrollBar().isVisible(), (
+            "the overflow belongs to the table, not to the page"
+        )
+    finally:
+        page.hide()
+
+
+def test_the_episode_column_fills_on_open_without_a_resize(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Fitting from the widget's own `resizeEvent` read a viewport that had
+    not been laid out yet, so the column opened at its floor and only found
+    its width once the user dragged the window. The viewport's own resize is
+    the event that knows the answer."""
+    page = _two_episode_page(tmp_path, monkeypatch)
+    page.initializePage()
+    page.resize(1600, 800)
+    page.show()
+    try:
+        QTest.qWait(1)
+        table = page.episode_claims.table
+
+        assert table.columnWidth(0) > 400, "should fill, not sit at its floor"
+        assert not table.horizontalScrollBar().isVisible()
+    finally:
+        page.hide()
+
+
+def test_the_scroll_bar_does_not_oscillate_across_the_threshold(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Fitting from a stale viewport width set a column wrong by exactly the
+    delta, which the next event corrected -- during a drag that is a scroll
+    bar blinking on and off. Sweeping the threshold must cross it once."""
+    page = _two_episode_page(tmp_path, monkeypatch)
+    page.initializePage()
+    page.resize(1150, 800)
+    page.show()
+    try:
+        QTest.qWait(1)
+        table = page.episode_claims.table
+        seen: list[bool] = []
+        for width in range(1150, 950, -10):
+            page.resize(width, 800)
+            QTest.qWait(1)
+            seen.append(table.horizontalScrollBar().isVisible())
+
+        transitions = sum(a != b for a, b in zip(seen, seen[1:], strict=False))
+        assert transitions <= 1, f"scroll bar flickered: {seen}"
+    finally:
+        page.hide()
+
+
+def test_every_per_file_claim_has_a_column() -> None:
+    """The table's columns and the resolver's keys are written out
+    separately, so adding a field to `FilenameClaims` would otherwise give it
+    a resolved value with nowhere on screen to set it."""
+    assert set(CLAIM_COLUMNS) == PER_FILE_CLAIM_KEYS


### PR DESCRIPTION
A season pack and the episodes inside it are different releases making
different assertions. Until now one control spoke for both: setting
Rerelease to REPACK stamped it on the root folder, the season subfolders,
the `.torrent` filename, the release title, the NFO *and* every episode
filename at once, with no way to separate them.

That is the wrong shape for the common case. A pack assembled from
episodes that were individually repacked is itself a first release, so
five REPACK episodes should keep their markers while the pack carries
none.

## What changed

**Two independent surfaces.** The pack controls drive the folder, torrent,
release title and NFO. A new per-episode table drives filenames. Neither
cascades into the other, so the case above is expressible by construction
rather than by precedence rules.

Seven claims participate per episode: edition, frame size, localization,
re-release, remux, hybrid and streaming service. The group is excluded --
a release carries at most one group tag, and splitting it per episode is
how another group's tag reaches an upload.

**The rule lives in `filename_claims.py`**, beside the detector it pairs
with, so it is testable without Qt. An edit wins over detection; presence
in the edits is what makes something an edit, so a cleared cell is a
decision that suppresses the claim rather than a gap that falls back.

**Bulk actions**, because setting a claim on a hundred rows by hand is not
a workflow. Each pack control carries a menu to stamp its value onto every
episode, or revert them to what their filenames say.

**A pack name preview**, showing what the folder and torrent will be
called. Nothing on the page showed that before.

## Also here

A separate `fix:` commit for an unrelated defect found in the same code: a
movie's `file_list` can hold more than one file, so a film shipped with an
`Extras` folder had its claims outvoted by its bloopers, silently clearing
the REMUX tick when Quality was set to a disc source.

## Notes for review

- Three commits, each leaving the suite green on its own.
- 3365 tests pass; ruff, ruff format and basedpyright clean.
- Per-episode state is deliberately ephemeral. The page is entered once per
  run, never returned to, and a job cannot be saved before it commits, so
  persisting it would store state nothing reads back.
- Tracker title coverage is unchanged and out of scope: four composing
  entries state no localization at all, and three suppress `Subbed`
  deliberately. That predates this work and applies equally to movies.
